### PR TITLE
Added and increased waiting time in several rclcpp tests

### DIFF
--- a/test_rclcpp/test/test_allocator.cpp
+++ b/test_rclcpp/test/test_allocator.cpp
@@ -37,8 +37,8 @@
 #endif  // not WIN32
 
 // TODO(jacquelinekay) improve this ignore rule (dogfooding or no allocations)
-static const size_t num_rmw_tokens = 5;
-static const char * rmw_tokens[num_rmw_tokens] = {"librmw", "dds", "DDS", "dcps", "DCPS"};
+static const size_t num_rmw_tokens = 6;
+static const char * rmw_tokens[num_rmw_tokens] = {"librmw", "dds", "DDS", "dcps", "DCPS", "fastrtps"};
 
 static const size_t iterations = 1;
 

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -65,6 +65,11 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous) {
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+
+  // wait a moment for everything to initialize
+  // TODO(richiprosima): fix nondeterministic startup behavior
+  rclcpp::utilities::sleep_for(40_ms);
+
   set_test_parameters(parameters_client);
   verify_test_parameters(parameters_client);
 }
@@ -74,6 +79,11 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_asynchronous) {
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
+
+  // wait a moment for everything to initialize
+  // TODO(richiprosima): fix nondeterministic startup behavior
+  rclcpp::utilities::sleep_for(40_ms);
+
   verify_set_parameters_async(node, parameters_client);
   verify_get_parameters_async(node, parameters_client);
 }

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -77,6 +77,8 @@ static inline void multi_consumer_pub_sub_test(bool intra_process)
   ++msg->data;
   pub->publish(msg);
 
+  rclcpp::utilities::sleep_for(subscriptions.size() * 5_ms);
+
   // test spin_some
   // Expectation: The message was published and all subscriptions fired the callback.
   // Use spin_once to block until published message triggers an event
@@ -98,7 +100,7 @@ static inline void multi_consumer_pub_sub_test(bool intra_process)
         timer.cancel();
         // wait for the last callback to fire before cancelling
         // Wait for pending subscription callbacks to trigger.
-        std::this_thread::sleep_for(std::chrono::milliseconds(executor.get_number_of_threads()));
+        std::this_thread::sleep_for(std::chrono::milliseconds(10 * executor.get_number_of_threads()));
         executor.cancel();
         return;
       }
@@ -249,7 +251,7 @@ static inline void multi_access_publisher(bool intra_process)
         while (subscription_counter < timer_counter &&
           ++i <= executor.get_number_of_threads() * 2)
         {
-          rclcpp::utilities::sleep_for(1_ms);
+          rclcpp::utilities::sleep_for(20_ms);
         }
         executor.cancel();
         return;

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -100,7 +100,7 @@ static inline void multi_consumer_pub_sub_test(bool intra_process)
         timer.cancel();
         // wait for the last callback to fire before cancelling
         // Wait for pending subscription callbacks to trigger.
-        std::this_thread::sleep_for(std::chrono::milliseconds(10 * executor.get_number_of_threads()));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20 * executor.get_number_of_threads()));
         executor.cancel();
         return;
       }
@@ -233,11 +233,25 @@ static inline void multi_access_publisher(bool intra_process)
   rclcpp::executors::MultiThreadedExecutor executor;
 
   auto pub = node->create_publisher<test_rclcpp::msg::UInt32>(node_topic_name);
+
+  std::atomic_uint subscription_counter(0);
+  auto sub_callback = [&subscription_counter](const test_rclcpp::msg::UInt32::SharedPtr)
+    {
+      ++subscription_counter;
+      printf("Subscription callback %u\n", subscription_counter.load());
+    };
+  auto sub = node->create_subscription<test_rclcpp::msg::UInt32>(node_topic_name, sub_callback,
+      rmw_qos_profile_default,
+      sub_callback_group);
+
+  // wait a moment for everything to initialize
+  // TODO(richiprosima): fix nondeterministic startup behavior
+  rclcpp::utilities::sleep_for(10_ms);
+
   // callback groups?
   auto msg = std::make_shared<test_rclcpp::msg::UInt32>();
   // use atomic
   std::atomic_uint timer_counter(0);
-  std::atomic_uint subscription_counter(0);
 
   const size_t iterations = 5 * executor.get_number_of_threads();
   auto timer_callback =
@@ -251,7 +265,7 @@ static inline void multi_access_publisher(bool intra_process)
         while (subscription_counter < timer_counter &&
           ++i <= executor.get_number_of_threads() * 2)
         {
-          rclcpp::utilities::sleep_for(20_ms);
+          rclcpp::utilities::sleep_for(40_ms);
         }
         executor.cancel();
         return;
@@ -266,14 +280,6 @@ static inline void multi_access_publisher(bool intra_process)
     timers.push_back(node->create_wall_timer(std::chrono::milliseconds(1), timer_callback));
   }
 
-  auto sub_callback = [&subscription_counter](const test_rclcpp::msg::UInt32::SharedPtr)
-    {
-      ++subscription_counter;
-      printf("Subscription callback %u\n", subscription_counter.load());
-    };
-  auto sub = node->create_subscription<test_rclcpp::msg::UInt32>(node_topic_name, sub_callback,
-      rmw_qos_profile_default,
-      sub_callback_group);
   executor.add_node(node);
   executor.spin();
   ASSERT_EQ(timer_counter.load(), iterations);

--- a/test_rclcpp/test/test_remote_parameters.cpp
+++ b/test_rclcpp/test/test_remote_parameters.cpp
@@ -33,6 +33,10 @@ TEST(parameters, test_remote_parameters) {
   auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node,
       test_server_name);
 
+  // wait a moment for everything to initialize
+  // TODO(richiprosima): fix nondeterministic startup behavior
+  rclcpp::utilities::sleep_for(100_ms);
+
   verify_set_parameters_async(node, parameters_client);
 
   verify_get_parameters_async(node, parameters_client);

--- a/test_rclcpp/test/test_services_client.cpp
+++ b/test_rclcpp/test/test_services_client.cpp
@@ -31,7 +31,7 @@ TEST(test_services_client, test_add_noreqid) {
 
   // wait a moment for everything to initialize
   // TODO(richiprosima): fix nondeterministic startup behavior
-  rclcpp::utilities::sleep_for(1_ms);
+  rclcpp::utilities::sleep_for(5_ms);
 
 
   auto result = client->async_send_request(request);
@@ -51,7 +51,7 @@ TEST(test_services_client, test_add_reqid) {
 
   // wait a moment for everything to initialize
   // TODO(richiprosima): fix nondeterministic startup behavior
-  rclcpp::utilities::sleep_for(1_ms);
+  rclcpp::utilities::sleep_for(5_ms);
 
   auto result = client->async_send_request(request);
 
@@ -67,6 +67,10 @@ TEST(test_services_client, test_return_request) {
   auto request = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
   request->a = 4;
   request->b = 5;
+
+  // wait a moment for everything to initialize
+  // TODO(richiprosima): fix nondeterministic startup behavior
+  rclcpp::utilities::sleep_for(5_ms);
 
   auto result = client->async_send_request(
     request,

--- a/test_rclcpp/test/test_services_client.cpp
+++ b/test_rclcpp/test/test_services_client.cpp
@@ -29,6 +29,11 @@ TEST(test_services_client, test_add_noreqid) {
   request->a = 1;
   request->b = 2;
 
+  // wait a moment for everything to initialize
+  // TODO(richiprosima): fix nondeterministic startup behavior
+  rclcpp::utilities::sleep_for(1_ms);
+
+
   auto result = client->async_send_request(request);
 
   rclcpp::spin_until_future_complete(node, result);  // Wait for the result.
@@ -43,6 +48,10 @@ TEST(test_services_client, test_add_reqid) {
   auto request = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
   request->a = 4;
   request->b = 5;
+
+  // wait a moment for everything to initialize
+  // TODO(richiprosima): fix nondeterministic startup behavior
+  rclcpp::utilities::sleep_for(1_ms);
 
   auto result = client->async_send_request(request);
 

--- a/test_rclcpp/test/test_services_client.cpp
+++ b/test_rclcpp/test/test_services_client.cpp
@@ -31,7 +31,7 @@ TEST(test_services_client, test_add_noreqid) {
 
   // wait a moment for everything to initialize
   // TODO(richiprosima): fix nondeterministic startup behavior
-  rclcpp::utilities::sleep_for(5_ms);
+  rclcpp::utilities::sleep_for(20_ms);
 
 
   auto result = client->async_send_request(request);
@@ -51,7 +51,7 @@ TEST(test_services_client, test_add_reqid) {
 
   // wait a moment for everything to initialize
   // TODO(richiprosima): fix nondeterministic startup behavior
-  rclcpp::utilities::sleep_for(5_ms);
+  rclcpp::utilities::sleep_for(20_ms);
 
   auto result = client->async_send_request(request);
 
@@ -70,7 +70,7 @@ TEST(test_services_client, test_return_request) {
 
   // wait a moment for everything to initialize
   // TODO(richiprosima): fix nondeterministic startup behavior
-  rclcpp::utilities::sleep_for(5_ms);
+  rclcpp::utilities::sleep_for(20_ms);
 
   auto result = client->async_send_request(
     request,

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -124,7 +124,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
       std::this_thread::sleep_for(std::chrono::milliseconds(25));
       printf("spin_node_some() - callback (%s) expected - trying again\n",
         counter == 3 ? "4 and 5" : "5");
-      executor.spin_node_once(node, std::chrono::milliseconds(0));
+      executor.spin_node_some(node);
     }
     ASSERT_EQ(5, counter);
   }


### PR DESCRIPTION
In order to solve http://ci.ros2.org/job/ci_linux/658/ we had to make some changes in several rclcpp tests. These changes are:
* test_allocator.cpp: Added new ```fastrtps``` token.
* test_multithreaded.cpp: Increased several sleeping times after publishing data, because executor is canceled before receiving all data.
* test_services_client.cpp: Added sleeping time after creating each client. It gives time to finish the discovery phase.
* test_subscriptions.cpp: Changed call ```spin_node_once``` for ```spin_node_some```. If sample 4 and 5 don't arrive in first try, in the second try only sample 4 is taken.