### PR TITLE
Reverse ignore logic in allocator test

### DIFF
--- a/test_rclcpp/test/test_allocator.cpp
+++ b/test_rclcpp/test/test_allocator.cpp
@@ -422,7 +422,7 @@ int main(int argc, char ** argv)
     return 0;
   }
   verbose = std::find(args.begin(), args.end(), "--verbose") != args.end();
-  ignore_middleware_tokens = std::find(args.begin(), args.end(), "--all-tokens") != args.end();
+  ignore_middleware_tokens = std::find(args.begin(), args.end(), "--all-tokens") == args.end();
 
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
ignore_middleware_tokens is the boolean in the allocator logic that causes the test to ignore allocations that originate in the DDS implementation.

--all-tokens is the command line argument flag that causes the test NOT to ignore middleware tokens.

This PR corrects the logic of the test to be consistent with this design.