### PR TITLE
change namespace of FutureReturnCode

### DIFF
--- a/test_rclcpp/test/test_spin.cpp
+++ b/test_rclcpp/test/test_spin.cpp
@@ -43,8 +43,10 @@ TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete) {
     };
   auto timer = node->create_wall_timer(std::chrono::milliseconds(25), callback);
 
-  ASSERT_EQ(rclcpp::spin_until_future_complete(node, future),
-    rclcpp::executors::FutureReturnCode::SUCCESS);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  ASSERT_EQ(executor.spin_until_future_complete(future),
+    rclcpp::executor::FutureReturnCode::SUCCESS);
   EXPECT_EQ(future.get(), true);
 }
 
@@ -66,11 +68,11 @@ TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete_timeou
   auto timer = node->create_wall_timer(std::chrono::milliseconds(50), callback);
 
   ASSERT_EQ(rclcpp::spin_until_future_complete(node, future, std::chrono::milliseconds(25)),
-    rclcpp::executors::FutureReturnCode::TIMEOUT);
+    rclcpp::executor::FutureReturnCode::TIMEOUT);
 
   // If we wait a little longer, we should complete the future
   ASSERT_EQ(rclcpp::spin_until_future_complete(node, future, std::chrono::milliseconds(50)),
-    rclcpp::executors::FutureReturnCode::SUCCESS);
+    rclcpp::executor::FutureReturnCode::SUCCESS);
 
   EXPECT_EQ(future.get(), true);
 }
@@ -99,7 +101,7 @@ TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete_interr
   auto shutdown_timer = node->create_wall_timer(std::chrono::milliseconds(25), shutdown_callback);
 
   ASSERT_EQ(rclcpp::spin_until_future_complete(node, future, std::chrono::milliseconds(50)),
-    rclcpp::executors::FutureReturnCode::INTERRUPTED);
+    rclcpp::executor::FutureReturnCode::INTERRUPTED);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Connects to ros2/rclcpp#149

Change namespace for refactoring and change one test case to invoke `Executor::spin_until_future_complete`.