### PR TITLE
use sleep if wait_for_service throws

### DIFF
--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -16,12 +16,12 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
-#include <thread>  // TODO(wjwwood): remove me when fastrtps exclusion is removed
+#include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 #include <utility>
 #include <vector>
 
+#include "rclcpp/exceptions.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "rmw/rmw.h"  // TODO(wjwwood): remove me when fastrtps exclusion is removed
 
 #include "service_fixtures.hpp"
 
@@ -39,12 +39,12 @@ int request(
 {
   int rc = 0;
   auto requester = node->create_client<T>(std::string("test_service_") + service_type);
-  {  // TODO(wjwwood): remove this block when fastrtps supports wait_for_service.
-    if (std::string(rmw_get_implementation_identifier()) != "rmw_fastrtps_cpp") {
+  {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
+    try {
       if (!requester->wait_for_service(20_s)) {
         throw std::runtime_error("requester service not available after waiting");
       }
-    } else {
+    } catch (rclcpp::exceptions::RCLError) {
       std::this_thread::sleep_for(1_s);
     }
   }

--- a/test_rclcpp/test/test_client_scope_client.cpp
+++ b/test_rclcpp/test/test_client_scope_client.cpp
@@ -14,12 +14,11 @@
 
 #include <iostream>
 #include <memory>
-#include <string>  // TODO(wjwwood): remove me when fastrtps exclusion is removed
-#include <thread>  // TODO(wjwwood): remove me when fastrtps exclusion is removed
+#include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 
 #include "gtest/gtest.h"
+#include "rclcpp/exceptions.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "rmw/rmw.h"  // TODO(wjwwood): remove me when fastrtps exclusion is removed
 #include "test_rclcpp/srv/add_two_ints.hpp"
 
 #ifdef RMW_IMPLEMENTATION
@@ -37,10 +36,12 @@ TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_regression_test
     printf("creating first client\n");
     std::cout.flush();
     auto client1 = node->create_client<test_rclcpp::srv::AddTwoInts>("client_scope");
-    {  // TODO(wjwwood): remove this block when fastrtps supports wait_for_service.
-      if (std::string(rmw_get_implementation_identifier()) != "rmw_fastrtps_cpp") {
-        ASSERT_TRUE(client1->wait_for_service(20_s)) << "service not available after waiting";
-      } else {
+    {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
+      try {
+        if (!client1->wait_for_service(20_s)) {
+          ASSERT_TRUE(false) << "service not available after waiting";
+        }
+      } catch (rclcpp::exceptions::RCLError) {
         std::this_thread::sleep_for(1_s);
       }
     }
@@ -68,10 +69,12 @@ TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_regression_test
     printf("creating second client\n");
     std::cout.flush();
     auto client2 = node->create_client<test_rclcpp::srv::AddTwoInts>("client_scope");
-    {  // TODO(wjwwood): remove this block when fastrtps supports wait_for_service.
-      if (std::string(rmw_get_implementation_identifier()) != "rmw_fastrtps_cpp") {
-        ASSERT_TRUE(client2->wait_for_service(20_s)) << "service not available after waiting";
-      } else {
+    {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
+      try {
+        if (!client2->wait_for_service(20_s)) {
+          ASSERT_TRUE(false) << "service not available after waiting";
+        }
+      } catch (rclcpp::exceptions::RCLError) {
         std::this_thread::sleep_for(1_s);
       }
     }

--- a/test_rclcpp/test/test_client_wait_for_service_shutdown.cpp
+++ b/test_rclcpp/test/test_client_wait_for_service_shutdown.cpp
@@ -30,8 +30,8 @@
 
 // rclcpp::shutdown() should wake up wait_for_service, even without spin.
 TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), wait_for_service_shutdown) {
-  // TODO(wjwwood): remove this "skip" when fastrtps supports wait_for_service.
-  if (std::string(rmw_get_implementation_identifier()) == "rmw_fastrtps_cpp") {
+  // TODO(wjwwood): remove this "skip" when Connext and FastRTPS support wait_for_service.
+  if (std::string(rmw_get_implementation_identifier()) != "rmw_opensplice_cpp") {
     return;
   }
   rclcpp::init(0, nullptr);

--- a/test_rclcpp/test/test_executor.cpp
+++ b/test_rclcpp/test/test_executor.cpp
@@ -17,12 +17,12 @@
 #include <future>
 #include <stdexcept>
 #include <string>
-#include <thread>  // TODO(wjwwood): remove me when fastrtps exclusion is removed
+#include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 
 #include "gtest/gtest.h"
 
+#include "rclcpp/exceptions.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "rmw/rmw.h"  // TODO(wjwwood): remove me when fastrtps exclusion is removed
 
 #include "test_rclcpp/utils.hpp"
 
@@ -205,10 +205,12 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), notify) {
     auto client = node->create_client<test_rclcpp::srv::AddTwoInts>(
       "test_executor_notify_service"
       );
-    {  // TODO(wjwwood): remove this block when fastrtps supports wait_for_service.
-      if (std::string(rmw_get_implementation_identifier()) != "rmw_fastrtps_cpp") {
-        ASSERT_TRUE(client->wait_for_service(20_s)) << "service not available after waiting";
-      } else {
+    {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
+      try {
+        if (!client->wait_for_service(20_s)) {
+          ASSERT_TRUE(false) << "service not available after waiting";
+        }
+      } catch (rclcpp::exceptions::RCLError) {
         std::this_thread::sleep_for(1_s);
       }
     }

--- a/test_rclcpp/test/test_multiple_service_calls.cpp
+++ b/test_rclcpp/test/test_multiple_service_calls.cpp
@@ -13,15 +13,14 @@
 // limitations under the License.
 
 #include <iostream>
-#include <string>  // TODO(wjwwood): remove me when fastrtps exclusion is removed
-#include <thread>  // TODO(wjwwood): remove me when fastrtps exclusion is removed
+#include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 #include <utility>
 #include <vector>
 
 #include "gtest/gtest.h"
 
+#include "rclcpp/exceptions.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "rmw/rmw.h"  // TODO(wjwwood): remove me when fastrtps exclusion is removed
 
 #include "test_rclcpp/srv/add_two_ints.hpp"
 
@@ -46,10 +45,12 @@ TEST(CLASSNAME(test_two_service_calls, RMW_IMPLEMENTATION), two_service_calls) {
     "test_two_service_calls", handle_add_two_ints);
 
   auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("test_two_service_calls");
-  {  // TODO(wjwwood): remove this block when fastrtps supports wait_for_service.
-    if (std::string(rmw_get_implementation_identifier()) != "rmw_fastrtps_cpp") {
-      ASSERT_TRUE(client->wait_for_service(20_s)) << "service not available after waiting";
-    } else {
+  {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
+    try {
+      if (!client->wait_for_service(20_s)) {
+        ASSERT_TRUE(false) << "service not available after waiting";
+      }
+    } catch (rclcpp::exceptions::RCLError) {
       std::this_thread::sleep_for(1_s);
     }
   }
@@ -112,10 +113,12 @@ TEST(CLASSNAME(test_multiple_service_calls, RMW_IMPLEMENTATION), multiple_client
   fflush(stdout);
   // Send all the requests
   for (auto & pair : client_request_pairs) {
-    {  // TODO(wjwwood): remove this block when fastrtps supports wait_for_service.
-      if (std::string(rmw_get_implementation_identifier()) != "rmw_fastrtps_cpp") {
-        ASSERT_TRUE(pair.first->wait_for_service(20_s)) << "service not available after waiting";
-      } else {
+    {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
+      try {
+        if (!pair.first->wait_for_service(20_s)) {
+          ASSERT_TRUE(false) << "service not available after waiting";
+        }
+      } catch (rclcpp::exceptions::RCLError) {
         std::this_thread::sleep_for(1_s);
       }
     }

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -14,15 +14,15 @@
 
 #include <limits>
 #include <string>
-#include <thread>  // TODO(wjwwood): remove me when fastrtps exclusion is removed
+#include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 #include <utility>
 #include <vector>
 
 #include "gtest/gtest.h"
 
+#include "rclcpp/exceptions.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/executors.hpp"
-#include "rmw/rmw.h"  // TODO(wjwwood): remove me when fastrtps exclusion is removed
 
 #include "test_rclcpp/utils.hpp"
 #include "test_rclcpp/msg/u_int32.hpp"
@@ -194,10 +194,12 @@ TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_clients) 
     std::vector<SharedFuture> results;
     // Send all the requests
     for (auto & pair : client_request_pairs) {
-      {  // TODO(wjwwood): remove this block when fastrtps supports wait_for_service.
-        if (std::string(rmw_get_implementation_identifier()) != "rmw_fastrtps_cpp") {
-          ASSERT_TRUE(pair.first->wait_for_service(20_s)) << "service not available after waiting";
-        } else {
+      {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
+        try {
+          if (!pair.first->wait_for_service(20_s)) {
+            ASSERT_TRUE(false) << "service not available after waiting";
+          }
+        } catch (rclcpp::exceptions::RCLError) {
           std::this_thread::sleep_for(1_s);
         }
       }
@@ -223,10 +225,12 @@ TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_clients) 
     std::vector<SharedFuture> results;
     // Send all the requests again
     for (auto & pair : client_request_pairs) {
-      {  // TODO(wjwwood): remove this block when fastrtps supports wait_for_service.
-        if (std::string(rmw_get_implementation_identifier()) != "rmw_fastrtps_cpp") {
-          ASSERT_TRUE(pair.first->wait_for_service(20_s)) << "service not available after waiting";
-        } else {
+      {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
+        try {
+          if (!pair.first->wait_for_service(20_s)) {
+            ASSERT_TRUE(false) << "service not available after waiting";
+          }
+        } catch (rclcpp::exceptions::RCLError) {
           std::this_thread::sleep_for(1_s);
         }
       }

--- a/test_rclcpp/test/test_services_client.cpp
+++ b/test_rclcpp/test/test_services_client.cpp
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 #include <chrono>
-#include <string>  // TODO(wjwwood): remove me when fastrtps exclusion is removed
 #include <thread>
 
 #include "gtest/gtest.h"
 
+#include "rclcpp/exceptions.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "rmw/rmw.h"  // TODO(wjwwood): remove me when fastrtps exclusion is removed
 
 #include "test_rclcpp/srv/add_two_ints.hpp"
 
@@ -38,10 +37,12 @@ TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_noreqid) {
   request->a = 1;
   request->b = 2;
 
-  {  // TODO(wjwwood): remove this block when fastrtps supports wait_for_service.
-    if (std::string(rmw_get_implementation_identifier()) != "rmw_fastrtps_cpp") {
-      ASSERT_TRUE(client->wait_for_service(20_s)) << "service not available after waiting";
-    } else {
+  {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
+    try {
+      if (!client->wait_for_service(20_s)) {
+        ASSERT_TRUE(false) << "service not available after waiting";
+      }
+    } catch (rclcpp::exceptions::RCLError) {
       std::this_thread::sleep_for(1_s);
     }
   }
@@ -62,10 +63,12 @@ TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_reqid) {
   request->a = 4;
   request->b = 5;
 
-  {  // TODO(wjwwood): remove this block when fastrtps supports wait_for_service.
-    if (std::string(rmw_get_implementation_identifier()) != "rmw_fastrtps_cpp") {
-      ASSERT_TRUE(client->wait_for_service(20_s)) << "service not available after waiting";
-    } else {
+  {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
+    try {
+      if (!client->wait_for_service(20_s)) {
+        ASSERT_TRUE(false) << "service not available after waiting";
+      }
+    } catch (rclcpp::exceptions::RCLError) {
       std::this_thread::sleep_for(1_s);
     }
   }
@@ -87,10 +90,12 @@ TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_return_request) {
   request->a = 4;
   request->b = 5;
 
-  {  // TODO(wjwwood): remove this block when fastrtps supports wait_for_service.
-    if (std::string(rmw_get_implementation_identifier()) != "rmw_fastrtps_cpp") {
-      ASSERT_TRUE(client->wait_for_service(20_s)) << "service not available after waiting";
-    } else {
+  {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
+    try {
+      if (!client->wait_for_service(20_s)) {
+        ASSERT_TRUE(false) << "service not available after waiting";
+      }
+    } catch (rclcpp::exceptions::RCLError) {
       std::this_thread::sleep_for(1_s);
     }
   }


### PR DESCRIPTION
With this patch Connext also sleeps since it doesn't implement `wait_for_service` yet (rather then failing these service tests).

Before: http://ci.ros2.org/job/ci_linux/1570/
After: http://ci.ros2.org/job/ci_linux/1571/