### PR TITLE
fix comparison warnings within uses of gtest macros

### DIFF
--- a/test_rclcpp/test/test_intra_process.cpp
+++ b/test_rclcpp/test/test_intra_process.cpp
@@ -36,7 +36,7 @@ TEST(test_intra_process_within_one_node, nominal_usage) {
   auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>(
     "test_intra_process", custom_qos_profile);
 
-  uint32_t counter = 0;
+  int counter = 0;
   auto callback =
     [&counter](
     const test_rclcpp::msg::UInt32::SharedPtr msg,
@@ -44,8 +44,9 @@ TEST(test_intra_process_within_one_node, nominal_usage) {
     ) -> void
     {
       ++counter;
-      printf("  callback() %4u with message data %u\n", counter, msg->data);
-      ASSERT_EQ(counter, msg->data);
+      printf("  callback() %d with message data %u\n", counter, msg->data);
+      ASSERT_GE(counter, 0);
+      ASSERT_EQ(static_cast<unsigned int>(counter), msg->data);
       ASSERT_TRUE(message_info.from_intra_process);
     };
 

--- a/test_rclcpp/test/test_publisher.cpp
+++ b/test_rclcpp/test/test_publisher.cpp
@@ -34,14 +34,15 @@ TEST(CLASSNAME(test_publisher, RMW_IMPLEMENTATION), publish_with_const_reference
 
   auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>("test_publisher", 10);
 
-  uint32_t counter = 0;
+  int counter = 0;
   auto callback =
     [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg,
       const rmw_message_info_t & info) -> void
     {
       ++counter;
-      printf("  callback() %4u with message data %u\n", counter, msg->data);
-      ASSERT_EQ(counter, msg->data);
+      printf("  callback() %d with message data %u\n", counter, msg->data);
+      ASSERT_GE(0, counter);
+      ASSERT_EQ(static_cast<unsigned int>(counter), msg->data);
       ASSERT_FALSE(info.from_intra_process);
     };
 

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <chrono>
+#include <future>
 #include <iostream>
 #include <string>
 
@@ -60,6 +61,9 @@ void busy_wait_for_subscriber(
     std::this_thread::sleep_for(sleep_period);
     time_slept += sleep_period;
   }
+  printf("Waited %lli microseconds for the subscriber to connect to topic '%s'\n",
+    std::chrono::duration_cast<std::chrono::microseconds>(time_slept).count(),
+    topic_name.c_str());
 }
 
 template<typename DurationT>
@@ -208,13 +212,14 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>(
     "test_subscription", rmw_qos_profile_default);
 
-  uint32_t counter = 0;
+  int counter = 0;
   auto callback =
     [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg) -> void
     {
       ++counter;
-      printf("  callback() %4u with message data %u\n", counter, msg->data);
-      ASSERT_EQ(counter, msg->data);
+      printf("  callback() %d with message data %u\n", counter, msg->data);
+      ASSERT_TRUE(counter >= 0);
+      ASSERT_EQ(static_cast<unsigned int>(counter), msg->data);
     };
 
   auto msg = std::make_shared<test_rclcpp::msg::UInt32>();
@@ -257,11 +262,12 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
 class CallbackHolder
 {
 public:
-  uint32_t counter;
+  int counter;
   void callback(test_rclcpp::msg::UInt32::ConstSharedPtr msg)
   {
     ++counter;
-    ASSERT_EQ(counter, msg->data);
+    ASSERT_TRUE(counter >= 0);
+    ASSERT_EQ(static_cast<unsigned int>(counter), msg->data);
   }
   CallbackHolder()
   : counter(0)
@@ -374,14 +380,15 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
   auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>(
     "test_subscription", rmw_qos_profile_default);
 
-  uint32_t counter = 0;
+  int counter = 0;
   auto callback =
     [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg,
       const rmw_message_info_t & info) -> void
     {
       ++counter;
-      printf("  callback() %4u with message data %u\n", counter, msg->data);
-      ASSERT_EQ(counter, msg->data);
+      printf("  callback() %d with message data %u\n", counter, msg->data);
+      ASSERT_TRUE(counter >= 0);
+      ASSERT_EQ(static_cast<unsigned int>(counter), msg->data);
       ASSERT_FALSE(info.from_intra_process);
     };
 
@@ -427,13 +434,14 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), spin_before_subscription)
   auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>(
     "spin_before_subscription", rmw_qos_profile_default);
 
-  uint32_t counter = 0;
+  int counter = 0;
   auto callback =
     [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg) -> void
     {
       ++counter;
-      printf("  callback() %4u with message data %u\n", counter, msg->data);
-      ASSERT_EQ(counter, msg->data);
+      printf("  callback() %d with message data %u\n", counter, msg->data);
+      ASSERT_TRUE(counter >= 0);
+      ASSERT_EQ(static_cast<unsigned int>(counter), msg->data);
     };
 
   auto msg = std::make_shared<test_rclcpp::msg::UInt32>();

--- a/test_rclcpp/test/test_timer.cpp
+++ b/test_rclcpp/test/test_timer.cpp
@@ -29,12 +29,12 @@
 TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_fire_regularly) {
   auto node = rclcpp::Node::make_shared("test_timer_fire_regularly");
 
-  uint32_t counter = 0;
+  int counter = 0;
   auto callback =
     [&counter]() -> void
     {
       ++counter;
-      printf("  callback() %4u\n", counter);
+      printf("  callback() %d\n", counter);
     };
 
   rclcpp::executors::SingleThreadedExecutor executor;
@@ -83,12 +83,12 @@ TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_fire_regularly) {
 TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_during_wait) {
   auto node = rclcpp::Node::make_shared("test_timer_during_wait");
 
-  uint32_t counter = 0;
+  int counter = 0;
   auto callback =
     [&counter]() -> void
     {
       ++counter;
-      printf("  callback() %4u", counter);
+      printf("  callback() %d", counter);
     };
 
   rclcpp::executors::SingleThreadedExecutor executor;
@@ -135,12 +135,12 @@ TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_during_wait) {
 TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), finite_timer) {
   auto node = rclcpp::Node::make_shared("finite_timer");
 
-  uint32_t counter = 0;
+  int counter = 0;
   auto callback =
     [&counter](rclcpp::timer::TimerBase & timer) -> void
     {
       ++counter;
-      printf("  callback() %4u\n", counter);
+      printf("  callback() %d\n", counter);
       // After spinning 3 times, cancel the timer
       if (counter == 2) {
         timer.cancel();


### PR DESCRIPTION
There were a lot of warnings when building the `test_rclcpp` package with `RelWithDebInfo` on OS X. Most are comparison between signed/unsigned numbers via (within) gtest macros.