### PR TITLE
init variables to avoid compiler warnings

### DIFF
--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -109,10 +109,10 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
     ASSERT_TRUE(result.successful);
   }
 
-  int foo;
+  int foo = 0;
   std::string bar, barstr;
-  double baz;
-  bool foobar;
+  double baz = 0.;
+  bool foobar = false;
   std::vector<uint8_t> barfoo;
 
   // Test variables that are set, verifying that types are obeyed, and defaults not used.


### PR DESCRIPTION
Avoid warnings shown in certain build configurations (e.g., http://ci.ros2.org/view/nightly/job/nightly_linux_release/129/warnings18Result/new/). I'll be out of contact for a while, so please merge without me.