### PR TITLE
Try to fix flaky services test by partitioning topic names

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -72,6 +72,8 @@ if(AMENT_ENABLE_TESTING)
     get_rmw_typesupport(typesupport_impl "${rmw_implementation}")
 
     add_executable(${target}${target_suffix} ${ARGN})
+    target_compile_definitions(${target}${target_suffix}
+      PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
     add_dependencies(${target}${target_suffix} ${PROJECT_NAME})
     rosidl_target_interfaces(${target}${target_suffix}
       ${PROJECT_NAME} ${typesupport_impl})

--- a/test_rclcpp/test/test_services_client.cpp
+++ b/test_rclcpp/test/test_services_client.cpp
@@ -21,7 +21,14 @@
 
 #include "test_rclcpp/srv/add_two_ints.hpp"
 
-TEST(test_services_client, test_add_noreqid) {
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_noreqid) {
   auto node = rclcpp::Node::make_shared("test_services_client_no_reqid");
 
   auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("add_two_ints_noreqid");
@@ -36,7 +43,7 @@ TEST(test_services_client, test_add_noreqid) {
   EXPECT_EQ(3, result.get()->sum);
 }
 
-TEST(test_services_client, test_add_reqid) {
+TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_reqid) {
   auto node = rclcpp::Node::make_shared("test_services_client_add_reqid");
 
   auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("add_two_ints_reqid");
@@ -51,7 +58,7 @@ TEST(test_services_client, test_add_reqid) {
   EXPECT_EQ(9, result.get()->sum);
 }
 
-TEST(test_services_client, test_return_request) {
+TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_return_request) {
   auto node = rclcpp::Node::make_shared("test_services_client_return_request");
 
   auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("add_two_ints_reqid_return_request");

--- a/test_rclcpp/test/test_services_client.cpp
+++ b/test_rclcpp/test/test_services_client.cpp
@@ -22,7 +22,7 @@
 #include "test_rclcpp/srv/add_two_ints.hpp"
 
 TEST(test_services_client, test_add_noreqid) {
-  auto node = rclcpp::Node::make_shared("test_services_client");
+  auto node = rclcpp::Node::make_shared("test_services_client_no_reqid");
 
   auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("add_two_ints_noreqid");
   auto request = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
@@ -37,7 +37,7 @@ TEST(test_services_client, test_add_noreqid) {
 }
 
 TEST(test_services_client, test_add_reqid) {
-  auto node = rclcpp::Node::make_shared("test_services_client");
+  auto node = rclcpp::Node::make_shared("test_services_client_add_reqid");
 
   auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("add_two_ints_reqid");
   auto request = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
@@ -52,9 +52,9 @@ TEST(test_services_client, test_add_reqid) {
 }
 
 TEST(test_services_client, test_return_request) {
-  auto node = rclcpp::Node::make_shared("test_services_client");
+  auto node = rclcpp::Node::make_shared("test_services_client_return_request");
 
-  auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("add_two_ints_reqid");
+  auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("add_two_ints_reqid_return_request");
   auto request = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
   request->a = 4;
   request->b = 5;

--- a/test_rclcpp/test/test_services_server.cpp
+++ b/test_rclcpp/test/test_services_server.cpp
@@ -44,6 +44,9 @@ int main(int argc, char ** argv)
   node->create_service<test_rclcpp::srv::AddTwoInts>(
     "add_two_ints_reqid", handle_add_two_ints_reqid);
 
+  node->create_service<test_rclcpp::srv::AddTwoInts>(
+    "add_two_ints_reqid_return_request", handle_add_two_ints_reqid);
+
   rclcpp::spin(node);
 
   return 0;


### PR DESCRIPTION
Fixes #93

I think there was a problem with crosstalk in DDS entities that weren't finished tearing down. I've separated all nodes and service names for the different cases.

The test is turning over reliably on my machine (has been for over 20 minutes). I'll start a repeat-until-fail job with this test on OSX, since that's the platform where it failed in the nightly job.