### PR TITLE
test loong strings for services

### DIFF
--- a/test_communication/test/service_fixtures.hpp
+++ b/test_communication/test/service_fixtures.hpp
@@ -107,7 +107,11 @@ get_services_primitives()
     request->uint32_value = 6;
     request->int64_value = 7;
     request->uint64_value = 8;
-    request->string_value = "request";
+    // check strings longer then 256 characters
+    request->string_value = "";
+    for (size_t i = 0; i < 20000; ++i) {
+      request->string_value += std::to_string(i % 10);
+    }
     auto reply = std::make_shared<test_communication::srv::Primitives::Response>();
     reply->bool_value = true;
     reply->byte_value = 11;
@@ -122,7 +126,11 @@ get_services_primitives()
     reply->uint32_value = 66;
     reply->int64_value = 77;
     reply->uint64_value = 88;
-    reply->string_value = "reply";
+    // check strings longer then 256 characters
+    reply->string_value = "";
+    for (size_t i = 0; i < 20000; ++i) {
+      reply->string_value += std::to_string(i % 10);
+    }
     services.emplace_back(request, reply);
   }
   return services;

--- a/test_communication/test/service_fixtures.py
+++ b/test_communication/test/service_fixtures.py
@@ -71,7 +71,10 @@ def get_msg_primitives():
     req.uint32_value = 6
     req.int64_value = 7
     req.uint64_value = 8
-    req.string_value = 'request'
+    # check strings longer then 256 characters
+    req.string_value = ''
+    for i in range(20000):
+        req.string_value += str(i % 10)
     resp = Primitives.Response()
     resp.bool_value = True
     resp.byte_value = bytes([11])
@@ -86,7 +89,10 @@ def get_msg_primitives():
     resp.uint32_value = 66
     resp.int64_value = 77
     resp.uint64_value = 88
-    resp.string_value = 'reply'
+    # check strings longer then 256 characters
+    resp.string_value = ''
+    for i in range(20000):
+        resp.string_value += str(i % 10)
     srvs.append([req, resp])
     return srvs
 


### PR DESCRIPTION
Extend test suite to test strings longer than 256 for services. This relies on https://github.com/ros2/rmw_fastrtps/issues/71