### PR TITLE
remove blocks and workarounds on service tests

### DIFF
--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -109,9 +109,6 @@ int main(int argc, char ** argv)
   std::string service = argv[1];
   auto node = rclcpp::Node::make_shared(std::string("test_requester_") + service);
 
-  // NOTE(esteve): sleep for two seconds to let the service start up
-  std::this_thread::sleep_for(std::chrono::seconds(2));
-
   int rc;
   if (service == "Empty") {
     rc = request<test_communication::srv::Empty>(

--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -16,7 +16,6 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
-#include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 #include <utility>
 #include <vector>
 
@@ -39,14 +38,8 @@ int request(
 {
   int rc = 0;
   auto requester = node->create_client<T>(std::string("test_service_") + service_type);
-  {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
-    try {
-      if (!requester->wait_for_service(20_s)) {
-        throw std::runtime_error("requester service not available after waiting");
-      }
-    } catch (rclcpp::exceptions::RCLError) {
-      std::this_thread::sleep_for(1_s);
-    }
+  if (!requester->wait_for_service(20_s)) {
+    throw std::runtime_error("requester service not available after waiting");
   }
 
   rclcpp::WallRate cycle_rate(10);

--- a/test_rclcpp/test/test_client_scope_client.cpp
+++ b/test_rclcpp/test/test_client_scope_client.cpp
@@ -14,7 +14,6 @@
 
 #include <iostream>
 #include <memory>
-#include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 
 #include "gtest/gtest.h"
 #include "rclcpp/exceptions.hpp"
@@ -36,14 +35,8 @@ TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_regression_test
     printf("creating first client\n");
     std::cout.flush();
     auto client1 = node->create_client<test_rclcpp::srv::AddTwoInts>("client_scope");
-    {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
-      try {
-        if (!client1->wait_for_service(20_s)) {
-          ASSERT_TRUE(false) << "service not available after waiting";
-        }
-      } catch (rclcpp::exceptions::RCLError) {
-        std::this_thread::sleep_for(1_s);
-      }
+    if (!client1->wait_for_service(20_s)) {
+      ASSERT_TRUE(false) << "service not available after waiting";
     }
     auto request1 = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
     request1->a = 1;
@@ -69,14 +62,8 @@ TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_regression_test
     printf("creating second client\n");
     std::cout.flush();
     auto client2 = node->create_client<test_rclcpp::srv::AddTwoInts>("client_scope");
-    {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
-      try {
-        if (!client2->wait_for_service(20_s)) {
-          ASSERT_TRUE(false) << "service not available after waiting";
-        }
-      } catch (rclcpp::exceptions::RCLError) {
-        std::this_thread::sleep_for(1_s);
-      }
+    if (!client2->wait_for_service(20_s)) {
+      ASSERT_TRUE(false) << "service not available after waiting";
     }
     auto request2 = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
     request2->a = 2;

--- a/test_rclcpp/test/test_client_wait_for_service_shutdown.cpp
+++ b/test_rclcpp/test/test_client_wait_for_service_shutdown.cpp
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 #include <chrono>
-#include <string>  // TODO(wjwwood): remove me when fastrtps exclusion is removed
 #include <thread>
 
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
-#include "rmw/rmw.h"  // TODO(wjwwood): remove me when fastrtps exclusion is removed
 #include "test_rclcpp/srv/add_two_ints.hpp"
 
 #ifdef RMW_IMPLEMENTATION
@@ -30,10 +28,6 @@
 
 // rclcpp::shutdown() should wake up wait_for_service, even without spin.
 TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), wait_for_service_shutdown) {
-  // TODO(wjwwood): remove this "skip" when Connext and FastRTPS support wait_for_service.
-  if (std::string(rmw_get_implementation_identifier()) != "rmw_opensplice_cpp") {
-    return;
-  }
   rclcpp::init(0, nullptr);
   auto node = rclcpp::node::Node::make_shared("wait_for_service_shutdown");
 

--- a/test_rclcpp/test/test_executor.cpp
+++ b/test_rclcpp/test/test_executor.cpp
@@ -17,7 +17,6 @@
 #include <future>
 #include <stdexcept>
 #include <string>
-#include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 
 #include "gtest/gtest.h"
 
@@ -205,14 +204,8 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), notify) {
     auto client = node->create_client<test_rclcpp::srv::AddTwoInts>(
       "test_executor_notify_service"
       );
-    {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
-      try {
-        if (!client->wait_for_service(20_s)) {
-          ASSERT_TRUE(false) << "service not available after waiting";
-        }
-      } catch (rclcpp::exceptions::RCLError) {
-        std::this_thread::sleep_for(1_s);
-      }
+    if (!client->wait_for_service(20_s)) {
+      ASSERT_TRUE(false) << "service not available after waiting";
     }
     auto request = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
     request->a = 4;

--- a/test_rclcpp/test/test_multiple_service_calls.cpp
+++ b/test_rclcpp/test/test_multiple_service_calls.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <iostream>
-#include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 #include <utility>
 #include <vector>
 
@@ -45,14 +44,8 @@ TEST(CLASSNAME(test_two_service_calls, RMW_IMPLEMENTATION), two_service_calls) {
     "test_two_service_calls", handle_add_two_ints);
 
   auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("test_two_service_calls");
-  {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
-    try {
-      if (!client->wait_for_service(20_s)) {
-        ASSERT_TRUE(false) << "service not available after waiting";
-      }
-    } catch (rclcpp::exceptions::RCLError) {
-      std::this_thread::sleep_for(1_s);
-    }
+  if (!client->wait_for_service(20_s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
   }
 
   auto request1 = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
@@ -113,14 +106,8 @@ TEST(CLASSNAME(test_multiple_service_calls, RMW_IMPLEMENTATION), multiple_client
   fflush(stdout);
   // Send all the requests
   for (auto & pair : client_request_pairs) {
-    {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
-      try {
-        if (!pair.first->wait_for_service(20_s)) {
-          ASSERT_TRUE(false) << "service not available after waiting";
-        }
-      } catch (rclcpp::exceptions::RCLError) {
-        std::this_thread::sleep_for(1_s);
-      }
+    if (!pair.first->wait_for_service(20_s)) {
+      ASSERT_TRUE(false) << "service not available after waiting";
     }
     results.push_back(pair.first->async_send_request(pair.second));
   }

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -14,7 +14,6 @@
 
 #include <limits>
 #include <string>
-#include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 #include <utility>
 #include <vector>
 
@@ -194,14 +193,8 @@ TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_clients) 
     std::vector<SharedFuture> results;
     // Send all the requests
     for (auto & pair : client_request_pairs) {
-      {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
-        try {
-          if (!pair.first->wait_for_service(20_s)) {
-            ASSERT_TRUE(false) << "service not available after waiting";
-          }
-        } catch (rclcpp::exceptions::RCLError) {
-          std::this_thread::sleep_for(1_s);
-        }
+      if (!pair.first->wait_for_service(20_s)) {
+        ASSERT_TRUE(false) << "service not available after waiting";
       }
       results.push_back(pair.first->async_send_request(pair.second));
     }
@@ -225,14 +218,8 @@ TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_clients) 
     std::vector<SharedFuture> results;
     // Send all the requests again
     for (auto & pair : client_request_pairs) {
-      {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
-        try {
-          if (!pair.first->wait_for_service(20_s)) {
-            ASSERT_TRUE(false) << "service not available after waiting";
-          }
-        } catch (rclcpp::exceptions::RCLError) {
-          std::this_thread::sleep_for(1_s);
-        }
+      if (!pair.first->wait_for_service(20_s)) {
+        ASSERT_TRUE(false) << "service not available after waiting";
       }
       results.push_back(pair.first->async_send_request(pair.second));
     }
@@ -333,7 +320,7 @@ TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_access_publisher_i
 
 int main(int argc, char ** argv)
 {
-  // NOTE: use custom main to ensure that rclcpp::init is called only once
+  // use custom main to ensure that rclcpp::init is called only once
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test_rclcpp/test/test_services_client.cpp
+++ b/test_rclcpp/test/test_services_client.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-#include <thread>
 
 #include "gtest/gtest.h"
 
@@ -37,14 +36,8 @@ TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_noreqid) {
   request->a = 1;
   request->b = 2;
 
-  {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
-    try {
-      if (!client->wait_for_service(20_s)) {
-        ASSERT_TRUE(false) << "service not available after waiting";
-      }
-    } catch (rclcpp::exceptions::RCLError) {
-      std::this_thread::sleep_for(1_s);
-    }
+  if (!client->wait_for_service(20_s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
   }
 
   auto result = client->async_send_request(request);
@@ -63,14 +56,8 @@ TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_reqid) {
   request->a = 4;
   request->b = 5;
 
-  {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
-    try {
-      if (!client->wait_for_service(20_s)) {
-        ASSERT_TRUE(false) << "service not available after waiting";
-      }
-    } catch (rclcpp::exceptions::RCLError) {
-      std::this_thread::sleep_for(1_s);
-    }
+  if (!client->wait_for_service(20_s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
   }
 
   auto result = client->async_send_request(request);
@@ -90,14 +77,8 @@ TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_return_request) {
   request->a = 4;
   request->b = 5;
 
-  {  // TODO(wjwwood): remove this block when Connext and FastRTPS support wait_for_service.
-    try {
-      if (!client->wait_for_service(20_s)) {
-        ASSERT_TRUE(false) << "service not available after waiting";
-      }
-    } catch (rclcpp::exceptions::RCLError) {
-      std::this_thread::sleep_for(1_s);
-    }
+  if (!client->wait_for_service(20_s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
   }
 
   auto result = client->async_send_request(


### PR DESCRIPTION
This should not be merged with eProsima/ROS-RMW-Fast-RTPS-cpp#56, but can be used for testing it, if Connext is not tested at the same time.

This can be merged once Connext has been updated to support wait_for_service complete as well (in progress).

Connects to eProsima/ROS-RMW-Fast-RTPS-cpp#56