### PR TITLE
Test publishing a ConstSharedPtr

### DIFF
--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -172,7 +172,9 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   ASSERT_EQ(0, counter);
 
   msg->data = 1;
-  publisher->publish(msg);
+  // Create a ConstSharedPtr message to publish
+  test_rclcpp::msg::UInt32::ConstSharedPtr const_msg(msg);
+  publisher->publish(const_msg);
   ASSERT_EQ(0, counter);
 
   // wait for the first callback


### PR DESCRIPTION
Connects to ros2/rclcpp#123

Fixes ros2/rclcpp#118

Without the rclcpp pull request, this test fails to compile.