### PR TITLE
add test to cover messages with an array of sub messages

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -18,6 +18,7 @@ if(AMENT_ENABLE_TESTING)
 
   set(message_files
     "msg/Builtins.msg"
+    "msg/DynamicArrayNested.msg"
     "msg/DynamicArrayPrimitives.msg"
     "msg/Empty.msg"
     "msg/Nested.msg"

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -23,6 +23,7 @@ if(AMENT_ENABLE_TESTING)
     "msg/Empty.msg"
     "msg/Nested.msg"
     "msg/Primitives.msg"
+    "msg/StaticArrayNested.msg"
     "msg/StaticArrayPrimitives.msg"
   )
   set(service_files

--- a/test_communication/msg/DynamicArrayNested.msg
+++ b/test_communication/msg/DynamicArrayNested.msg
@@ -1,0 +1,1 @@
+test_communication/Primitives[] primitive_values

--- a/test_communication/msg/DynamicArrayNested.msg
+++ b/test_communication/msg/DynamicArrayNested.msg
@@ -1,1 +1,1 @@
-test_communication/Primitives[] primitive_values
+Primitives[] primitive_values

--- a/test_communication/msg/Nested.msg
+++ b/test_communication/msg/Nested.msg
@@ -1,1 +1,1 @@
-test_communication/Primitives primitive_values
+Primitives primitive_values

--- a/test_communication/msg/StaticArrayNested.msg
+++ b/test_communication/msg/StaticArrayNested.msg
@@ -1,0 +1,1 @@
+Primitives[3] primitive_values

--- a/test_communication/test/message_fixtures.hpp
+++ b/test_communication/test/message_fixtures.hpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include <test_communication/msg/builtins.hpp>
+#include <test_communication/msg/dynamic_array_nested.hpp>
 #include <test_communication/msg/dynamic_array_primitives.hpp>
 #include <test_communication/msg/empty.hpp>
 #include <test_communication/msg/nested.hpp>
@@ -203,6 +204,21 @@ get_messages_nested()
   for (auto primitive_msg : primitive_msgs) {
     auto msg = std::make_shared<test_communication::msg::Nested>();
     msg->primitive_values = *primitive_msg;
+    messages.push_back(msg);
+  }
+  return messages;
+}
+
+std::vector<test_communication::msg::DynamicArrayNested::SharedPtr>
+get_messages_dynamic_array_nested()
+{
+  std::vector<test_communication::msg::DynamicArrayNested::SharedPtr> messages;
+  {
+    auto msg = std::make_shared<test_communication::msg::DynamicArrayNested>();
+    auto primitive_msgs = get_messages_primitives();
+    for (auto primitive_msg : primitive_msgs) {
+      msg->primitive_values.push_back(*primitive_msg);
+    }
     messages.push_back(msg);
   }
   return messages;

--- a/test_communication/test/message_fixtures.hpp
+++ b/test_communication/test/message_fixtures.hpp
@@ -15,6 +15,7 @@
 #ifndef __test_communication__message_fixtures__hpp__
 #define __test_communication__message_fixtures__hpp__
 
+#include <cassert>
 #include <vector>
 
 #include <test_communication/msg/builtins.hpp>
@@ -23,6 +24,7 @@
 #include <test_communication/msg/empty.hpp>
 #include <test_communication/msg/nested.hpp>
 #include <test_communication/msg/primitives.hpp>
+#include <test_communication/msg/static_array_nested.hpp>
 #include <test_communication/msg/static_array_primitives.hpp>
 
 
@@ -218,6 +220,24 @@ get_messages_dynamic_array_nested()
     auto primitive_msgs = get_messages_primitives();
     for (auto primitive_msg : primitive_msgs) {
       msg->primitive_values.push_back(*primitive_msg);
+    }
+    messages.push_back(msg);
+  }
+  return messages;
+}
+
+std::vector<test_communication::msg::StaticArrayNested::SharedPtr>
+get_messages_static_array_nested()
+{
+  std::vector<test_communication::msg::StaticArrayNested::SharedPtr> messages;
+  {
+    auto msg = std::make_shared<test_communication::msg::StaticArrayNested>();
+    auto primitive_msgs = get_messages_primitives();
+    assert(primitive_msgs.size() == msg->primitive_values.size());
+    size_t i = 0;
+    for (auto primitive_msg : primitive_msgs) {
+      msg->primitive_values[i] = *primitive_msg;
+      ++i;
     }
     messages.push_back(msg);
   }

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -77,6 +77,8 @@ int main(int argc, char ** argv)
     publish<test_communication::msg::Nested>(node, message, get_messages_nested());
   } else if (message == "dynamicarraynested") {
     publish<test_communication::msg::DynamicArrayNested>(node, message, get_messages_dynamic_array_nested());
+  } else if (message == "staticarraynested") {
+    publish<test_communication::msg::StaticArrayNested>(node, message, get_messages_static_array_nested());
   } else if (message == "builtins") {
     publish<test_communication::msg::Builtins>(node, message, get_messages_builtins());
   } else {

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -75,6 +75,8 @@ int main(int argc, char ** argv)
     publish<test_communication::msg::DynamicArrayPrimitives>(node, message, get_messages_dynamic_array_primitives());
   } else if (message == "nested") {
     publish<test_communication::msg::Nested>(node, message, get_messages_nested());
+  } else if (message == "dynamicarraynested") {
+    publish<test_communication::msg::DynamicArrayNested>(node, message, get_messages_dynamic_array_nested());
   } else if (message == "builtins") {
     publish<test_communication::msg::Builtins>(node, message, get_messages_builtins());
   } else {

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -119,6 +119,7 @@ int main(int argc, char ** argv)
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
   auto messages_nested = get_messages_nested();
   auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
+  auto messages_static_array_nested = get_messages_static_array_nested();
   auto messages_builtins = get_messages_builtins();
 
   if (message == "empty") {
@@ -145,6 +146,10 @@ int main(int argc, char ** argv)
     subscriber = subscribe<test_communication::msg::DynamicArrayNested>(
       node, message, messages_dynamic_array_nested, received_messages);
     publish<test_communication::msg::DynamicArrayNested>(node, message, messages_dynamic_array_nested);
+  } else if (message == "staticarraynested") {
+    subscriber = subscribe<test_communication::msg::StaticArrayNested>(
+      node, message, messages_static_array_nested, received_messages);
+    publish<test_communication::msg::StaticArrayNested>(node, message, messages_static_array_nested);
   } else if (message == "builtins") {
     subscriber = subscribe<test_communication::msg::Builtins>(
       node, message, messages_builtins, received_messages);

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -118,6 +118,7 @@ int main(int argc, char ** argv)
   auto messages_static_array_primitives = get_messages_static_array_primitives();
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
   auto messages_nested = get_messages_nested();
+  auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
   auto messages_builtins = get_messages_builtins();
 
   if (message == "empty") {
@@ -140,6 +141,10 @@ int main(int argc, char ** argv)
     subscriber = subscribe<test_communication::msg::Nested>(
       node, message, messages_nested, received_messages);
     publish<test_communication::msg::Nested>(node, message, messages_nested);
+  } else if (message == "dynamicarraynested") {
+    subscriber = subscribe<test_communication::msg::DynamicArrayNested>(
+      node, message, messages_dynamic_array_nested, received_messages);
+    publish<test_communication::msg::DynamicArrayNested>(node, message, messages_dynamic_array_nested);
   } else if (message == "builtins") {
     subscriber = subscribe<test_communication::msg::Builtins>(
       node, message, messages_builtins, received_messages);

--- a/test_communication/test/test_publisher_subscriber.py.in
+++ b/test_communication/test/test_publisher_subscriber.py.in
@@ -22,8 +22,8 @@ def test_publisher_subscriber():
     rc = launcher.launch()
 
     assert rc == 0, \
-        "The subscriber failed with exit code '" + str(rc) + "'. " \
-        'May be it did not receive any messages?'
+        "The launch file failed with exit code '" + str(rc) + "'. " \
+        'May be the subscriber did not receive any messages?'
 
 
 if __name__ == '__main__':

--- a/test_communication/test/test_requester_replier.py.in
+++ b/test_communication/test/test_requester_replier.py.in
@@ -21,7 +21,9 @@ def test_requester_replier():
     launcher.add_launch_descriptor(ld)
     rc = launcher.launch()
 
-    assert rc == 0, 'The requester did not receive any replies'
+    assert rc == 0, \
+        "The launch file failed with exit code '" + str(rc) + "'. " \
+        'May be the requester did not receive any replies?'
 
 
 if __name__ == '__main__':

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -87,6 +87,7 @@ int main(int argc, char ** argv)
   auto messages_static_array_primitives = get_messages_static_array_primitives();
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
   auto messages_nested = get_messages_nested();
+  auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
   auto messages_builtins = get_messages_builtins();
 
   rclcpp::subscription::SubscriptionBase::SharedPtr subscriber;
@@ -106,6 +107,9 @@ int main(int argc, char ** argv)
   } else if (message == "nested") {
     subscriber = subscribe<test_communication::msg::Nested>(
       node, message, messages_nested, received_messages);
+  } else if (message == "dynamicarraynested") {
+    subscriber = subscribe<test_communication::msg::DynamicArrayNested>(
+      node, message, messages_dynamic_array_nested, received_messages);
   } else if (message == "builtins") {
     subscriber = subscribe<test_communication::msg::Builtins>(
       node, message, messages_builtins, received_messages);

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -88,6 +88,7 @@ int main(int argc, char ** argv)
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
   auto messages_nested = get_messages_nested();
   auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
+  auto messages_static_array_nested = get_messages_static_array_nested();
   auto messages_builtins = get_messages_builtins();
 
   rclcpp::subscription::SubscriptionBase::SharedPtr subscriber;
@@ -110,6 +111,9 @@ int main(int argc, char ** argv)
   } else if (message == "dynamicarraynested") {
     subscriber = subscribe<test_communication::msg::DynamicArrayNested>(
       node, message, messages_dynamic_array_nested, received_messages);
+  } else if (message == "staticarraynested") {
+    subscriber = subscribe<test_communication::msg::StaticArrayNested>(
+      node, message, messages_static_array_nested, received_messages);
   } else if (message == "builtins") {
     subscriber = subscribe<test_communication::msg::Builtins>(
       node, message, messages_builtins, received_messages);


### PR DESCRIPTION
This tests covers the case which currently fails in #14.

I will wait with the merge until a fix has been committed to `rmw_connext_dynamic_cpp`.