### PR TITLE
Revert "add sleep to avoid client/server race until we have a better solution"

### DIFF
--- a/test_rclcpp/test/test_remote_parameters.cpp
+++ b/test_rclcpp/test/test_remote_parameters.cpp
@@ -37,13 +37,6 @@ TEST(CLASSNAME(parameters, rmw_implementation), test_remote_parameters) {
 
   auto node = rclcpp::Node::make_shared(std::string("test_remote_parameters"));
 
-  // TODO(wjwwood): remove this block when there is a wait_for_parameter_server option.
-  {
-    // This is requried specifically for FastRTPS, see:
-    //   https://github.com/eProsima/ROS-RMW-Fast-RTPS-cpp/pull/51#issuecomment-242872096
-    std::this_thread::sleep_for(1_s);
-  }
-
   auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node,
       test_server_name);
 


### PR DESCRIPTION
Reverts ros2/system_tests#159

I'm using this to test an upstream change for eProsima. Please do not merge.