### PR TITLE
Use rcl

### DIFF
--- a/test_communication/test/test_subscription_valid_data.cpp
+++ b/test_communication/test/test_subscription_valid_data.cpp
@@ -20,8 +20,9 @@
 
 #include "test_communication/msg/u_int32.hpp"
 
-int main(int, char **)
+int main(int argv, char ** argv)
 {
+  rclcpp::init(argc, argv);
   auto start = std::chrono::steady_clock::now();
 
   auto node = rclcpp::Node::make_shared("test_subscription_valid_data");

--- a/test_communication/test/test_subscription_valid_data.cpp
+++ b/test_communication/test/test_subscription_valid_data.cpp
@@ -20,7 +20,7 @@
 
 #include "test_communication/msg/u_int32.hpp"
 
-int main(int argv, char ** argv)
+int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   auto start = std::chrono::steady_clock::now();

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -102,7 +102,7 @@ if(AMENT_ENABLE_TESTING)
       TIMEOUT 15)
     custom_gtest(gtest_executor
       "test/test_executor.cpp"
-      TIMEOUT 20)
+      TIMEOUT 30)
     custom_gtest(gtest_repeated_publisher_subscriber
       "test/test_repeated_publisher_subscriber.cpp"
       TIMEOUT 15)

--- a/test_rclcpp/test/test_multiple_service_calls.cpp
+++ b/test_rclcpp/test/test_multiple_service_calls.cpp
@@ -37,8 +37,6 @@ void handle_add_two_ints(
 }
 
 TEST(CLASSNAME(test_two_service_calls, RMW_IMPLEMENTATION), two_service_calls) {
-  rclcpp::init(0, nullptr);
-
   auto node = rclcpp::Node::make_shared("test_two_service_calls");
 
   node->create_service<test_rclcpp::srv::AddTwoInts>(
@@ -77,8 +75,6 @@ TEST(CLASSNAME(test_two_service_calls, RMW_IMPLEMENTATION), two_service_calls) {
 
 TEST(CLASSNAME(test_multiple_service_calls, RMW_IMPLEMENTATION), multiple_clients) {
   const uint32_t n = 5;
-
-  rclcpp::init(0, nullptr);
 
   auto node = rclcpp::Node::make_shared("test_multiple_clients");
   rclcpp::executors::SingleThreadedExecutor executor;
@@ -131,4 +127,11 @@ TEST(CLASSNAME(test_multiple_service_calls, RMW_IMPLEMENTATION), multiple_client
     printf("Got response #%u with value %zd\n", i, results[i].get()->sum);
     fflush(stdout);
   }
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/test_rclcpp/test/test_publisher.cpp
+++ b/test_rclcpp/test/test_publisher.cpp
@@ -19,6 +19,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#include "test_rclcpp/utils.hpp"
 #include "test_rclcpp/msg/u_int32.hpp"
 
 #ifdef RMW_IMPLEMENTATION
@@ -60,6 +61,7 @@ TEST(CLASSNAME(test_publisher, RMW_IMPLEMENTATION), publish_with_const_reference
   // nothing should be pending here
   executor.spin_node_some(node);
   ASSERT_EQ(0, counter);
+  test_rclcpp::busy_wait_for_subscriber(node, "test_publisher");
 
   msg.data = 1;
   publisher->publish(msg);

--- a/test_rclcpp/test/test_publisher.cpp
+++ b/test_rclcpp/test/test_publisher.cpp
@@ -30,6 +30,7 @@
 
 // Short test for the const reference publish signature.
 TEST(CLASSNAME(test_publisher, RMW_IMPLEMENTATION), publish_with_const_reference) {
+  rclcpp::init(0, nullptr);
   auto node = rclcpp::Node::make_shared("test_publisher");
 
   auto publisher = node->create_publisher<test_rclcpp::msg::UInt32>("test_publisher", 10);

--- a/test_rclcpp/test/test_timer.cpp
+++ b/test_rclcpp/test/test_timer.cpp
@@ -124,7 +124,7 @@ TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_during_wait) {
 
   // check number of callbacks
   printf("expecting 4 callbacks\n");
-  ASSERT_EQ(4, counter);
+  EXPECT_EQ(4, counter);
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);


### PR DESCRIPTION
Connects to ros2/rclcpp#204

`rclcpp::init` is actually required now. It also can't be called twice.