### PR TITLE
comply with stricter cpplint rules

### DIFF
--- a/test_communication/test/message_fixtures.hpp
+++ b/test_communication/test/message_fixtures.hpp
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <limits>
+#include <memory>
 #include <vector>
 
 #include "test_communication/msg/bounded_array_nested.hpp"

--- a/test_communication/test/service_fixtures.hpp
+++ b/test_communication/test/service_fixtures.hpp
@@ -15,6 +15,7 @@
 #ifndef SERVICE_FIXTURES_HPP_
 #define SERVICE_FIXTURES_HPP_
 
+#include <memory>
 #include <utility>
 #include <vector>
 

--- a/test_communication/test/test_subscription_valid_data.cpp
+++ b/test_communication/test/test_subscription_valid_data.cpp
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"

--- a/test_rclcpp/include/test_rclcpp/utils.hpp
+++ b/test_rclcpp/include/test_rclcpp/utils.hpp
@@ -15,8 +15,8 @@
 #ifndef TEST_RCLCPP__UTILS_HPP_
 #define TEST_RCLCPP__UTILS_HPP_
 
-
 #include <cinttypes>
+#include <memory>
 #include <stdexcept>
 #include <string>
 
@@ -60,7 +60,6 @@ void busy_wait_for_subscriber(
     time_slept_count,
     topic_name.c_str());
 }
-
 
 }  // namespace test_rclcpp
 

--- a/test_rclcpp/test/parameter_fixtures.hpp
+++ b/test_rclcpp/test/parameter_fixtures.hpp
@@ -16,6 +16,7 @@
 #define PARAMETER_FIXTURES_HPP_
 
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/test_rclcpp/test/test_executor.cpp
+++ b/test_rclcpp/test/test_executor.cpp
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <cinttypes>
 #include <future>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed

--- a/test_rclcpp/test/test_intra_process.cpp
+++ b/test_rclcpp/test/test_intra_process.cpp
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <memory>
 
 #include "gtest/gtest.h"
 

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <cstdint>

--- a/test_rclcpp/test/test_multiple_service_calls.cpp
+++ b/test_rclcpp/test/test_multiple_service_calls.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <iostream>
+#include <memory>
 #include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 #include <utility>
 #include <vector>

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <limits>
+#include <memory>
 #include <string>
 #include <thread>  // TODO(wjwwood): remove me when Connext and FastRTPS exclusions are removed
 #include <utility>

--- a/test_rclcpp/test/test_parameters_server.cpp
+++ b/test_rclcpp/test/test_parameters_server.cpp
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 #include <string>
 

--- a/test_rclcpp/test/test_remote_parameters.cpp
+++ b/test_rclcpp/test/test_remote_parameters.cpp
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 #include <string>
 

--- a/test_rclcpp/test/test_repeated_publisher_subscriber.cpp
+++ b/test_rclcpp/test/test_repeated_publisher_subscriber.cpp
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <memory>
 
 #include "gtest/gtest.h"
 

--- a/test_rclcpp/test/test_services_client.cpp
+++ b/test_rclcpp/test/test_services_client.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <chrono>
+#include <memory>
 #include <thread>
 
 #include "gtest/gtest.h"

--- a/test_rclcpp/test/test_services_server.cpp
+++ b/test_rclcpp/test/test_services_server.cpp
@@ -16,6 +16,8 @@
 
 #include <test_rclcpp/srv/add_two_ints.hpp>
 
+#include <memory>
+
 void handle_add_two_ints_noreqid(
   const std::shared_ptr<test_rclcpp::srv::AddTwoInts::Request> request,
   std::shared_ptr<test_rclcpp::srv::AddTwoInts::Response> response)

--- a/test_rclcpp/test/test_spin.cpp
+++ b/test_rclcpp/test/test_spin.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <future>
 #include <iostream>
+#include <memory>
 #include <thread>
 
 #include "gtest/gtest.h"

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <future>
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
Update style to pass new cpplint check (ament/ament_lint#59).

http://ci.ros2.org/job/ci_linux/1763/