### PR TITLE
Add test for timeout parameter

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -69,6 +69,27 @@ if(AMENT_ENABLE_TESTING)
         "${middleware_impl}"
         "rclcpp")
     endif()
+
+    # test_timeout_subscriber
+    ament_add_gtest(
+      gtest_timeout_subscriber__${middleware_impl}
+      "test/test_timeout_subscriber.cpp"
+      TIMEOUT 30
+    )
+    if(TARGET gtest_timeout_subscriber__${middleware_impl})
+      target_link_libraries(gtest_timeout_subscriber__${middleware_impl}
+        ${_AMENT_EXPORT_ABSOLUTE_LIBRARIES}
+        ${_AMENT_EXPORT_LIBRARY_TARGETS})
+      target_compile_definitions(gtest_timeout_subscriber__${middleware_impl}
+        PUBLIC "RMW_IMPLEMENTATION=${middleware_impl}")
+      add_dependencies(gtest_timeout_subscriber__${middleware_impl} ${PROJECT_NAME})
+      rosidl_target_interfaces(gtest_timeout_subscriber__${middleware_impl}
+        ${PROJECT_NAME} ${typesupport_impl})
+      ament_target_dependencies(gtest_timeout_subscriber__${middleware_impl}
+        "${middleware_impl}"
+        "rclcpp")
+    endif()
+
   endforeach()
 endif()  # AMENT_ENABLE_TESTING
 

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -57,7 +57,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
 
     // nothing should be pending here
     printf("spin_node_once(nonblocking) - no callback expected\n");
-    executor.spin_node_once(node, true);
+    executor.spin_node_once(node, std::chrono::milliseconds(0));
     ASSERT_EQ(0, counter);
     printf("spin_node_some() - no callback expected\n");
     executor.spin_node_some(node);
@@ -74,7 +74,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
 
     // nothing should be pending here
     printf("spin_node_once(nonblocking) - no callback expected\n");
-    executor.spin_node_once(node, true);
+    executor.spin_node_once(node, std::chrono::milliseconds(0));
     ASSERT_EQ(1, counter);
     printf("spin_node_some() - no callback expected\n");
     executor.spin_node_some(node);
@@ -92,23 +92,23 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
 
     // while four messages have been published one callback should be triggered here
     printf("spin_node_once(nonblocking) - callback (2) expected\n");
-    executor.spin_node_once(node, true);
+    executor.spin_node_once(node, std::chrono::milliseconds(0));
     if (counter == 1) {
       // give the executor thread time to process the event
       std::this_thread::sleep_for(std::chrono::milliseconds(25));
       printf("spin_node_once(nonblocking) - callback (2) expected - trying again\n");
-      executor.spin_node_once(node, true);
+      executor.spin_node_once(node, std::chrono::milliseconds(0));
     }
     ASSERT_EQ(2, counter);
 
     // check for next pending call
     printf("spin_node_once(nonblocking) - callback (3) expected\n");
-    executor.spin_node_once(node, true);
+    executor.spin_node_once(node, std::chrono::milliseconds(0));
     if (counter == 2) {
       // give the executor thread time to process the event
       std::this_thread::sleep_for(std::chrono::milliseconds(25));
       printf("spin_node_once(nonblocking) - callback (3) expected - trying again\n");
-      executor.spin_node_once(node, true);
+      executor.spin_node_once(node, std::chrono::milliseconds(0));
     }
     ASSERT_EQ(3, counter);
 
@@ -120,7 +120,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
       std::this_thread::sleep_for(std::chrono::milliseconds(25));
       printf("spin_node_some() - callback (%s) expected - trying again\n",
         counter == 3 ? "4 and 5" : "5");
-      executor.spin_node_once(node, true);
+      executor.spin_node_once(node, std::chrono::milliseconds(0));
     }
     ASSERT_EQ(5, counter);
   }

--- a/test_rclcpp/test/test_timeout_subscriber.cpp
+++ b/test_rclcpp/test/test_timeout_subscriber.cpp
@@ -1,0 +1,70 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <rclcpp/rclcpp.hpp>
+#include <test_rclcpp/msg/u_int32.hpp>
+
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+void callback(const test_rclcpp::msg::UInt32::ConstSharedPtr & /*msg*/)
+{
+  throw std::runtime_error("Subscriber received a message and therefore didn't timeout!");
+}
+
+TEST(CLASSNAME(test_timeout_subscriber, RMW_IMPLEMENTATION), timeout_subscriber) {
+  rclcpp::init(0, nullptr);
+
+  auto start = std::chrono::steady_clock::now();
+
+  auto node = rclcpp::Node::make_shared("test_timeout_subscriber");
+  auto subscriber = node->create_subscription<test_rclcpp::msg::UInt32>(
+    "test_message_timeout_uint32", 10, callback);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+
+  size_t num_cycles = 5;
+
+  for (size_t i = 0; i < num_cycles; ++i) {
+    auto tolerance = std::chrono::milliseconds(15);
+
+    auto nonblocking_start = std::chrono::steady_clock::now();
+    executor.spin_node_once(node, std::chrono::milliseconds::zero());
+    auto nonblocking_end = std::chrono::steady_clock::now();
+    auto nonblocking_diff = nonblocking_end - nonblocking_start;
+    EXPECT_LT(nonblocking_diff, tolerance);
+
+    auto blocking_timeout = std::chrono::milliseconds(100);
+    auto blocking_start = std::chrono::steady_clock::now();
+    executor.spin_node_once(node, blocking_timeout);
+    auto blocking_end = std::chrono::steady_clock::now();
+    auto blocking_diff = blocking_end - blocking_start;
+    EXPECT_LT(blocking_diff, blocking_timeout + tolerance);
+  }
+
+  auto end = std::chrono::steady_clock::now();
+  std::chrono::duration<float> diff = (end - start);
+  std::cout << "subscribed for " << diff.count() << " seconds" << std::endl;
+}


### PR DESCRIPTION
Connects to ros2/ros2#73

This test could be prone to flakiness due to scheduling nondeterminism, hence the extremely high tolerance. If we'd prefer to avoid flaky tests, I'm fine with declining this change, but I posted it to prove the correctness of my timeout PRs.