### PR TITLE
fix use of bracket

### DIFF
--- a/test_communication/test/message_fixtures.hpp
+++ b/test_communication/test/message_fixtures.hpp
@@ -162,20 +162,20 @@ get_messages_dynamic_array_primitives()
   std::vector<test_communication::msg::DynamicArrayPrimitives::SharedPtr> messages;
   {
     auto msg = std::make_shared<test_communication::msg::DynamicArrayPrimitives>();
-    msg->bool_values = {{}};
-    msg->byte_values = {{}};
-    msg->char_values = {{}};
-    msg->float32_values = {{}};
-    msg->float64_values = {{}};
-    msg->int8_values = {{}};
-    msg->uint8_values = {{}};
-    msg->int16_values = {{}};
-    msg->uint16_values = {{}};
-    msg->int32_values = {{}};
-    msg->uint32_values = {{}};
-    msg->int64_values = {{}};
-    msg->uint64_values = {{}};
-    msg->string_values = {{}};
+    msg->bool_values = {};
+    msg->byte_values = {};
+    msg->char_values = {};
+    msg->float32_values = {};
+    msg->float64_values = {};
+    msg->int8_values = {};
+    msg->uint8_values = {};
+    msg->int16_values = {};
+    msg->uint16_values = {};
+    msg->int32_values = {};
+    msg->uint32_values = {};
+    msg->int64_values = {};
+    msg->uint64_values = {};
+    msg->string_values = {};
     msg->check = 0;
     messages.push_back(msg);
   }


### PR DESCRIPTION
It seems that https://github.com/ros2/system_tests/commit/4f05870ee0fa897cc9a950be59d3219fc3956ebc while fixing some warnings changed the test behavior.
I assume that the "expected" message would be a message with only empty arrays (std::vectors). But adding a second pair of curly brackets results in initializing all vectors with one element set to its default value (e.g. `msg->bool_values={{}}` will result in `{false}`)
It seems that `{{` is needed only when you want to initialize a vector with more than one element.

This would PR allows to get back to what I think was the expected behavior.

Pending CI jobs to confirm that no new warnings show up:
 * Linux [![Build Status](http://ci.ros2.org/job/ci_linux/1377/badge/icon)](http://ci.ros2.org/job/ci_linux/1377)
 * OSX [![Build Status](http://ci.ros2.org/job/ci_osx/1073/badge/icon)](http://ci.ros2.org/job/ci_osx/1073/)
 * Windows [![Build Status](http://ci.ros2.org/job/ci_windows/1382/badge/icon)](http://ci.ros2.org/job/ci_windows/1382)