### PR TITLE
revert test requester timing

### DIFF
--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -35,7 +35,7 @@ int request(
       typename T::Response::SharedPtr
     >
   > services,
-  size_t number_of_cycles = 100)
+  size_t number_of_cycles = 10)
 {
   int rc = 0;
   auto requester = node->create_client<T>(std::string("test_service_") + service_type);
@@ -50,7 +50,7 @@ int request(
   }
 
   rclcpp::WallRate cycle_rate(10);
-  auto wait_between_services = std::chrono::milliseconds(10);
+  auto wait_between_services = std::chrono::milliseconds(100);
   size_t cycle_index = 0;
   size_t service_index = 0;
   auto start = std::chrono::steady_clock::now();


### PR DESCRIPTION
Revert / modify the timing changes form #144 for the `test_requester`. Since the variable `wait_between_services` does not do what it name implies but defines the timeout how long to wait for a response to arrive the shorter timing doesn't apply to it.

Before: http://ci.ros2.org/job/ci_linux/1589/testReport/(root)/test_requester_replier_cpp__Primitives__rmw_connext_cpp_/
After http://ci.ros2.org/job/ci_linux/1590/testReport/(root)/test_requester_replier_cpp__Primitives__rmw_connext_cpp_/

Please review.