### PR TITLE
add tests for publish/subscribe in a single process

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -57,7 +57,34 @@ if(AMENT_ENABLE_TESTING)
     # get typesupport of rmw implementation to include / link against the corresponding interfaces
     get_rmw_typesupport(typesupport_impl "${middleware_impl}")
 
-    # executables publish / subscribe primitives
+    # executables publisher combined with a subscriber
+    add_executable(test_publisher_subscriber_cpp__${middleware_impl} "test/test_publisher_subscriber.cpp")
+    target_link_libraries(test_publisher_subscriber_cpp__${middleware_impl}
+      ${_AMENT_EXPORT_ABSOLUTE_LIBRARIES}
+      ${_AMENT_EXPORT_LIBRARY_TARGETS})
+    add_dependencies(test_publisher_subscriber_cpp__${middleware_impl} ${PROJECT_NAME})
+    rosidl_target_interfaces(test_publisher_subscriber_cpp__${middleware_impl}
+      ${PROJECT_NAME} ${typesupport_impl})
+    ament_target_dependencies(test_publisher_subscriber_cpp__${middleware_impl}
+      "${middleware_impl}"
+      "rclcpp")
+    # register executable as a test
+    get_target_property(target_path test_publisher_subscriber_cpp__${middleware_impl} RUNTIME_OUTPUT_DIRECTORY)
+    if(NOT target_path)
+      set(target_path "${CMAKE_CURRENT_BINARY_DIR}")
+    endif()
+    # testing this with a single message type should be enough
+    ament_add_test(
+      "test_publisher_subscriber_cpp__${middleware_impl}"
+      COMMAND "${target_path}/test_publisher_subscriber_cpp__${middleware_impl}" empty
+      TIMEOUT 15
+    )
+    set_tests_properties(
+      test_publisher_subscriber_cpp__${middleware_impl}
+      PROPERTIES REQUIRED_FILES "${target_path}/test_publisher_subscriber_cpp__${middleware_impl}"
+    )
+
+    # executables publisher / subscriber
     add_executable(test_publisher_cpp__${middleware_impl} "test/test_publisher.cpp")
     target_link_libraries(test_publisher_cpp__${middleware_impl}
       ${_AMENT_EXPORT_ABSOLUTE_LIBRARIES}

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -21,7 +21,7 @@
 #include "message_fixtures.hpp"
 
 template<typename T>
-int publish(
+void publish(
   rclcpp::Node::SharedPtr node,
   const std::string & message_type,
   std::vector<typename T::SharedPtr> messages,
@@ -52,8 +52,6 @@ int publish(
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
   std::cout << "published for " << diff.count() << " seconds" << std::endl;
-
-  return 0;
 }
 
 int main(int argc, char ** argv)
@@ -67,22 +65,21 @@ int main(int argc, char ** argv)
   std::string message = argv[1];
   auto node = rclcpp::Node::make_shared(std::string("test_publisher_") + message);
 
-  int rc;
   if (message == "empty") {
-    rc = publish<test_communication::msg::Empty>(node, message, get_messages_empty());
+    publish<test_communication::msg::Empty>(node, message, get_messages_empty());
   } else if (message == "primitives") {
-    rc = publish<test_communication::msg::Primitives>(node, message, get_messages_primitives());
+    publish<test_communication::msg::Primitives>(node, message, get_messages_primitives());
   } else if (message == "staticarrayprimitives") {
-    rc = publish<test_communication::msg::StaticArrayPrimitives>(node, message, get_messages_static_array_primitives());
+    publish<test_communication::msg::StaticArrayPrimitives>(node, message, get_messages_static_array_primitives());
   } else if (message == "dynamicarrayprimitives") {
-    rc = publish<test_communication::msg::DynamicArrayPrimitives>(node, message, get_messages_dynamic_array_primitives());
+    publish<test_communication::msg::DynamicArrayPrimitives>(node, message, get_messages_dynamic_array_primitives());
   } else if (message == "nested") {
-    rc = publish<test_communication::msg::Nested>(node, message, get_messages_nested());
+    publish<test_communication::msg::Nested>(node, message, get_messages_nested());
   } else if (message == "builtins") {
-    rc = publish<test_communication::msg::Builtins>(node, message, get_messages_builtins());
+    publish<test_communication::msg::Builtins>(node, message, get_messages_builtins());
   } else {
     fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());
     return 1;
   }
-  return rc;
+  return 0;
 }

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -1,0 +1,165 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <iostream>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "message_fixtures.hpp"
+
+template<typename T>
+void publish(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  std::vector<typename T::SharedPtr> messages,
+  size_t number_of_cycles = 5)
+{
+  auto publisher = node->create_publisher<T>(
+    std::string("test_message_") + message_type, messages.size());
+
+  rclcpp::WallRate time_between_cycles(1);
+  rclcpp::WallRate time_between_messages(10);
+  size_t cycle_index = 0;
+  // publish all messages up to number_of_cycles times, longer sleep between each cycle
+  while (rclcpp::ok() && cycle_index < number_of_cycles) {
+    size_t message_index = 0;
+    // publish all messages one by one, shorter sleep between each message
+    while (rclcpp::ok() && message_index < messages.size()) {
+      std::cout << "publishing message #" << (message_index + 1) << std::endl;
+      publisher->publish(messages[message_index]);
+      ++message_index;
+      time_between_messages.sleep();
+      rclcpp::spin_some(node);
+    }
+    ++cycle_index;
+    time_between_cycles.sleep();
+    rclcpp::spin_some(node);
+  }
+}
+
+template<typename T>
+rclcpp::subscription::SubscriptionBase::SharedPtr subscribe(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  std::vector<typename T::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages)
+{
+  received_messages.assign(expected_messages.size(), false);
+
+  auto callback =
+    [&expected_messages, &received_messages](const typename T::SharedPtr received_message) -> void
+    {
+      // find received message in vector of expected messages
+      auto received = received_messages.begin();
+      bool known_message = false;
+      size_t index = 0;
+      for (auto expected_message : expected_messages) {
+        if (*received_message == *expected_message) {
+          *received = true;
+          std::cout << "received message #" << (index + 1) << " of " <<
+            expected_messages.size() << std::endl;
+          known_message = true;
+          break;
+        }
+        ++received;
+        ++index;
+      }
+      if (!known_message) {
+        fprintf(stderr, "received message does not match any expected message\n");
+        rclcpp::shutdown();
+        throw std::runtime_error("received message does not match any expected message");
+      }
+
+      // shutdown node when all expected messages have been received
+      for (auto received : received_messages) {
+        if (!received) {
+          return;
+        }
+      }
+      rclcpp::shutdown();
+    };
+
+  auto subscriber = node->create_subscription<T>(
+    std::string("test_message_") + message_type, expected_messages.size(), callback);
+  return subscriber;
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  if (argc != 2) {
+    fprintf(stderr, "Wrong number of arguments, pass one message type\n");
+    return 1;
+  }
+
+  auto start = std::chrono::steady_clock::now();
+
+  std::string message = argv[1];
+  auto node = rclcpp::Node::make_shared(std::string("test_publisher_subscriber_") + message);
+
+  rclcpp::subscription::SubscriptionBase::SharedPtr subscriber;
+  std::vector<bool> received_messages;  // collect flags about received messages
+
+  auto messages_empty = get_messages_empty();
+  auto messages_primitives = get_messages_primitives();
+  auto messages_static_array_primitives = get_messages_static_array_primitives();
+  auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
+  auto messages_nested = get_messages_nested();
+  auto messages_builtins = get_messages_builtins();
+
+  if (message == "empty") {
+    subscriber = subscribe<test_communication::msg::Empty>(
+      node, message, messages_empty, received_messages);
+    publish<test_communication::msg::Empty>(node, message, messages_empty);
+  } else if (message == "primitives") {
+    subscriber = subscribe<test_communication::msg::Primitives>(
+      node, message, messages_primitives, received_messages);
+    publish<test_communication::msg::Primitives>(node, message, messages_primitives);
+  } else if (message == "staticarrayprimitives") {
+    subscriber = subscribe<test_communication::msg::StaticArrayPrimitives>(
+      node, message, messages_static_array_primitives, received_messages);
+    publish<test_communication::msg::StaticArrayPrimitives>(node, message, messages_static_array_primitives);
+  } else if (message == "dynamicarrayprimitives") {
+    subscriber = subscribe<test_communication::msg::DynamicArrayPrimitives>(
+      node, message, messages_dynamic_array_primitives, received_messages);
+    publish<test_communication::msg::DynamicArrayPrimitives>(node, message, messages_dynamic_array_primitives);
+  } else if (message == "nested") {
+    subscriber = subscribe<test_communication::msg::Nested>(
+      node, message, messages_nested, received_messages);
+    publish<test_communication::msg::Nested>(node, message, messages_nested);
+  } else if (message == "builtins") {
+    subscriber = subscribe<test_communication::msg::Builtins>(
+      node, message, messages_builtins, received_messages);
+    publish<test_communication::msg::Builtins>(node, message, messages_builtins);
+  } else {
+    fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());
+    return 1;
+  }
+
+  rclcpp::spin_some(node);
+
+  auto end = std::chrono::steady_clock::now();
+  std::chrono::duration<float> diff = (end - start);
+  std::cout << "published and subscribed for " << diff.count() << " seconds" << std::endl;
+
+  for (auto received : received_messages) {
+    if (!received) {
+      return 1;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This test currently fails with the Connext rwm implementations.