### PR TITLE
fix pyflakes

### DIFF
--- a/test_communication/test/publisher_py.py
+++ b/test_communication/test/publisher_py.py
@@ -26,7 +26,6 @@ def talker(message_name, number_of_cycles):
     from message_fixtures import get_test_msg
     import rclpy
     from rclpy.impl.rmw_implementation_tools import select_rmw_implementation
-    from rclpy.impl.rmw_implementation_tools import get_rmw_implementations
     from rclpy.qos import qos_profile_default
 
     message_pkg = 'test_communication'

--- a/test_communication/test/subscriber_py.py
+++ b/test_communication/test/subscriber_py.py
@@ -46,7 +46,6 @@ def listener(message_name, number_of_cycles):
     from message_fixtures import get_test_msg
     import rclpy
     from rclpy.impl.rmw_implementation_tools import select_rmw_implementation
-    from rclpy.impl.rmw_implementation_tools import get_rmw_implementations
     from rclpy.qos import qos_profile_default
 
     message_pkg = 'test_communication'


### PR DESCRIPTION
Remove unused module since https://github.com/ros2/system_tests/pull/152/commits/55d6d75f2684f78d3ae17b508ac1c4bbeba893c8

should fix: http://ci.ros2.org/job/ci_windows/1806/testReport/junit/test_communication/pyflakes/UnusedImport__test_publisher_py_py_29_/