### PR TITLE
Ascii fixture

### DIFF
--- a/test_communication/test/message_fixtures.hpp
+++ b/test_communication/test/message_fixtures.hpp
@@ -66,7 +66,7 @@ get_messages_primitives()
     auto msg = std::make_shared<test_communication::msg::Primitives>();
     msg->bool_value = true;
     msg->byte_value = 255;
-    msg->char_value = '\255';
+    msg->char_value = '\x7f';
     msg->float32_value = 1.125f;
     msg->float64_value = 1.125;
     msg->int8_value = (std::numeric_limits<int8_t>::max)();
@@ -131,7 +131,7 @@ get_messages_static_array_primitives()
     auto msg = std::make_shared<test_communication::msg::StaticArrayPrimitives>();
     msg->bool_values = {{false, true, false}};
     msg->byte_values = {{0, 0xff, 0}};
-    msg->char_values = {{'\0', '\255', '\0'}};
+    msg->char_values = {{'\0', '\x7f', '\0'}};
     msg->float32_values = {{0.0f, 1.125f, -2.125f}};
     msg->float64_values = {{0, 1.125, -2.125}};
     // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
@@ -185,7 +185,7 @@ get_messages_dynamic_array_primitives()
     auto msg = std::make_shared<test_communication::msg::DynamicArrayPrimitives>();
     msg->bool_values = {true};
     msg->byte_values = {0xff};
-    msg->char_values = {'\255'};
+    msg->char_values = {'\x7f'};
     msg->float32_values = {1.125f};
     msg->float64_values = {1.125};
     msg->int8_values = {(std::numeric_limits<int8_t>::max)()};
@@ -204,7 +204,7 @@ get_messages_dynamic_array_primitives()
     auto msg = std::make_shared<test_communication::msg::DynamicArrayPrimitives>();
     msg->bool_values = {{false, true}};
     msg->byte_values = {{0, 0xff}};
-    msg->char_values = {{'\0', '\255'}};
+    msg->char_values = {{'\0', '\x7f'}};
     msg->float32_values = {{0.0f, 1.125f, -2.125f}};
     msg->float64_values = {{0, 1.125, -2.125}};
     // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
@@ -285,7 +285,7 @@ get_messages_bounded_array_primitives()
     auto msg = std::make_shared<test_communication::msg::BoundedArrayPrimitives>();
     msg->bool_values = {{false, true, false}};
     msg->byte_values = {{0, 1, 0xff}};
-    msg->char_values = {{'\0', '\1', '\255'}};
+    msg->char_values = {{'\0', '\1', '\x7f'}};
     msg->float32_values = {{0.0f, 1.125f, -2.125f}};
     msg->float64_values = {{0, 1.125, -2.125}};
     // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)

--- a/test_communication/test/message_fixtures.py
+++ b/test_communication/test/message_fixtures.py
@@ -98,8 +98,8 @@ def get_msg_primitives():
     msg.bool_value = True
     msg.byte_value = bytes([1])
     msg.char_value = '\x01'
-    msg.float32_value = float(1.125)
-    msg.float64_value = float(1.125)
+    msg.float32_value = float(1.0)
+    msg.float64_value = float(1.0)
     msg.int8_value = 1
     msg.uint8_value = 1
     msg.int16_value = 1
@@ -264,56 +264,21 @@ def get_msg_dynamic_array_nested():
 
 def get_msg_bounded_array_primitives():
     msgs = []
-    msg = BoundedArrayPrimitives()
-    msg.bool_values = []
-    msg.char_values = []
-    msg.byte_values = []
-    msg.float32_values = []
-    msg.float64_values = []
-    msg.int8_values = []
-    msg.uint8_values = []
-    msg.int16_values = []
-    msg.uint16_values = []
-    msg.int32_values = []
-    msg.uint32_values = []
-    msg.int64_values = []
-    msg.uint64_values = []
-    msg.string_values = []
-    msg.check = 0
-    msgs.append(msg)
 
     msg = BoundedArrayPrimitives()
-    msg.bool_values = [True]
-    msg.byte_values = [bytes([255])]
-    msg.char_values = ['\x7f']
-    msg.float32_values = [1.125]
-    msg.float64_values = [1.125]
-    msg.int8_values = [127]
-    msg.uint8_values = [255]
-    msg.int16_values = [32767]
-    msg.uint16_values = [65535]
-    msg.int32_values = [2147483647]
-    msg.uint32_values = [4294967295]
-    msg.int64_values = [9223372036854775807]
-    msg.uint64_values = [18446744073709551615]
-    msg.string_values = ['max value']
-    msg.check = 1
-    msgs.append(msg)
-
-    msg = BoundedArrayPrimitives()
-    msg.bool_values = [False, True]
-    msg.byte_values = [bytes([0]), bytes([255])]
-    msg.char_values = ['\0', '\x7f']
+    msg.bool_values = [False, True, False]
+    msg.byte_values = [bytes([0]), bytes([1]), bytes([255])]
+    msg.char_values = ['\0', '\1', '\x7f']
     msg.float32_values = [0.0, 1.125, -2.125]
     msg.float64_values = [0.0, 1.125, -2.125]
     msg.int8_values = [0, 127, -128]
-    msg.uint8_values = [0, 255]
+    msg.uint8_values = [0, 1, 255]
     msg.int16_values = [0, 32767, -32768]
-    msg.uint16_values = [0, 65535]
+    msg.uint16_values = [0, 1, 65535]
     msg.int32_values = [0, 2147483647, -2147483648]
-    msg.uint32_values = [0, 4294967295]
+    msg.uint32_values = [0, 1, 4294967295]
     msg.int64_values = [0, 9223372036854775807, -9223372036854775808]
-    msg.uint64_values = [0, 18446744073709551615]
+    msg.uint64_values = [0, 1, 18446744073709551615]
     msg.string_values = ['', 'max value', 'optional min value']
     msg.check = 2
     msgs.append(msg)

--- a/test_communication/test/message_fixtures.py
+++ b/test_communication/test/message_fixtures.py
@@ -100,15 +100,16 @@ def get_msg_primitives():
     msg.char_value = '\x01'
     msg.float32_value = float(1.125)
     msg.float64_value = float(1.125)
-    msg.int8_value = int(1)
-    msg.uint8_value = int(1)
-    msg.int16_value = int(1)
-    msg.uint16_value = int(1)
-    msg.int32_value = int(1)
-    msg.uint32_value = int(1)
-    msg.int64_value = int(1)
-    msg.uint64_value = int(1)
+    msg.int8_value = 1
+    msg.uint8_value = 1
+    msg.int16_value = 1
+    msg.uint16_value = 1
+    msg.int32_value = 1
+    msg.uint32_value = 1
+    msg.int64_value = 1
+    msg.uint64_value = 1
     msg.string_value = ''
+    # check strings longer then 255 characters
     for i in range(256):
         msg.string_value += str(i % 10)
     msgs.append(msg)
@@ -194,7 +195,7 @@ def get_msg_dynamic_array_primitives():
     msg = DynamicArrayPrimitives()
     msg.bool_values = [True]
     msg.byte_values = [bytes([255])]
-    msg.char_values = [chr(0x7f)]
+    msg.char_values = ['\x7f']
     msg.float32_values = [1.125]
     msg.float64_values = [1.125]
     msg.int8_values = [127]
@@ -212,7 +213,7 @@ def get_msg_dynamic_array_primitives():
     msg = DynamicArrayPrimitives()
     msg.bool_values = [False, True]
     msg.byte_values = [bytes([0]), bytes([255])]
-    msg.char_values = [chr(0), chr(127)]
+    msg.char_values = ['\0', '\x7f']
     msg.float32_values = [0.0, 1.125, -2.125]
     msg.float64_values = [0.0, 1.125, -2.125]
     msg.int8_values = [0, 127, -128]
@@ -284,7 +285,7 @@ def get_msg_bounded_array_primitives():
     msg = BoundedArrayPrimitives()
     msg.bool_values = [True]
     msg.byte_values = [bytes([255])]
-    msg.char_values = [chr(0x7f)]
+    msg.char_values = ['\x7f']
     msg.float32_values = [1.125]
     msg.float64_values = [1.125]
     msg.int8_values = [127]
@@ -302,7 +303,7 @@ def get_msg_bounded_array_primitives():
     msg = BoundedArrayPrimitives()
     msg.bool_values = [False, True]
     msg.byte_values = [bytes([0]), bytes([255])]
-    msg.char_values = [chr(0), chr(127)]
+    msg.char_values = ['\0', '\x7f']
     msg.float32_values = [0.0, 1.125, -2.125]
     msg.float64_values = [0.0, 1.125, -2.125]
     msg.int8_values = [0, 127, -128]


### PR DESCRIPTION
This PR homogenize fixture between for cpp and python tests so that we can run multi rcl tests.
Note that char values are set to valid ASCII values the time we decide how to handle encoding.

Tests pass locally on opensplice and connext for all message types.
CI jobs:
- Linux:    [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1718)](http://ci.ros2.org/job/ci_linux/1718)
- OSX:    [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1283)](http://ci.ros2.org/job/ci_osx/1283)
- Windows:    [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1639)](http://ci.ros2.org/job/ci_windows/1639)