### PR TITLE
adjust use of braces to fix warnings with clang

### DIFF
--- a/test_communication/test/message_fixtures.hpp
+++ b/test_communication/test/message_fixtures.hpp
@@ -101,27 +101,26 @@ get_messages_static_array_primitives()
   std::vector<test_communication::msg::StaticArrayPrimitives::Ptr> messages;
   {
     auto msg = std::make_shared<test_communication::msg::StaticArrayPrimitives>();
-    msg->bool_values = {false, true, false};
-    msg->byte_values = {0, 0xff, 0};
-    msg->char_values = {'\0', '\255', '\0'};
-    msg->float32_values = {0.0f, 1.11f, -2.22f};
-    msg->float64_values = {0, 1.11, -2.22};
-    msg->int8_values = {0, 127, -128};
-    msg->uint8_values = {0, 255, 0};
-    msg->int16_values = {0, 32767, -32768};
-    msg->uint16_values = {0, 65535, 0};
-    // The narrowing static cast is required to avoid build errors on Windows.
-    msg->int32_values = {
+    msg->bool_values = {{false, true, false}};
+    msg->byte_values = {{0, 0xff, 0}};
+    msg->char_values = {{'\0', '\255', '\0'}};
+    msg->float32_values = {{0.0f, 1.11f, -2.22f}};
+    msg->float64_values = {{0, 1.11, -2.22}};
+    msg->int8_values = {{0, 127, -128}};
+    msg->uint8_values = {{0, 255, 0}};
+    msg->int16_values = {{0, 32767, -32768}};
+    msg->uint16_values = {{0, 65535, 0}};
+    msg->int32_values = {{
       static_cast<int32_t>(0),
       static_cast<int32_t>(2147483647),
       static_cast<int32_t>(-2147483648)
-    };
-    msg->uint32_values = {0, 4294967295, 0};
+    }};
+    msg->uint32_values = {{0, 4294967295, 0}};
     msg->int64_values[0] = 0;
     msg->int64_values[1] = 9223372036854775807;
     msg->int64_values[2] = -9223372036854775808UL;
-    msg->uint64_values = {0, 18446744073709551615UL, 0};
-    msg->string_values = {"", "max value", "min value"};
+    msg->uint64_values = {{0, 18446744073709551615UL, 0}};
+    msg->string_values = {{"", "max value", "min value"}};
     messages.push_back(msg);
   }
   return messages;
@@ -151,19 +150,19 @@ get_messages_dynamic_array_primitives()
   }
   {
     auto msg = std::make_shared<test_communication::msg::DynamicArrayPrimitives>();
-    msg->bool_values = {{true}};
-    msg->byte_values = {{0xff}};
-    msg->char_values = {{'\255'}};
-    msg->float32_values = {{1.11f}};
-    msg->float64_values = {{1.11}};
-    msg->int8_values = {{127}};
-    msg->uint8_values = {{255}};
-    msg->int16_values = {{32767}};
-    msg->uint16_values = {{65535}};
-    msg->int32_values = {{2147483647}};
-    msg->uint32_values = {{4294967295}};
-    msg->int64_values = {{9223372036854775807}};
-    msg->uint64_values = {{18446744073709551615UL}};
+    msg->bool_values = {true};
+    msg->byte_values = {0xff};
+    msg->char_values = {'\255'};
+    msg->float32_values = {1.11f};
+    msg->float64_values = {1.11};
+    msg->int8_values = {127};
+    msg->uint8_values = {255};
+    msg->int16_values = {32767};
+    msg->uint16_values = {65535};
+    msg->int32_values = {2147483647};
+    msg->uint32_values = {4294967295};
+    msg->int64_values = {9223372036854775807};
+    msg->uint64_values = {18446744073709551615UL};
     msg->string_values = {{"max value"}};
     messages.push_back(msg);
   }


### PR DESCRIPTION
I was getting warnings about too many braces and too few. We'll see if this pull request introduces new warnings or otherwise breaks the Linux or Windows builds.

Connects to ros2/ros2#53