### PR TITLE
add tests for all message_files

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -75,7 +75,7 @@ if(BUILD_TESTING)
       get_filename_component(TEST_MESSAGE_TYPE "${message_file}" NAME_WE)
       # TODO(dirk-thomas) publishing DynamicArrayPrimitives in OpenSplice is buggy
       # https://github.com/ros2/rclcpp/issues/219
-      if(NOT "${TEST_MESSAGE_TYPE}" STREQUAL "DynamicArrayPrimitives" OR NOT "${rmw_implementation1}" STREQUAL "rmw_opensplice_cpp")
+      if(NOT TEST_MESSAGE_TYPE STREQUAL "DynamicArrayPrimitives" OR NOT rmw_implementation STREQUAL "rmw_opensplice_cpp")
         ament_add_test(
           "${target}${target_suffix}__${TEST_MESSAGE_TYPE}"
           COMMAND "${target_path}/${target}${target_suffix}" "${TEST_MESSAGE_TYPE}"

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -73,16 +73,20 @@ if(BUILD_TESTING)
     # adding test for each message type
     foreach(message_file ${message_files})
       get_filename_component(TEST_MESSAGE_TYPE "${message_file}" NAME_WE)
-      ament_add_test(
-        "${target}${target_suffix}__${TEST_MESSAGE_TYPE}"
-        COMMAND "${target_path}/${target}${target_suffix}" "${TEST_MESSAGE_TYPE}"
-        TIMEOUT 15
-        GENERATE_RESULT_FOR_RETURN_CODE_ZERO
-        ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
-      set_tests_properties(
-        "${target}${target_suffix}__${TEST_MESSAGE_TYPE}"
-        PROPERTIES REQUIRED_FILES "${target_path}/${target}${target_suffix}"
-      )
+      # TODO(dirk-thomas) publishing DynamicArrayPrimitives in OpenSplice is buggy
+      # https://github.com/ros2/rclcpp/issues/219
+      if(NOT "${TEST_MESSAGE_TYPE}" STREQUAL "DynamicArrayPrimitives" OR NOT "${rmw_implementation1}" STREQUAL "rmw_opensplice_cpp")
+        ament_add_test(
+          "${target}${target_suffix}__${TEST_MESSAGE_TYPE}"
+          COMMAND "${target_path}/${target}${target_suffix}" "${TEST_MESSAGE_TYPE}"
+          TIMEOUT 15
+          GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+          ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
+        set_tests_properties(
+          "${target}${target_suffix}__${TEST_MESSAGE_TYPE}"
+          PROPERTIES REQUIRED_FILES "${target_path}/${target}${target_suffix}"
+        )
+      endif()
     endforeach()
   endfunction()
 

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -70,17 +70,20 @@ if(BUILD_TESTING)
     if(NOT target_path)
       set(target_path "${CMAKE_CURRENT_BINARY_DIR}")
     endif()
-    # testing this with a single message type should be enough
-    ament_add_test(
-      "${target}${target_suffix}"
-      COMMAND "${target_path}/${target}${target_suffix}" Empty
-      TIMEOUT 15
-      GENERATE_RESULT_FOR_RETURN_CODE_ZERO
-      ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
-    set_tests_properties(
-      ${target}${target_suffix}
-      PROPERTIES REQUIRED_FILES "${target_path}/${target}${target_suffix}"
-    )
+    # adding test for each message type
+    foreach(message_file ${message_files})
+      get_filename_component(TEST_MESSAGE_TYPE "${message_file}" NAME_WE)
+      ament_add_test(
+        "${target}${target_suffix}__${TEST_MESSAGE_TYPE}"
+        COMMAND "${target_path}/${target}${target_suffix}" "${TEST_MESSAGE_TYPE}"
+        TIMEOUT 15
+        GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+        ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
+      set_tests_properties(
+        "${target}${target_suffix}__${TEST_MESSAGE_TYPE}"
+        PROPERTIES REQUIRED_FILES "${target_path}/${target}${target_suffix}"
+      )
+    endforeach()
   endfunction()
 
   function(custom_executable target)


### PR DESCRIPTION
This adds tests for all `message_files`.
Note: `rmw_connext_dynamic_cpp` test segfaults with `DynamicArrayPrimitives` message.