### PR TITLE
Increase timeout on subscription test

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -114,7 +114,7 @@ if(AMENT_ENABLE_TESTING)
       TIMEOUT 30)
     custom_gtest(gtest_subscription
       "test/test_subscription.cpp"
-      TIMEOUT 15)
+      TIMEOUT 30)
     custom_gtest(gtest_multiple_service_calls
       "test/test_multiple_service_calls.cpp"
       TIMEOUT 15)


### PR DESCRIPTION
This change is intended to fix 4 of the 6 failures (the ones not mentioning "pendulum" in the name) listed here:

http://ci.ros2.org/view/nightly/job/nightly_linux/130/testReport/

Rationale: With the new tests added in #88, the Connext flavors of this test executable are now taking longer to run. Here's timing info from my Linux machine, running the executables directly:

~~~
$ time ./build/test_rclcpp/gtest_subscription__rmw_opensplice_cpp
real    0m1.270s

$ time ./build/test_rclcpp/gtest_subscription__rmw_connext_cpp
real    0m20.203s

$ time ./build/test_rclcpp/gtest_subscription__rmw_connext_dynamic_cpp
real    0m20.201s
~~~

Given that the Connext versions are taking about 20s, it's no wonder that they failed with a timeout of 15s. I'm doubling the timeout to 30s to have some margin.

I ran the full `test_rclcpp` test suite on my local machine, verifying that without this change I get the same timeout failures that Jenkins saw and that with this change I get no failures. Given the obvious and low-risk nature of the change, I don't intend to run CI jobs.

Another question is whether it's possible to shorten the time required by Connext to be closer to that of OpenSplice, but that's out of scope for this test.