### PR TITLE
update test times

### DIFF
--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -26,7 +26,7 @@ void publish(
   rclcpp::Node::SharedPtr node,
   const std::string & message_type,
   std::vector<typename T::SharedPtr> messages,
-  size_t number_of_cycles = 5)
+  size_t number_of_cycles = 100)
 {
   auto start = std::chrono::steady_clock::now();
 
@@ -36,8 +36,8 @@ void publish(
   auto publisher = node->create_publisher<T>(
     std::string("test_message_") + message_type, custom_qos_profile);
 
-  rclcpp::WallRate cycle_rate(1);
-  rclcpp::WallRate message_rate(10);
+  rclcpp::WallRate cycle_rate(10);
+  rclcpp::WallRate message_rate(100);
   size_t cycle_index = 0;
   // publish all messages up to number_of_cycles times, longer sleep between each cycle
   while (rclcpp::ok() && cycle_index < number_of_cycles) {

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -26,7 +26,7 @@ void publish(
   rclcpp::Node::SharedPtr node,
   const std::string & message_type,
   std::vector<typename T::SharedPtr> messages,
-  size_t number_of_cycles = 5)
+  size_t number_of_cycles = 100)
 {
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
   custom_qos_profile.depth = messages.size();
@@ -35,7 +35,7 @@ void publish(
     std::string("test_message_") + message_type, custom_qos_profile);
 
   rclcpp::WallRate cycle_rate(10);
-  rclcpp::WallRate message_rate(40);
+  rclcpp::WallRate message_rate(100);
   size_t cycle_index = 0;
   // publish all messages up to number_of_cycles times, longer sleep between each cycle
   while (rclcpp::ok() && cycle_index < number_of_cycles) {

--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -35,7 +35,7 @@ int request(
       typename T::Response::SharedPtr
     >
   > services,
-  size_t number_of_cycles = 5)
+  size_t number_of_cycles = 100)
 {
   int rc = 0;
   auto requester = node->create_client<T>(std::string("test_service_") + service_type);
@@ -49,8 +49,8 @@ int request(
     }
   }
 
-  rclcpp::WallRate cycle_rate(1);
-  auto wait_between_services = std::chrono::milliseconds(100);
+  rclcpp::WallRate cycle_rate(10);
+  auto wait_between_services = std::chrono::milliseconds(10);
   size_t cycle_index = 0;
   size_t service_index = 0;
   auto start = std::chrono::steady_clock::now();


### PR DESCRIPTION
If test cycles start as infrequent as once per second that implies that after discovery finished the average wasted time is .5 seconds. And if multiple different messages in a cycle are then spaced out by 100ms that can add up to another .5 seconds (for five different messages, e.g. `DynamicArrayPrimitives`).

Since with all the matrix tests we run more than 220 tests in the `test_communication` package alone it makes sense to reduce the amount of wasted time per test as much as possible. Therefore this patch changes the timing to start new cycles at least 10 times per second and only use 10ms between different messages within one cycle. That should reduce the average time per test by .45 - .9 seconds on average. While not all tests are updated the majority of them are (`test_publisher_subscriber__*`) which will safe about 2 minutes:

* Before: http://ci.ros2.org/job/ci_linux/1517/ testing took 680s (only using Connext and OpenSplice, hence only 148 tests)
* After: http://ci.ros2.org/job/ci_linux/1520/ testing took only 619s, which is 61s less / 9% faster