### PR TITLE
Call rclcpp::init only once

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -79,6 +79,7 @@ if(AMENT_ENABLE_TESTING)
     ament_add_gtest(
       gtest_timer__${middleware_impl}
       "test/test_timer.cpp"
+      SKIP_LINKING_MAIN_LIBRARIES
       TIMEOUT 30
     )
     if(TARGET gtest_timer__${middleware_impl})

--- a/test_rclcpp/test/test_timer.cpp
+++ b/test_rclcpp/test/test_timer.cpp
@@ -27,8 +27,6 @@
 #endif
 
 TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_fire_regularly) {
-  rclcpp::init(0, nullptr);
-
   auto node = rclcpp::Node::make_shared("test_timer_fire_regularly");
 
   unsigned long counter = 0;
@@ -83,8 +81,6 @@ TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_fire_regularly) {
 }
 
 TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_during_wait) {
-  rclcpp::init(0, nullptr);
-
   auto node = rclcpp::Node::make_shared("test_timer_during_wait");
 
   unsigned long counter = 0;
@@ -133,4 +129,12 @@ TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_during_wait) {
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
   printf("running for %.3f seconds\n", diff.count());
+}
+
+int main(int argc, char ** argv)
+{
+  // NOTE: use custom main to ensure that rclcpp::init is called only once
+  rclcpp::init(0, nullptr);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This PR moves calls to `rclcpp::init` into a main function to ensure that it's only being called once.