### PR TITLE
add message which has fields with the same non-primitive type

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -28,6 +28,7 @@ if(BUILD_TESTING)
     "msg/DynamicArrayNested.msg"
     "msg/DynamicArrayPrimitives.msg"
     "msg/Empty.msg"
+    "msg/FieldsWithSameType.msg"
     "msg/Nested.msg"
     "msg/Primitives.msg"
     "msg/StaticArrayNested.msg"

--- a/test_communication/msg/FieldsWithSameType.msg
+++ b/test_communication/msg/FieldsWithSameType.msg
@@ -1,0 +1,2 @@
+Primitives primitive_values1
+Primitives primitive_values2


### PR DESCRIPTION
Add a message which has multiple fields with the same non-primitive type.

* http://ci.ros2.org/job/ci_linux/1263/
* http://ci.ros2.org/job/ci_osx/1009/
* http://ci.ros2.org/job/ci_windows/1296/

This is mainly to demonstrate that ros2/rmw_opensplice#109 is not necessary. Should we still merge this (to catch potential problems in the future) or just close it?