### PR TITLE
Enable python fastrtps

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -187,13 +187,12 @@ if(BUILD_TESTING)
   endmacro()
 
   macro(custom_test_py)
-    # adding python tests
+    # test publish / subscribe messages
     find_package(rmw_implementation_cmake REQUIRED)
     set(TEST_PUBLISHER_PY_EXECUTABLE "${CMAKE_CURRENT_SOURCE_DIR}/test/publisher_py.py")
     set(TEST_SUBSCRIBER_PY_EXECUTABLE "${CMAKE_CURRENT_SOURCE_DIR}/test/subscriber_py.py")
-    # TODO(mikaelarguedas) edit this once typesupport_introspection_c merged in fastrtps
     # TODO(mikaelarguedas) edit this once connext_dynamic working with all message types
-    if(NOT (rmw_implementation1 STREQUAL "rmw_fastrtps_cpp" OR rmw_implementation1 STREQUAL "rmw_connext_dynamic_cpp"))
+    if(NOT rmw_implementation1 STREQUAL "rmw_connext_dynamic_cpp")
       get_rmw_typesupport(typesupport_c_impl "${rmw_implementation1}" LANGUAGE "c")
       set(TEST_RMW_IMPLEMENTATION_PY "${rmw_implementation1}")
       if(NOT typesupport_c_impl STREQUAL "")

--- a/test_communication/test/publisher_py.py
+++ b/test_communication/test/publisher_py.py
@@ -51,7 +51,7 @@ def talker(message_name, rmw_implementation, number_of_cycles):
             chatter_pub.publish(msg)
             msg_count += 1
             print('publishing message #%d' % msg_count)
-            time.sleep(0.1)
+        print('cycle_count: ' + str(cycle_count))
         time.sleep(1)
     rclpy.shutdown()
 
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     parser.add_argument('-r', '--rmw_implementation', default=rmw_implementations[0],
                         choices=rmw_implementations,
                         help='rmw_implementation identifier')
-    parser.add_argument('-n', '--number_of_cycles', type=int, default=10,
+    parser.add_argument('-n', '--number_of_cycles', type=int, default=20,
                         help='number of sending attempts')
     args = parser.parse_args()
     try:

--- a/test_communication/test/subscriber_py.py
+++ b/test_communication/test/subscriber_py.py
@@ -74,6 +74,7 @@ def listener(message_name, rmw_implementation, number_of_cycles):
            len(received_messages) != len(expected_msgs)):
         rclpy.spin_once(node)
         spin_count += 1
+        print('spin_count: ' + str(spin_count))
     rclpy.shutdown()
 
     assert len(received_messages) == len(expected_msgs),\
@@ -88,7 +89,7 @@ if __name__ == '__main__':
     parser.add_argument('-r', '--rmw_implementation', default=rmw_implementations[0],
                         choices=rmw_implementations,
                         help='rmw_implementation identifier')
-    parser.add_argument('-n', '--number_of_cycles', type=int, default=10,
+    parser.add_argument('-n', '--number_of_cycles', type=int, default=50,
                         help='number of sending attempts')
     args = parser.parse_args()
     try:


### PR DESCRIPTION
this PR enables python tests for fastrtps now that c typesupport works for all message types.

Note: this PR also extends the maximum number of `spin_once` acceptable per test given that fastrtps calls  `rcl_take_with_info` several times per second even if no message is received. This required more investigation and will be addressed in a follow-up PR

Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1759)](http://ci.ros2.org/job/ci_linux/1759)
OSX: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1308)](http://ci.ros2.org/job/ci_osx/1308/)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1680)](http://ci.ros2.org/job/ci_windows/1680/)