### PR TITLE
add test with repeated publishers / subscribers

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -31,6 +31,26 @@ if(AMENT_ENABLE_TESTING)
     # get typesupport of rmw implementation to include / link against the corresponding interfaces
     get_rmw_typesupport(typesupport_impl "${middleware_impl}")
 
+    # test_repeated_publisher_subscriber
+    ament_add_gtest(
+      gtest_repeated_publisher_subscriber__${middleware_impl}
+      "test/test_repeated_publisher_subscriber.cpp"
+      TIMEOUT 15
+    )
+    if(TARGET gtest_repeated_publisher_subscriber__${middleware_impl})
+      target_link_libraries(gtest_repeated_publisher_subscriber__${middleware_impl}
+        ${_AMENT_EXPORT_ABSOLUTE_LIBRARIES}
+        ${_AMENT_EXPORT_LIBRARY_TARGETS})
+      target_compile_definitions(gtest_repeated_publisher_subscriber__${middleware_impl}
+        PUBLIC "RMW_IMPLEMENTATION=${middleware_impl}")
+      add_dependencies(gtest_repeated_publisher_subscriber__${middleware_impl} ${PROJECT_NAME})
+      rosidl_target_interfaces(gtest_repeated_publisher_subscriber__${middleware_impl}
+        ${PROJECT_NAME} ${typesupport_impl})
+      ament_target_dependencies(gtest_repeated_publisher_subscriber__${middleware_impl}
+        "${middleware_impl}"
+        "rclcpp")
+    endif()
+
     # test_subscription
     ament_add_gtest(
       gtest_subscription__${middleware_impl}

--- a/test_rclcpp/test/test_repeated_publisher_subscriber.cpp
+++ b/test_rclcpp/test/test_repeated_publisher_subscriber.cpp
@@ -1,0 +1,96 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <test_rclcpp/msg/u_int32.hpp>
+
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+TEST(CLASSNAME(test_repeated_publisher_subscriber, RMW_IMPLEMENTATION), subscription_and_spinning) {
+  rclcpp::init(0, nullptr);
+
+  auto node = rclcpp::Node::make_shared("test_repeated_publisher_subscriber");
+
+  auto callback =
+    [](const test_rclcpp::msg::UInt32::SharedPtr) -> void
+    {
+    };
+
+  auto msg = std::make_shared<test_rclcpp::msg::UInt32>();
+  msg->data = 0;
+  rclcpp::executors::SingleThreadedExecutor executor;
+
+  {
+    printf("Creating publisher and subscriber...\n");
+    fflush(stdout);
+    auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>(
+      "test_repeated_publisher_subscriber", rmw_qos_profile_default);
+    auto subscriber = node->create_subscription<test_rclcpp::msg::UInt32>(
+      "test_repeated_publisher_subscriber", rmw_qos_profile_default, callback);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    printf("spin_node_some()\n");
+    fflush(stdout);
+    executor.spin_node_some(node);
+
+    msg->data = 1;
+    publisher->publish(msg);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    printf("spin_node_some()\n");
+    fflush(stdout);
+    executor.spin_node_some(node);
+
+    printf("Destroying publisher and subscriber...\n");
+    fflush(stdout);
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  {
+    printf("Recreating publisher and subscriber...\n");
+    fflush(stdout);
+    auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>(
+      "test_repeated_publisher_subscriber", rmw_qos_profile_default);
+    auto subscriber = node->create_subscription<test_rclcpp::msg::UInt32>(
+      "test_repeated_publisher_subscriber", rmw_qos_profile_default, callback);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    printf("spin_node_some()\n");
+    fflush(stdout);
+    executor.spin_node_some(node);
+
+    msg->data = 2;
+    publisher->publish(msg);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    printf("spin_node_some()\n");
+    fflush(stdout);
+    executor.spin_node_some(node);
+
+    printf("Destroying publisher and subscriber...\n");
+    fflush(stdout);
+  }
+}


### PR DESCRIPTION
The test fails for `rmw_connext_dynamic_cpp`:

http://ci.ros2.org/job/ros2_batch_ci_linux/228/
http://ci.ros2.org/job/ros2_batch_ci_osx/149/
http://ci.ros2.org/job/ros2_batch_ci_windows/231/