### PR TITLE
fix flaky shared_ptr_const test cases

### DIFF
--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -74,6 +74,11 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
     // wait for the first callback
     printf("spin_node_once() - callback (1) expected\n");
     executor.spin_node_once(node);
+    size_t i = 0;
+    while (counter < 1 && i < 2) {
+      executor.spin_node_once(node, std::chrono::milliseconds(25));
+      printf("spin_node_once(blocking for 25 ms) - callback (2) expected - try %zu/2\n", ++i);
+    }
     ASSERT_EQ(1, counter);
 
     // nothing should be pending here
@@ -99,9 +104,8 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
     executor.spin_node_once(node, std::chrono::milliseconds(0));
     if (counter == 1) {
       // give the executor thread time to process the event
-      std::this_thread::sleep_for(std::chrono::milliseconds(25));
-      printf("spin_node_once(nonblocking) - callback (2) expected - trying again\n");
-      executor.spin_node_once(node, std::chrono::milliseconds(0));
+      printf("spin_node_once(blocking for 25 ms) - callback (2) expected - trying again\n");
+      executor.spin_node_once(node, std::chrono::milliseconds(25));
     }
     ASSERT_EQ(2, counter);
 
@@ -110,9 +114,8 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
     executor.spin_node_once(node, std::chrono::milliseconds(0));
     if (counter == 2) {
       // give the executor thread time to process the event
-      std::this_thread::sleep_for(std::chrono::milliseconds(25));
-      printf("spin_node_once(nonblocking) - callback (3) expected - trying again\n");
-      executor.spin_node_once(node, std::chrono::milliseconds(0));
+      printf("spin_node_once(blocking for 25 ms) - callback (3) expected - trying again\n");
+      executor.spin_node_once(node, std::chrono::milliseconds(25));
     }
     ASSERT_EQ(3, counter);
 
@@ -121,10 +124,9 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
     executor.spin_node_some(node);
     if (counter == 3 || counter == 4) {
       // give the executor thread time to process the event
-      std::this_thread::sleep_for(std::chrono::milliseconds(25));
       printf("spin_node_some() - callback (%s) expected - trying again\n",
         counter == 3 ? "4 and 5" : "5");
-      executor.spin_node_once(node, std::chrono::milliseconds(0));
+      executor.spin_node_once(node, std::chrono::milliseconds(25));
     }
     ASSERT_EQ(5, counter);
   }
@@ -168,6 +170,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   ASSERT_EQ(0, counter);
 
   // nothing should be pending here
+  printf("spin_node_some() - no callback expected\n");
   executor.spin_node_some(node);
   ASSERT_EQ(0, counter);
 
@@ -181,14 +184,16 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   printf("spin_node_some() - callback (1) expected\n");
 
   executor.spin_node_some(node);
-  // spin up to 4 times with a 25 ms wait in between
-  for (uint32_t i = 0; i < 4 && counter == 0; ++i) {
-    printf("callback not called, sleeping and trying again\n");
+  size_t i = 0;
+  while (counter < 1 && i < 4) {
     std::this_thread::sleep_for(std::chrono::milliseconds(25));
-    executor.spin_node_some(node);
+    executor.spin_node_once(node, std::chrono::milliseconds(0));
+    printf("spin_node_once(nonblocking) - callback (1) expected - try %zu/4\n", ++i);
   }
+
   ASSERT_EQ(1, counter);
 }
+
 // Shortened version of the test for the ConstSharedPtr with info callback signature
 TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_const_with_info) {
   auto node = rclcpp::Node::make_shared("test_subscription");
@@ -218,6 +223,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   ASSERT_EQ(0, counter);
 
   // nothing should be pending here
+  printf("spin_node_some() - no callback expected\n");
   executor.spin_node_some(node);
   ASSERT_EQ(0, counter);
 
@@ -228,12 +234,11 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   // wait for the first callback
   printf("spin_node_some() - callback (1) expected\n");
 
-  executor.spin_node_some(node);
-  // spin up to 4 times with a 25 ms wait in between
-  for (uint32_t i = 0; i < 4 && counter == 0; ++i) {
-    printf("callback not called, sleeping and trying again\n");
+  size_t i = 0;
+  while (counter < 1 && i < 4) {
     std::this_thread::sleep_for(std::chrono::milliseconds(25));
-    executor.spin_node_some(node);
+    executor.spin_node_once(node, std::chrono::milliseconds(0));
+    printf("spin_node_once(nonblocking) - callback (1) expected - try %zu/4\n", ++i);
   }
   ASSERT_EQ(1, counter);
 }

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -60,10 +60,10 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
     ASSERT_EQ(0, counter);
 
     // nothing should be pending here
-    printf("spin_node_once(nonblocking) - no callback expected\n");
+    // printf("spin_node_once(nonblocking) - no callback expected\n");
     executor.spin_node_once(node, std::chrono::milliseconds(0));
     ASSERT_EQ(0, counter);
-    printf("spin_node_some() - no callback expected\n");
+    // printf("spin_node_some() - no callback expected\n");
     executor.spin_node_some(node);
     ASSERT_EQ(0, counter);
 
@@ -72,20 +72,21 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
     ASSERT_EQ(0, counter);
 
     // wait for the first callback
-    printf("spin_node_once() - callback (1) expected\n");
+    // printf("spin_node_once() - callback (1) expected\n");
     executor.spin_node_once(node);
     size_t i = 0;
     while (counter < 1 && i < 2) {
       executor.spin_node_once(node, std::chrono::milliseconds(25));
-      printf("spin_node_once(blocking for 25 ms) - callback (2) expected - try %zu/2\n", ++i);
+      // printf("spin_node_once(blocking for 25 ms) - callback (2) expected - try %zu/2\n", ++i);
+      ++i;
     }
     ASSERT_EQ(1, counter);
 
     // nothing should be pending here
-    printf("spin_node_once(nonblocking) - no callback expected\n");
+    //printf("spin_node_once(nonblocking) - no callback expected\n");
     executor.spin_node_once(node, std::chrono::milliseconds(0));
     ASSERT_EQ(1, counter);
-    printf("spin_node_some() - no callback expected\n");
+    //printf("spin_node_some() - no callback expected\n");
     executor.spin_node_some(node);
     ASSERT_EQ(1, counter);
 
@@ -100,32 +101,32 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
     ASSERT_EQ(1, counter);
 
     // while four messages have been published one callback should be triggered here
-    printf("spin_node_once(nonblocking) - callback (2) expected\n");
+    //printf("spin_node_once(nonblocking) - callback (2) expected\n");
     executor.spin_node_once(node, std::chrono::milliseconds(0));
     if (counter == 1) {
       // give the executor thread time to process the event
-      printf("spin_node_once(blocking for 25 ms) - callback (2) expected - trying again\n");
+      //printf("spin_node_once(blocking for 25 ms) - callback (2) expected - trying again\n");
       executor.spin_node_once(node, std::chrono::milliseconds(25));
     }
     ASSERT_EQ(2, counter);
 
     // check for next pending call
-    printf("spin_node_once(nonblocking) - callback (3) expected\n");
+    //printf("spin_node_once(nonblocking) - callback (3) expected\n");
     executor.spin_node_once(node, std::chrono::milliseconds(0));
     if (counter == 2) {
       // give the executor thread time to process the event
-      printf("spin_node_once(blocking for 25 ms) - callback (3) expected - trying again\n");
+      //printf("spin_node_once(blocking for 25 ms) - callback (3) expected - trying again\n");
       executor.spin_node_once(node, std::chrono::milliseconds(25));
     }
     ASSERT_EQ(3, counter);
 
     // check for all remaning calls
-    printf("spin_node_some() - callbacks (4 and 5) expected\n");
+    //printf("spin_node_some() - callbacks (4 and 5) expected\n");
     executor.spin_node_some(node);
     if (counter == 3 || counter == 4) {
       // give the executor thread time to process the event
-      printf("spin_node_some() - callback (%s) expected - trying again\n",
-        counter == 3 ? "4 and 5" : "5");
+      /*printf("spin_node_some() - callback (%s) expected - trying again\n",
+        counter == 3 ? "4 and 5" : "5");*/
       executor.spin_node_once(node, std::chrono::milliseconds(25));
     }
     ASSERT_EQ(5, counter);
@@ -138,7 +139,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
   std::this_thread::sleep_for(std::chrono::milliseconds(25));
 
   // check that no further callbacks have been invoked
-  printf("spin_node_some() - no callbacks expected\n");
+  //printf("spin_node_some() - no callbacks expected\n");
   executor.spin_node_some(node);
   ASSERT_EQ(5, counter);
 }
@@ -170,8 +171,10 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   ASSERT_EQ(0, counter);
 
   // nothing should be pending here
-  printf("spin_node_some() - no callback expected\n");
+  //printf("spin_node_some() - no callback expected\n");
   executor.spin_node_some(node);
+  ASSERT_EQ(0, counter);
+  executor.spin_node_once(node, std::chrono::milliseconds(0));
   ASSERT_EQ(0, counter);
 
   msg->data = 1;
@@ -181,14 +184,16 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   ASSERT_EQ(0, counter);
 
   // wait for the first callback
-  printf("spin_node_some() - callback (1) expected\n");
-
+  //printf("spin_node_some() - callback (1) expected\n");
   executor.spin_node_some(node);
+
   size_t i = 0;
-  while (counter < 1 && i < 4) {
+  //while (counter < 1 && i < 4) {
+  while (counter < 1 && i < 2) {
     std::this_thread::sleep_for(std::chrono::milliseconds(25));
     executor.spin_node_once(node, std::chrono::milliseconds(0));
-    printf("spin_node_once(nonblocking) - callback (1) expected - try %zu/4\n", ++i);
+    //printf("spin_node_once(nonblocking) - callback (1) expected - try %zu/4\n", ++i);
+    ++i;
   }
 
   ASSERT_EQ(1, counter);
@@ -223,8 +228,10 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   ASSERT_EQ(0, counter);
 
   // nothing should be pending here
-  printf("spin_node_some() - no callback expected\n");
+  //printf("spin_node_some() - no callback expected\n");
   executor.spin_node_some(node);
+  ASSERT_EQ(0, counter);
+  executor.spin_node_once(node, std::chrono::milliseconds(0));
   ASSERT_EQ(0, counter);
 
   msg->data = 1;
@@ -232,13 +239,16 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   ASSERT_EQ(0, counter);
 
   // wait for the first callback
-  printf("spin_node_some() - callback (1) expected\n");
+  //printf("spin_node_some() - callback (1) expected\n");
+  executor.spin_node_some(node);
 
   size_t i = 0;
-  while (counter < 1 && i < 4) {
+  //while (counter < 1 && i < 4) {
+  while (counter < 1 && i < 2) {
     std::this_thread::sleep_for(std::chrono::milliseconds(25));
     executor.spin_node_once(node, std::chrono::milliseconds(0));
-    printf("spin_node_once(nonblocking) - callback (1) expected - try %zu/4\n", ++i);
+    //printf("spin_node_once(nonblocking) - callback (1) expected - try %zu/4\n", ++i);
+    ++i;
   }
   ASSERT_EQ(1, counter);
 }


### PR DESCRIPTION
The `shared_ptr_const*` test cases of `test_subscription` fail intermittently on OSX and almost always fail in the nightly jobs:

http://ci.ros2.org/view/nightly/job/ros2_batch_ci_osx_nightly/101/testReport/junit/%28root%29/test_subscription__rmw_connext_dynamic_cpp/subscription_shared_ptr_const_with_info/
http://ci.ros2.org/view/nightly/job/ros2_batch_ci_osx_nightly/100/testReport/%28root%29/test_subscription__rmw_connext_cpp/subscription_shared_ptr_const_with_info/
http://ci.ros2.org/view/nightly/job/ros2_batch_ci_osx_nightly/99/testReport/junit/%28root%29/test_subscription__rmw_connext_dynamic_cpp/subscription_shared_ptr_const/

I take responsibility for this as the author of these tests--I think the problem is that I don't sleep after intitializing rclcpp entities and before spinning.

I also changed the subscription_and_spinning test to use `spin_once` with a timeout in several cases, instead of blocking and then calling spin_once without a timeout. This is more likely to give successful results and may be marginally faster, because spin_once will block asynchronously until the middleware is ready.

I started a job using `repeat-until-fail 20` and a regex to run only `test_subscription`:

http://ci.ros2.org/job/ros2_batch_ci_osx/440/