### PR TITLE
add communication tests for bounded arrays

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -24,6 +24,8 @@ if(BUILD_TESTING)
   endforeach()
 
   set(message_files
+    "msg/BoundedArrayNested.msg"
+    "msg/BoundedArrayPrimitives.msg"
     "msg/Builtins.msg"
     "msg/DynamicArrayNested.msg"
     "msg/DynamicArrayPrimitives.msg"

--- a/test_communication/msg/BoundedArrayNested.msg
+++ b/test_communication/msg/BoundedArrayNested.msg
@@ -1,0 +1,1 @@
+Primitives[<=4] primitive_values

--- a/test_communication/msg/BoundedArrayPrimitives.msg
+++ b/test_communication/msg/BoundedArrayPrimitives.msg
@@ -1,0 +1,15 @@
+bool[<=3] bool_values
+byte[<=3] byte_values
+char[<=3] char_values
+float32[<=3] float32_values
+float64[<=3] float64_values
+int8[<=3] int8_values
+uint8[<=3] uint8_values
+int16[<=3] int16_values
+uint16[<=3] uint16_values
+int32[<=3] int32_values
+uint32[<=3] uint32_values
+int64[<=3] int64_values
+uint64[<=3] uint64_values
+string[<=3] string_values
+int32 check

--- a/test_communication/test/message_fixtures.hpp
+++ b/test_communication/test/message_fixtures.hpp
@@ -19,6 +19,8 @@
 #include <limits>
 #include <vector>
 
+#include "test_communication/msg/bounded_array_nested.hpp"
+#include "test_communication/msg/bounded_array_primitives.hpp"
 #include "test_communication/msg/builtins.hpp"
 #include "test_communication/msg/dynamic_array_nested.hpp"
 #include "test_communication/msg/dynamic_array_primitives.hpp"
@@ -275,6 +277,49 @@ get_messages_dynamic_array_primitives()
   return messages;
 }
 
+std::vector<test_communication::msg::BoundedArrayPrimitives::SharedPtr>
+get_messages_bounded_array_primitives()
+{
+  std::vector<test_communication::msg::BoundedArrayPrimitives::SharedPtr> messages;
+  {
+    auto msg = std::make_shared<test_communication::msg::BoundedArrayPrimitives>();
+    msg->bool_values = {{false, true, false}};
+    msg->byte_values = {{0, 1, 0xff}};
+    msg->char_values = {{'\0', '\1', '\255'}};
+    msg->float32_values = {{0.0f, 1.125f, -2.125f}};
+    msg->float64_values = {{0, 1.125, -2.125}};
+    // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
+    msg->int8_values = {{
+      0, (std::numeric_limits<int8_t>::max)(), (std::numeric_limits<int8_t>::min)()}};
+    msg->uint8_values = {{0, 1, (std::numeric_limits<uint8_t>::max)()}};
+    msg->int16_values = {{
+      0, (std::numeric_limits<int16_t>::max)(), (std::numeric_limits<int16_t>::min)()}};
+    msg->uint16_values = {{0, 1, (std::numeric_limits<uint16_t>::max)()}};
+    // The narrowing static cast is required to avoid build errors on Windows.
+    msg->int32_values = {{
+      static_cast<int32_t>(0),
+      (std::numeric_limits<int32_t>::max)(),
+      (std::numeric_limits<int32_t>::min)()
+    }};
+    // *INDENT-ON*
+    msg->uint32_values = {{0, 1, (std::numeric_limits<uint32_t>::max)()}};
+    msg->int64_values[0] = 0;
+    msg->int64_values[1] = (std::numeric_limits<int64_t>::max)();
+    msg->int64_values[2] = (std::numeric_limits<int64_t>::min)();
+    msg->uint64_values = {{0, 1, (std::numeric_limits<uint64_t>::max)()}};
+    msg->string_values = {{"", "max value", "optional min value"}};
+    msg->check = 2;
+    messages.push_back(msg);
+  }
+  {
+    auto msg = std::make_shared<test_communication::msg::BoundedArrayPrimitives>();
+    // check default sequences
+    msg->check = 4;
+    messages.push_back(msg);
+  }
+  return messages;
+}
+
 std::vector<test_communication::msg::Nested::SharedPtr>
 get_messages_nested()
 {
@@ -297,6 +342,23 @@ get_messages_dynamic_array_nested()
     auto primitive_msgs = get_messages_primitives();
     for (auto primitive_msg : primitive_msgs) {
       msg->primitive_values.push_back(*primitive_msg);
+    }
+    messages.push_back(msg);
+  }
+  return messages;
+}
+
+std::vector<test_communication::msg::BoundedArrayNested::SharedPtr>
+get_messages_bounded_array_nested()
+{
+  std::vector<test_communication::msg::BoundedArrayNested::SharedPtr> messages;
+  {
+    auto msg = std::make_shared<test_communication::msg::BoundedArrayNested>();
+    auto primitive_msgs = get_messages_primitives();
+    size_t i = 0;
+    for (auto primitive_msg : primitive_msgs) {
+      msg->primitive_values[i] = *primitive_msg;
+      ++i;
     }
     messages.push_back(msg);
   }

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -79,11 +79,17 @@ int main(int argc, char ** argv)
   } else if (message == "DynamicArrayPrimitives") {
     publish<test_communication::msg::DynamicArrayPrimitives>(
       node, message, get_messages_dynamic_array_primitives());
+  } else if (message == "BoundedArrayPrimitives") {
+    publish<test_communication::msg::BoundedArrayPrimitives>(
+      node, message, get_messages_bounded_array_primitives());
   } else if (message == "Nested") {
     publish<test_communication::msg::Nested>(node, message, get_messages_nested());
   } else if (message == "DynamicArrayNested") {
     publish<test_communication::msg::DynamicArrayNested>(
       node, message, get_messages_dynamic_array_nested());
+  } else if (message == "BoundedArrayNested") {
+    publish<test_communication::msg::BoundedArrayNested>(
+      node, message, get_messages_bounded_array_nested());
   } else if (message == "StaticArrayNested") {
     publish<test_communication::msg::StaticArrayNested>(
       node, message, get_messages_static_array_nested());

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -124,8 +124,10 @@ int main(int argc, char ** argv)
   auto messages_primitives = get_messages_primitives();
   auto messages_static_array_primitives = get_messages_static_array_primitives();
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
+  auto messages_bounded_array_primitives = get_messages_bounded_array_primitives();
   auto messages_nested = get_messages_nested();
   auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
+  auto messages_bounded_array_nested = get_messages_bounded_array_nested();
   auto messages_static_array_nested = get_messages_static_array_nested();
   auto messages_builtins = get_messages_builtins();
 
@@ -147,6 +149,11 @@ int main(int argc, char ** argv)
       node, message, messages_dynamic_array_primitives, received_messages);
     publish<test_communication::msg::DynamicArrayPrimitives>(node, message,
       messages_dynamic_array_primitives);
+  } else if (message == "BoundedArrayPrimitives") {
+    subscriber = subscribe<test_communication::msg::BoundedArrayPrimitives>(
+      node, message, messages_bounded_array_primitives, received_messages);
+    publish<test_communication::msg::BoundedArrayPrimitives>(node, message,
+      messages_bounded_array_primitives);
   } else if (message == "Nested") {
     subscriber = subscribe<test_communication::msg::Nested>(
       node, message, messages_nested, received_messages);
@@ -156,6 +163,11 @@ int main(int argc, char ** argv)
       node, message, messages_dynamic_array_nested, received_messages);
     publish<test_communication::msg::DynamicArrayNested>(node, message,
       messages_dynamic_array_nested);
+  } else if (message == "BoundedArrayNested") {
+    subscriber = subscribe<test_communication::msg::BoundedArrayNested>(
+      node, message, messages_bounded_array_nested, received_messages);
+    publish<test_communication::msg::BoundedArrayNested>(node, message,
+      messages_bounded_array_nested);
   } else if (message == "StaticArrayNested") {
     subscriber = subscribe<test_communication::msg::StaticArrayNested>(
       node, message, messages_static_array_nested, received_messages);

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -90,8 +90,10 @@ int main(int argc, char ** argv)
   auto messages_primitives = get_messages_primitives();
   auto messages_static_array_primitives = get_messages_static_array_primitives();
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
+  auto messages_bounded_array_primitives = get_messages_bounded_array_primitives();
   auto messages_nested = get_messages_nested();
   auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
+  auto messages_bounded_array_nested = get_messages_bounded_array_nested();
   auto messages_static_array_nested = get_messages_static_array_nested();
   auto messages_builtins = get_messages_builtins();
 
@@ -109,12 +111,18 @@ int main(int argc, char ** argv)
   } else if (message == "DynamicArrayPrimitives") {
     subscriber = subscribe<test_communication::msg::DynamicArrayPrimitives>(
       node, message, messages_dynamic_array_primitives, received_messages);
+  } else if (message == "BoundedArrayPrimitives") {
+    subscriber = subscribe<test_communication::msg::BoundedArrayPrimitives>(
+      node, message, messages_bounded_array_primitives, received_messages);
   } else if (message == "Nested") {
     subscriber = subscribe<test_communication::msg::Nested>(
       node, message, messages_nested, received_messages);
   } else if (message == "DynamicArrayNested") {
     subscriber = subscribe<test_communication::msg::DynamicArrayNested>(
       node, message, messages_dynamic_array_nested, received_messages);
+  } else if (message == "BoundedArrayNested") {
+    subscriber = subscribe<test_communication::msg::BoundedArrayNested>(
+      node, message, messages_bounded_array_nested, received_messages);
   } else if (message == "StaticArrayNested") {
     subscriber = subscribe<test_communication::msg::StaticArrayNested>(
       node, message, messages_static_array_nested, received_messages);


### PR DESCRIPTION
Connect to #123.

Currently the code generated for bounded arrays by some rosidl generators doesn't even compile, e.g. `rosidl_generator_py`, `rosidl_typesupport_connext_c`, `rosidl_typesupport_opensplice_c/cpp`.