### PR TITLE
reiniting a node after destructing a parameter_service in opensplice causes a segfault

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -89,6 +89,14 @@ if(AMENT_ENABLE_TESTING)
         "rclcpp")
     endif()
 
+    ament_add_gtest(double_init_cpp__${middleware_impl} "test/double_init.cpp")
+    add_dependencies(double_init_cpp__${middleware_impl} ${PROJECT_NAME})
+    rosidl_target_interfaces(double_init_cpp__${middleware_impl}
+      ${PROJECT_NAME} ${typesupport_impl})
+    ament_target_dependencies(double_init_cpp__${middleware_impl}
+      "${middleware_impl}"
+      "rclcpp")
+
   endforeach()
 endif()  # AMENT_ENABLE_TESTING
 

--- a/test_rclcpp/test/double_init.cpp
+++ b/test_rclcpp/test/double_init.cpp
@@ -1,0 +1,37 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include "gtest/gtest.h"
+
+#include <rclcpp/rclcpp.hpp>
+
+
+TEST(node, double_init) {
+  auto node = rclcpp::Node::make_shared(std::string("test_init_"));
+  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+  parameter_service.reset();
+
+  node.reset();
+  node = rclcpp::Node::make_shared(std::string("test_init_2"));
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is a ticket masquerading as a pull-request as it comes with a failing unit test. This is isolated from failing tests in #14 

I suspect the issue is in rmw_opensplice. 

```
Error in destruction of rmw node handle: failed to delete participant, at /home/tfoote/work/ros2/test_param/src/ros2/rmw_opensplice/rmw_opensplice_cpp/src/functions.cpp:426
```

Full backtrace: 
```
Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff463f700 (LWP 2097)]
0x00007ffff63034bd in ?? () from /usr/lib/libdcpssacpp.so
(gdb) bt full
#0  0x00007ffff63034bd in ?? () from /usr/lib/libdcpssacpp.so
No symbol table info available.
#1  0x00007ffff5f04197 in _StatusNotifyDataAvailable () from /usr/lib/libddskernel.so
No symbol table info available.
#2  0x00007ffff5f045cb in _DataReaderNotifyListener () from /usr/lib/libddskernel.so
No symbol table info available.
#3  0x00007ffff5f046f7 in gapi_entityNotifyEvent () from /usr/lib/libddskernel.so
No symbol table info available.
#4  0x00007ffff5f04898 in ?? () from /usr/lib/libddskernel.so
No symbol table info available.
#5  0x00007ffff5f57a26 in ?? () from /usr/lib/libddskernel.so
No symbol table info available.
#6  0x00007ffff7054182 in start_thread (arg=0x7ffff463f700) at pthread_create.c:312
        __res = <optimized out>
        pd = 0x7ffff463f700
        now = <optimized out>
        unwind_buf = {cancel_jmp_buf = {{jmp_buf = {140737293580032, -3892017613621006498, 1, 0, 140737293580736, 140737293580032, 3892005485134376798, 
                3891999116583268190}, mask_was_saved = 0}}, priv = {pad = {0x0, 0x0, 0x0, 0x0}, data = {prev = 0x0, cleanup = 0x0, canceltype = 0}}}
        not_first_call = <optimized out>
        pagesize_m1 = <optimized out>
        sp = <optimized out>
        freesize = <optimized out>
        __PRETTY_FUNCTION__ = "start_thread"
#7  0x00007ffff686747d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111
No locals.
(gdb) 
```

