### PR TITLE
add test with multiple service calls

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -133,6 +133,26 @@ if(AMENT_ENABLE_TESTING)
         "rclcpp")
     endif()
 
+    # test_multiple_service_calls
+    ament_add_gtest(
+      gtest_multiple_service_calls__${middleware_impl}
+      "test/test_multiple_service_calls.cpp"
+      TIMEOUT 15
+    )
+    if(TARGET gtest_multiple_service_calls__${middleware_impl})
+      target_link_libraries(gtest_multiple_service_calls__${middleware_impl}
+        ${_AMENT_EXPORT_ABSOLUTE_LIBRARIES}
+        ${_AMENT_EXPORT_LIBRARY_TARGETS})
+      target_compile_definitions(gtest_multiple_service_calls__${middleware_impl}
+        PUBLIC "RMW_IMPLEMENTATION=${middleware_impl}")
+      add_dependencies(gtest_multiple_service_calls__${middleware_impl} ${PROJECT_NAME})
+      rosidl_target_interfaces(gtest_multiple_service_calls__${middleware_impl}
+        ${PROJECT_NAME} ${typesupport_impl})
+      ament_target_dependencies(gtest_multiple_service_calls__${middleware_impl}
+        "${middleware_impl}"
+        "rclcpp")
+    endif()
+
     # test_timer
     ament_add_gtest(
       gtest_timer__${middleware_impl}

--- a/test_rclcpp/test/test_multiple_service_calls.cpp
+++ b/test_rclcpp/test/test_multiple_service_calls.cpp
@@ -1,0 +1,72 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <test_rclcpp/srv/add_two_ints.hpp>
+
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+void handle_add_two_ints(
+  const std::shared_ptr<test_rclcpp::srv::AddTwoInts::Request> request,
+  std::shared_ptr<test_rclcpp::srv::AddTwoInts::Response> response)
+{
+  response->sum = request->a + request->b;
+}
+
+TEST(CLASSNAME(test_multiple_service_calls, RMW_IMPLEMENTATION), multiple_service_calls) {
+  rclcpp::init(0, nullptr);
+
+  auto node = rclcpp::Node::make_shared("test_multiple_service_calls");
+
+  node->create_service<test_rclcpp::srv::AddTwoInts>(
+    "test_multiple_service_calls", handle_add_two_ints);
+
+  auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("test_multiple_service_calls");
+
+  auto request1 = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
+  request1->a = 1;
+  request1->b = 0;
+
+  auto request2 = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
+  request2->a = 2;
+  request2->b = 0;
+
+  printf("Sending two requests...\n");
+  fflush(stdout);
+
+  auto result1 = client->async_send_request(request1);
+  auto result2 = client->async_send_request(request2);
+
+  printf("Waiting for first reply...\n");
+  fflush(stdout);
+  rclcpp::spin_until_future_complete(node, result1);
+  printf("Received first reply\n");
+  EXPECT_EQ(1, result1.get()->sum);
+
+  printf("Waiting for second reply...\n");
+  fflush(stdout);
+  rclcpp::spin_until_future_complete(node, result2);
+  printf("Received second reply\n");
+  EXPECT_EQ(2, result2.get()->sum);
+}


### PR DESCRIPTION
This new test implement exactly the same test for services as ros2/system_tests#20 does for pub/sub. It covers what has been tracked in ros2/rclcpp#52 for a while.

Without any patches the test fails since most rmw implementations currently don't wake up a second time: http://ci.ros2.org/job/ros2_batch_ci_osx/349/

With the two patches (ros2/rmw_connext#66 ros2/rmw_opensplice#60) the test passes since the rmw implementations check the read correctly (as suggested in https://github.com/ros2/rclcpp/issues/52#issuecomment-126523047): http://ci.ros2.org/job/ros2_batch_ci_osx/350/

Connect to ros2/rclcpp#52