### PR TITLE
fix narrowing conversion error on windows

### DIFF
--- a/test_communication/test/message_fixtures.hpp
+++ b/test_communication/test/message_fixtures.hpp
@@ -110,7 +110,12 @@ get_messages_static_array_primitives()
     msg->uint8_values = {0, 255, 0};
     msg->int16_values = {0, 32767, -32768};
     msg->uint16_values = {0, 65535, 0};
-    msg->int32_values = {0, 2147483647, -2147483648};
+    // The narrowing static cast is required to avoid build errors on Windows.
+    msg->int32_values = {
+      static_cast<int32_t>(0),
+      static_cast<int32_t>(2147483647),
+      static_cast<int32_t>(-2147483648)
+    };
     msg->uint32_values = {0, 4294967295, 0};
     msg->int64_values[0] = 0;
     msg->int64_values[1] = 9223372036854775807;
@@ -173,7 +178,12 @@ get_messages_dynamic_array_primitives()
     msg->uint8_values = {{0, 255}};
     msg->int16_values = {{0, 32767, -32768}};
     msg->uint16_values = {{0, 65535}};
-    msg->int32_values = {{0, 2147483647, -2147483648}};
+    // The narrowing static cast is required to avoid build errors on Windows.
+    msg->int32_values = {{
+      static_cast<int32_t>(0),
+      static_cast<int32_t>(2147483647),
+      static_cast<int32_t>(-2147483648)
+    }};
     msg->uint32_values = {{0, 4294967295}};
     msg->int64_values.resize(3);
     msg->int64_values[0] = 0;


### PR DESCRIPTION
I had to do this to fix a build error on Windows like this:

```
31>c:\dev\ros2\src\ros2\system_tests\test_communication\test\message_fixtures.hpp(113): error C2397: conversion from 'unsigned long' to 'int32_t' requires a narrowing conversion [C:\dev\ros2\build\test_communication\test_subscriber_cpp__rmw_connext_cpp.vcxproj]
...
31>c:\dev\ros2\src\ros2\system_tests\test_communication\test\message_fixtures.hpp(176): error C2398: Element '3': conversion from 'unsigned long' to 'int' requires a narrowing conversion [C:\dev\ros2\build\test_communication\test_subscriber_cpp__rmw_connext_cpp.vcxproj]
```

I followed the suggestion of this SO: http://stackoverflow.com/a/4690988

I'm open to other suggestions, but with this patch I'm able to build our entire stack on Windows (from the cmd prompt the IDL error is still an issue with Jenkins...)