### PR TITLE
Add test for "has_bounded_size" message function

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -22,9 +22,13 @@ if(AMENT_ENABLE_TESTING)
     "msg/DynamicArrayPrimitives.msg"
     "msg/Empty.msg"
     "msg/Nested.msg"
+    "msg/NestedBounded.msg"
     "msg/Primitives.msg"
+    "msg/PrimitivesBounded.msg"
     "msg/StaticArrayNested.msg"
+    "msg/StaticArrayNestedBounded.msg"
     "msg/StaticArrayPrimitives.msg"
+    "msg/StaticArrayBounded.msg"
   )
   set(service_files
     "srv/Empty.srv"
@@ -121,6 +125,15 @@ if(AMENT_ENABLE_TESTING)
     rosidl_target_interfaces(test_replier_cpp__${middleware_impl}
       ${PROJECT_NAME} ${typesupport_impl})
     ament_target_dependencies(test_replier_cpp__${middleware_impl}
+      "${middleware_impl}"
+      "rclcpp")
+
+    # executables messages
+    add_executable(test_messages_cpp__${middleware_impl} "test/test_messages.cpp")
+    add_dependencies(test_messages_cpp__${middleware_impl} ${PROJECT_NAME})
+    rosidl_target_interfaces(test_messages_cpp__${middleware_impl}
+      ${PROJECT_NAME} ${typesupport_impl})
+    ament_target_dependencies(test_messages_cpp__${middleware_impl}
       "${middleware_impl}"
       "rclcpp")
   endforeach()

--- a/test_communication/msg/NestedBounded.msg
+++ b/test_communication/msg/NestedBounded.msg
@@ -1,0 +1,1 @@
+PrimitivesBounded primitive_values

--- a/test_communication/msg/PrimitivesBounded.msg
+++ b/test_communication/msg/PrimitivesBounded.msg
@@ -1,0 +1,13 @@
+bool bool_value
+byte byte_value
+char char_value
+float32 float32_value
+float64 float64_value
+int8 int8_value
+uint8 uint8_value
+int16 int16_value
+uint16 uint16_value
+int32 int32_value
+uint32 uint32_value
+int64 int64_value
+uint64 uint64_value

--- a/test_communication/msg/PrimitivesBounded.msg
+++ b/test_communication/msg/PrimitivesBounded.msg
@@ -11,3 +11,4 @@ int32 int32_value
 uint32 uint32_value
 int64 int64_value
 uint64 uint64_value
+string<=8 string_value

--- a/test_communication/msg/StaticArrayBounded.msg
+++ b/test_communication/msg/StaticArrayBounded.msg
@@ -1,0 +1,13 @@
+bool[3] bool_values
+byte[3] byte_values
+char[3] char_values
+float32[3] float32_values
+float64[3] float64_values
+int8[3] int8_values
+uint8[3] uint8_values
+int16[3] int16_values
+uint16[3] uint16_values
+int32[3] int32_values
+uint32[3] uint32_values
+int64[3] int64_values
+uint64[3] uint64_values

--- a/test_communication/msg/StaticArrayNestedBounded.msg
+++ b/test_communication/msg/StaticArrayNestedBounded.msg
@@ -1,0 +1,1 @@
+PrimitivesBounded[3] primitive_values

--- a/test_communication/test/test_messages.cpp
+++ b/test_communication/test/test_messages.cpp
@@ -1,0 +1,101 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "message_fixtures.hpp"
+
+#include <test_communication/msg/primitives_bounded.hpp>
+#include <test_communication/msg/static_array_bounded.hpp>
+#include <test_communication/msg/static_array_nested_bounded.hpp>
+#include <test_communication/msg/nested_bounded.hpp>
+
+int main(int argc, char ** argv)
+{
+  auto message_empty = get_messages_empty()[0];
+  auto message_primitives = get_messages_primitives()[0];
+  auto message_static_array_primitives = get_messages_static_array_primitives()[0];
+  auto message_dynamic_array_primitives = get_messages_dynamic_array_primitives()[0];
+  auto message_nested = get_messages_nested()[0];
+  auto message_dynamic_array_nested = get_messages_dynamic_array_nested()[0];
+  auto message_static_array_nested = get_messages_static_array_nested()[0];
+  auto message_builtins = get_messages_builtins()[0];
+
+  test_communication::msg::PrimitivesBounded::SharedPtr message_primitives_bounded;
+  test_communication::msg::StaticArrayBounded::SharedPtr message_static_array_bounded;
+  test_communication::msg::StaticArrayNestedBounded::SharedPtr message_static_array_nested_bounded;
+  test_communication::msg::NestedBounded::SharedPtr message_nested_bounded;
+
+  // Check the types of all instantiated messages
+
+  if (message_empty->is_dynamic()) {
+    fprintf(stderr, "Empty::is_dynamic() returned true!\n");
+    return 1;
+  }
+
+  if (!message_primitives->is_dynamic()) {
+    fprintf(stderr, "Primitives::is_dynamic() returned false!\n");
+    return 1;
+  }
+
+  if (message_primitives_bounded->is_dynamic()) {
+    fprintf(stderr, "PrimitivesBounded::is_dynamic() returned true!\n");
+    return 1;
+  }
+
+  if (!message_static_array_primitives->is_dynamic()) {
+    fprintf(stderr, "StaticArrayPrimitives::is_dynamic() returned false!\n");
+    return 1;
+  }
+
+  if (message_static_array_bounded->is_dynamic()) {
+    fprintf(stderr, "StaticArrayBounded::is_dynamic() returned true!\n");
+    return 1;
+  }
+
+  if (!message_dynamic_array_primitives->is_dynamic()) {
+    fprintf(stderr, "DynamicArrayPrimitives::is_dynamic() returned false!\n");
+    return 1;
+  }
+
+  if (!message_nested->is_dynamic()) {
+    fprintf(stderr, "Nested::is_dynamic() returned false!\n");
+    return 1;
+  }
+
+  if (message_nested_bounded->is_dynamic()) {
+    fprintf(stderr, "NestedBounded::is_dynamic() returned true!\n");
+    return 1;
+  }
+  if (!message_dynamic_array_nested->is_dynamic()) {
+    fprintf(stderr, "DynamicArrayNested::is_dynamic() returned false!\n");
+    return 1;
+  }
+  if (!message_static_array_nested->is_dynamic()) {
+    fprintf(stderr, "StaticArrayNested::is_dynamic() returned false!\n");
+    return 1;
+  }
+  if (message_static_array_nested_bounded->is_dynamic()) {
+    fprintf(stderr, "StaticArrayNestedBounded::is_dynamic() returned true!\n");
+    return 1;
+  }
+  if (message_builtins->is_dynamic()) {
+    fprintf(stderr, "Builtins::is_dynamic() returned true!\n");
+    return 1;
+  }
+
+  fprintf(stderr, "All tests passed.\n");
+  return 0;
+}

--- a/test_communication/test/test_messages.cpp
+++ b/test_communication/test/test_messages.cpp
@@ -40,60 +40,64 @@ int main(int argc, char ** argv)
 
   // Check the types of all instantiated messages
 
-  if (message_empty->is_dynamic()) {
-    fprintf(stderr, "Empty::is_dynamic() returned true!\n");
-    return 1;
+  if (!message_empty->has_bounded_size()) {
+    fprintf(stderr, "Empty::has_bounded_size() returned false!\n");
+    //return 1;
   }
 
-  if (!message_primitives->is_dynamic()) {
-    fprintf(stderr, "Primitives::is_dynamic() returned false!\n");
-    return 1;
+  if (message_primitives->has_bounded_size()) {
+    fprintf(stderr, "Primitives::has_bounded_size() returned true!\n");
+    //return 1;
   }
 
-  if (message_primitives_bounded->is_dynamic()) {
-    fprintf(stderr, "PrimitivesBounded::is_dynamic() returned true!\n");
-    return 1;
+  if (!message_primitives_bounded->has_bounded_size()) {
+    fprintf(stderr, "PrimitivesBounded::has_bounded_size() returned false!\n");
+    //return 1;
   }
 
-  if (!message_static_array_primitives->is_dynamic()) {
-    fprintf(stderr, "StaticArrayPrimitives::is_dynamic() returned false!\n");
-    return 1;
+  if (message_static_array_primitives->has_bounded_size()) {
+    fprintf(stderr, "StaticArrayPrimitives::has_bounded_size() returned true!\n");
+    //return 1;
   }
 
-  if (message_static_array_bounded->is_dynamic()) {
-    fprintf(stderr, "StaticArrayBounded::is_dynamic() returned true!\n");
-    return 1;
+  // TODO
+  if (!message_static_array_bounded->has_bounded_size()) {
+    fprintf(stderr, "StaticArrayBounded::has_bounded_size() returned false!\n");
+    //return 1;
   }
 
-  if (!message_dynamic_array_primitives->is_dynamic()) {
-    fprintf(stderr, "DynamicArrayPrimitives::is_dynamic() returned false!\n");
-    return 1;
+  if (message_dynamic_array_primitives->has_bounded_size()) {
+    fprintf(stderr, "DynamicArrayPrimitives::has_bounded_size() returned true!\n");
+    //return 1;
   }
 
-  if (!message_nested->is_dynamic()) {
-    fprintf(stderr, "Nested::is_dynamic() returned false!\n");
-    return 1;
+  if (message_nested->has_bounded_size()) {
+    fprintf(stderr, "Nested::has_bounded_size() returned true!\n");
+    //return 1;
   }
 
-  if (message_nested_bounded->is_dynamic()) {
-    fprintf(stderr, "NestedBounded::is_dynamic() returned true!\n");
-    return 1;
+  if (!message_nested_bounded->has_bounded_size()) {
+    fprintf(stderr, "NestedBounded::has_bounded_size() returned false!\n");
+    //return 1;
   }
-  if (!message_dynamic_array_nested->is_dynamic()) {
-    fprintf(stderr, "DynamicArrayNested::is_dynamic() returned false!\n");
-    return 1;
+  if (message_dynamic_array_nested->has_bounded_size()) {
+    fprintf(stderr, "DynamicArrayNested::has_bounded_size() returned true!\n");
+    //return 1;
   }
-  if (!message_static_array_nested->is_dynamic()) {
-    fprintf(stderr, "StaticArrayNested::is_dynamic() returned false!\n");
-    return 1;
+
+  if (message_static_array_nested->has_bounded_size()) {
+    fprintf(stderr, "StaticArrayNested::has_bounded_size() returned true!\n");
+    //return 1;
   }
-  if (message_static_array_nested_bounded->is_dynamic()) {
-    fprintf(stderr, "StaticArrayNestedBounded::is_dynamic() returned true!\n");
-    return 1;
+
+  // TODO
+  if (!message_static_array_nested_bounded->has_bounded_size()) {
+    fprintf(stderr, "StaticArrayNestedBounded::has_bounded_size() returned false!\n");
+    //return 1;
   }
-  if (message_builtins->is_dynamic()) {
-    fprintf(stderr, "Builtins::is_dynamic() returned true!\n");
-    return 1;
+  if (!message_builtins->has_bounded_size()) {
+    fprintf(stderr, "Builtins::has_bounded_size() returned false!\n");
+    //return 1;
   }
 
   fprintf(stderr, "All tests passed.\n");

--- a/test_communication/test/test_messages.cpp
+++ b/test_communication/test/test_messages.cpp
@@ -33,73 +33,74 @@ int main(int argc, char ** argv)
   auto message_static_array_nested = get_messages_static_array_nested()[0];
   auto message_builtins = get_messages_builtins()[0];
 
-  test_communication::msg::PrimitivesBounded::SharedPtr message_primitives_bounded;
-  test_communication::msg::StaticArrayBounded::SharedPtr message_static_array_bounded;
-  test_communication::msg::StaticArrayNestedBounded::SharedPtr message_static_array_nested_bounded;
-  test_communication::msg::NestedBounded::SharedPtr message_nested_bounded;
+  auto message_primitives_bounded = std::make_shared<test_communication::msg::PrimitivesBounded>();
+  auto message_static_array_bounded = std::make_shared<test_communication::msg::StaticArrayBounded>();
+  auto message_static_array_nested_bounded = std::make_shared<test_communication::msg::StaticArrayNestedBounded>();
+  auto message_nested_bounded = std::make_shared<test_communication::msg::NestedBounded>();
 
   // Check the types of all instantiated messages
 
+  int retcode = 0;
   if (!message_empty->has_bounded_size()) {
     fprintf(stderr, "Empty::has_bounded_size() returned false!\n");
-    //return 1;
+    retcode = 1;
   }
 
   if (message_primitives->has_bounded_size()) {
     fprintf(stderr, "Primitives::has_bounded_size() returned true!\n");
-    //return 1;
+    retcode = 1;
   }
 
   if (!message_primitives_bounded->has_bounded_size()) {
     fprintf(stderr, "PrimitivesBounded::has_bounded_size() returned false!\n");
-    //return 1;
+    retcode = 1;
   }
 
   if (message_static_array_primitives->has_bounded_size()) {
     fprintf(stderr, "StaticArrayPrimitives::has_bounded_size() returned true!\n");
-    //return 1;
+    retcode = 1;
   }
 
-  // TODO
   if (!message_static_array_bounded->has_bounded_size()) {
     fprintf(stderr, "StaticArrayBounded::has_bounded_size() returned false!\n");
-    //return 1;
+    retcode = 1;
   }
 
   if (message_dynamic_array_primitives->has_bounded_size()) {
     fprintf(stderr, "DynamicArrayPrimitives::has_bounded_size() returned true!\n");
-    //return 1;
+    retcode = 1;
   }
 
   if (message_nested->has_bounded_size()) {
     fprintf(stderr, "Nested::has_bounded_size() returned true!\n");
-    //return 1;
+    retcode = 1;
   }
 
   if (!message_nested_bounded->has_bounded_size()) {
     fprintf(stderr, "NestedBounded::has_bounded_size() returned false!\n");
-    //return 1;
+    retcode = 1;
   }
   if (message_dynamic_array_nested->has_bounded_size()) {
     fprintf(stderr, "DynamicArrayNested::has_bounded_size() returned true!\n");
-    //return 1;
+    retcode = 1;
   }
 
   if (message_static_array_nested->has_bounded_size()) {
     fprintf(stderr, "StaticArrayNested::has_bounded_size() returned true!\n");
-    //return 1;
+    retcode = 1;
   }
 
-  // TODO
   if (!message_static_array_nested_bounded->has_bounded_size()) {
     fprintf(stderr, "StaticArrayNestedBounded::has_bounded_size() returned false!\n");
-    //return 1;
+    retcode = 1;
   }
   if (!message_builtins->has_bounded_size()) {
     fprintf(stderr, "Builtins::has_bounded_size() returned false!\n");
-    //return 1;
+    retcode = 1;
   }
 
-  fprintf(stderr, "All tests passed.\n");
-  return 0;
+  if (retcode == 0)
+    fprintf(stderr, "All tests passed.\n");
+
+  return retcode;
 }

--- a/test_communication/test/test_messages.cpp
+++ b/test_communication/test/test_messages.cpp
@@ -34,8 +34,10 @@ int main(int argc, char ** argv)
   auto message_builtins = get_messages_builtins()[0];
 
   auto message_primitives_bounded = std::make_shared<test_communication::msg::PrimitivesBounded>();
-  auto message_static_array_bounded = std::make_shared<test_communication::msg::StaticArrayBounded>();
-  auto message_static_array_nested_bounded = std::make_shared<test_communication::msg::StaticArrayNestedBounded>();
+  auto message_static_array_bounded =
+    std::make_shared<test_communication::msg::StaticArrayBounded>();
+  auto message_static_array_nested_bounded =
+    std::make_shared<test_communication::msg::StaticArrayNestedBounded>();
   auto message_nested_bounded = std::make_shared<test_communication::msg::NestedBounded>();
 
   // Check the types of all instantiated messages
@@ -99,8 +101,9 @@ int main(int argc, char ** argv)
     retcode = 1;
   }
 
-  if (retcode == 0)
+  if (retcode == 0) {
     fprintf(stderr, "All tests passed.\n");
+  }
 
   return retcode;
 }


### PR DESCRIPTION
Connects to https://github.com/ros2/rosidl/pull/29

Adds a test for message types and several new message types for the purposes of testing the `has_bounded_size()` function for messages.