### PR TITLE
fix the order of the assert_ge check in test_publisher

### DIFF
--- a/test_rclcpp/test/test_publisher.cpp
+++ b/test_rclcpp/test/test_publisher.cpp
@@ -41,7 +41,7 @@ TEST(CLASSNAME(test_publisher, RMW_IMPLEMENTATION), publish_with_const_reference
     {
       ++counter;
       printf("  callback() %d with message data %u\n", counter, msg->data);
-      ASSERT_GE(0, counter);
+      ASSERT_GE(counter, 0);
       ASSERT_EQ(static_cast<unsigned int>(counter), msg->data);
       ASSERT_FALSE(info.from_intra_process);
     };

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <chrono>
+#include <cinttypes>
 #include <future>
 #include <iostream>
 #include <string>
@@ -61,8 +62,10 @@ void busy_wait_for_subscriber(
     std::this_thread::sleep_for(sleep_period);
     time_slept += sleep_period;
   }
-  printf("Waited %lli microseconds for the subscriber to connect to topic '%s'\n",
-    std::chrono::duration_cast<std::chrono::microseconds>(time_slept).count(),
+  int64_t time_slept_count =
+    std::chrono::duration_cast<std::chrono::microseconds>(time_slept).count();
+  printf("Waited %" PRId64 " microseconds for the subscriber to connect to topic '%s'\n",
+    time_slept_count,
     topic_name.c_str());
 }
 


### PR DESCRIPTION
Looks like I got the order wrong on an `ASSERT_GE` when addressing the cpplint warnings. See: https://github.com/ros2/system_tests/pull/109#issuecomment-195020801