### PR TITLE
Replace unsigned long with uint32_t

### DIFF
--- a/test_rclcpp/test/test_intra_process.cpp
+++ b/test_rclcpp/test/test_intra_process.cpp
@@ -33,7 +33,7 @@ TEST(test_intra_process_within_one_node, nominal_usage) {
   auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>(
     "test_intra_process", custom_qos_profile);
 
-  unsigned long counter = 0;
+  uint32_t counter = 0;
   auto callback =
     [&counter](
     const test_rclcpp::msg::UInt32::SharedPtr msg,
@@ -41,7 +41,7 @@ TEST(test_intra_process_within_one_node, nominal_usage) {
     ) -> void
     {
       ++counter;
-      printf("  callback() %lu with message data %u\n", counter, msg->data);
+      printf("  callback() %4u with message data %u\n", counter, msg->data);
       ASSERT_EQ(counter, msg->data);
       ASSERT_TRUE(message_info.from_intra_process);
     };

--- a/test_rclcpp/test/test_publisher.cpp
+++ b/test_rclcpp/test/test_publisher.cpp
@@ -34,13 +34,13 @@ TEST(CLASSNAME(test_publisher, RMW_IMPLEMENTATION), publish_with_const_reference
 
   auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>("test_publisher", 10);
 
-  unsigned long counter = 0;
+  uint32_t counter = 0;
   auto callback =
     [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg,
       const rmw_message_info_t & info) -> void
     {
       ++counter;
-      printf("  callback() %lu with message data %u\n", counter, msg->data);
+      printf("  callback() %4u with message data %u\n", counter, msg->data);
       ASSERT_EQ(counter, msg->data);
       ASSERT_FALSE(info.from_intra_process);
     };
@@ -68,7 +68,7 @@ TEST(CLASSNAME(test_publisher, RMW_IMPLEMENTATION), publish_with_const_reference
 
   executor.spin_node_some(node);
   // spin up to 4 times with a 25 ms wait in between
-  for (unsigned long i = 0; i < 4 && counter == 0; ++i) {
+  for (uint32_t i = 0; i < 4 && counter == 0; ++i) {
     printf("callback not called, sleeping and trying again\n");
     std::this_thread::sleep_for(std::chrono::milliseconds(25));
     executor.spin_node_some(node);

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -39,12 +39,12 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
   auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>(
     "test_subscription", custom_qos_profile);
 
-  unsigned long counter = 0;
+  uint32_t counter = 0;
   auto callback =
     [&counter](const test_rclcpp::msg::UInt32::SharedPtr msg) -> void
     {
       ++counter;
-      printf("  callback() %lu with message data %u\n", counter, msg->data);
+      printf("  callback() %4u with message data %u\n", counter, msg->data);
       ASSERT_EQ(counter, msg->data);
     };
 
@@ -148,12 +148,12 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>(
     "test_subscription", rmw_qos_profile_default);
 
-  unsigned long counter = 0;
+  uint32_t counter = 0;
   auto callback =
     [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg) -> void
     {
       ++counter;
-      printf("  callback() %lu with message data %u\n", counter, msg->data);
+      printf("  callback() %4u with message data %u\n", counter, msg->data);
       ASSERT_EQ(counter, msg->data);
     };
 
@@ -182,7 +182,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
 
   executor.spin_node_some(node);
   // spin up to 4 times with a 25 ms wait in between
-  for (unsigned long i = 0; i < 4 && counter == 0; ++i) {
+  for (uint32_t i = 0; i < 4 && counter == 0; ++i) {
     printf("callback not called, sleeping and trying again\n");
     std::this_thread::sleep_for(std::chrono::milliseconds(25));
     executor.spin_node_some(node);
@@ -196,13 +196,13 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>(
     "test_subscription", rmw_qos_profile_default);
 
-  unsigned long counter = 0;
+  uint32_t counter = 0;
   auto callback =
     [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg,
       const rmw_message_info_t & info) -> void
     {
       ++counter;
-      printf("  callback() %lu with message data %u\n", counter, msg->data);
+      printf("  callback() %4u with message data %u\n", counter, msg->data);
       ASSERT_EQ(counter, msg->data);
       ASSERT_FALSE(info.from_intra_process);
     };
@@ -230,7 +230,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
 
   executor.spin_node_some(node);
   // spin up to 4 times with a 25 ms wait in between
-  for (unsigned long i = 0; i < 4 && counter == 0; ++i) {
+  for (uint32_t i = 0; i < 4 && counter == 0; ++i) {
     printf("callback not called, sleeping and trying again\n");
     std::this_thread::sleep_for(std::chrono::milliseconds(25));
     executor.spin_node_some(node);

--- a/test_rclcpp/test/test_timer.cpp
+++ b/test_rclcpp/test/test_timer.cpp
@@ -29,12 +29,12 @@
 TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_fire_regularly) {
   auto node = rclcpp::Node::make_shared("test_timer_fire_regularly");
 
-  unsigned long counter = 0;
+  uint32_t counter = 0;
   auto callback =
     [&counter]() -> void
     {
       ++counter;
-      printf("  callback() %lu\n", counter);
+      printf("  callback() %4u\n", counter);
     };
 
   rclcpp::executors::SingleThreadedExecutor executor;
@@ -83,12 +83,12 @@ TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_fire_regularly) {
 TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_during_wait) {
   auto node = rclcpp::Node::make_shared("test_timer_during_wait");
 
-  unsigned long counter = 0;
+  uint32_t counter = 0;
   auto callback =
     [&counter]() -> void
     {
       ++counter;
-      printf("  callback() %lu", counter);
+      printf("  callback() %4u", counter);
     };
 
   rclcpp::executors::SingleThreadedExecutor executor;


### PR DESCRIPTION
Use `uint32_t` instead of `unsigned long` to comply with `cpplint`

Connects to ament/ament_lint#34