### PR TITLE
changed how the subscription_and_spinning test works

### DIFF
--- a/test_rclcpp/test/test_spin.cpp
+++ b/test_rclcpp/test/test_spin.cpp
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include <chrono>
+#include <future>
 #include <iostream>
+#include <thread>
 
 #include "gtest/gtest.h"
 
@@ -27,6 +29,86 @@
 #else
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
+
+/*
+   Ensures that the timeout behavior of spin_until_future_complete is correct.
+ */
+TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), test_spin_until_future_complete_timeout) {
+  using rclcpp::executor::FutureReturnCode;
+  rclcpp::executors::SingleThreadedExecutor executor;
+
+  // Try passing an already complete future, it should succeed.
+  {
+    std::promise<void> already_set_promise;
+    std::shared_future<void> already_complete_future = already_set_promise.get_future();
+    already_set_promise.set_value();
+    auto ret = executor.spin_until_future_complete(already_complete_future, 1_s);
+    EXPECT_EQ(FutureReturnCode::SUCCESS, ret);
+    // Also try blocking with no timeout (default timeout of -1).
+    ret = executor.spin_until_future_complete(already_complete_future);
+    EXPECT_EQ(FutureReturnCode::SUCCESS, ret);
+  }
+
+  // Try to trigger the timeout by passing a never completed future.
+  {
+    std::promise<void> never_set_promise;
+    std::shared_future<void> never_complete_future = never_set_promise.get_future();
+    // Set the timeout just long enough to make sure it isn't incorrectly set.
+    auto ret = executor.spin_until_future_complete(never_complete_future, 50_ms);
+    EXPECT_EQ(FutureReturnCode::TIMEOUT, ret);
+    // Also try with zero timeout.
+    ret = executor.spin_until_future_complete(never_complete_future, 0_s);
+    EXPECT_EQ(FutureReturnCode::TIMEOUT, ret);
+  }
+
+  // Try to complete the future asynchronously, but not from within spinning.
+  {
+    std::shared_future<void> async_future = std::async(std::launch::async, []() {
+      std::this_thread::sleep_for(50_ms);
+    });
+    auto ret = executor.spin_until_future_complete(async_future, 100_ms);
+    EXPECT_EQ(FutureReturnCode::SUCCESS, ret);
+  }
+
+  auto node = rclcpp::Node::make_shared("test_spin");
+  executor.add_node(node);
+  // Try trigger a timeout while spinning events are being handled.
+  {
+    std::promise<void> never_set_promise;
+    auto timer = node->create_wall_timer(7_ms, []() {
+      // Do nothing.
+    });
+    auto timer2 = node->create_wall_timer(50_ms, []() {
+      // Do nothing.
+    });
+    std::shared_future<void> never_completed_future = never_set_promise.get_future();
+    // Try with a timeout long enough for both timers to fire at least once.
+    auto ret = executor.spin_until_future_complete(never_completed_future, 75_ms);
+    EXPECT_EQ(FutureReturnCode::TIMEOUT, ret);
+    // Also try with a timeout of zero (nonblocking).
+    ret = executor.spin_until_future_complete(never_completed_future, 0_s);
+    EXPECT_EQ(FutureReturnCode::TIMEOUT, ret);
+  }
+
+  // Try to complete a future from within a spinning callback, in the presence of other events.
+  {
+    std::promise<void> timer_fired_promise;
+    auto timer = node->create_wall_timer(50_ms, [&timer_fired_promise]() {
+      timer_fired_promise.set_value();
+    });
+    auto timer2 = node->create_wall_timer(1_ms, []() {
+      // Do nothing.
+    });
+    std::shared_future<void> timer_fired_future = timer_fired_promise.get_future();
+    auto ret = executor.spin_until_future_complete(timer_fired_future, 100_ms);
+    EXPECT_EQ(FutureReturnCode::SUCCESS, ret);
+    // Also try again with blocking spin_until_future_complete.
+    timer_fired_promise = std::promise<void>();
+    timer_fired_future = timer_fired_promise.get_future();
+    ret = executor.spin_until_future_complete(timer_fired_future);
+    EXPECT_EQ(FutureReturnCode::SUCCESS, ret);
+  }
+}
 
 TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete) {
   auto node = rclcpp::Node::make_shared("test_spin");


### PR DESCRIPTION
So I've attempted to make this test less flaky. What I did was use a `std::shared_future` and `std::promise` so that I could have the executor spin until the predicate was fulfilled. The predicate was that the subscription's callback was called. So I replaced the use of `spin_once` with `spin_until_future_complete`.