### PR TITLE
rclpy tests match rclcpp timing

### DIFF
--- a/test_communication/test/publisher_py.py
+++ b/test_communication/test/publisher_py.py
@@ -45,20 +45,21 @@ def talker(message_name, number_of_cycles):
     print('talker: beginning loop')
     msgs = get_test_msg(message_name)
     while rclpy.ok() and cycle_count < number_of_cycles:
-        cycle_count += 1
         msg_count = 0
         for msg in msgs:
             chatter_pub.publish(msg)
             msg_count += 1
             print('publishing message #%d' % msg_count)
-        time.sleep(1)
+            time.sleep(0.01)
+        cycle_count += 1
+        time.sleep(0.1)
     rclpy.shutdown()
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('message_name', default='Primitives',
                         help='name of the ROS message')
-    parser.add_argument('-n', '--number_of_cycles', type=int, default=20,
+    parser.add_argument('-n', '--number_of_cycles', type=int, default=100,
                         help='number of sending attempts')
     args = parser.parse_args()
     try:

--- a/test_communication/test/subscriber_py.py
+++ b/test_communication/test/subscriber_py.py
@@ -42,7 +42,7 @@ def listener_cb(msg, received_messages, expected_msgs):
         raise RuntimeError('received unexpected message %r' % msg)
 
 
-def listener(message_name, number_of_cycles):
+def listener(message_name):
     from message_fixtures import get_test_msg
     import rclpy
     from rclpy.impl.rmw_implementation_tools import select_rmw_implementation
@@ -70,8 +70,7 @@ def listener(message_name, number_of_cycles):
 
     spin_count = 1
     print('subscriber: beginning loop')
-    while (rclpy.ok() and spin_count < number_of_cycles and
-           len(received_messages) != len(expected_msgs)):
+    while (rclpy.ok() and len(received_messages) != len(expected_msgs)):
         rclpy.spin_once(node)
         spin_count += 1
         print('spin_count: ' + str(spin_count))
@@ -84,13 +83,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('message_name', default='Primitives',
                         help='name of the ROS message')
-    parser.add_argument('-n', '--number_of_cycles', type=int, default=50,
-                        help='number of sending attempts')
     args = parser.parse_args()
     try:
-        listener(
-            message_name=args.message_name,
-            number_of_cycles=args.number_of_cycles)
+        listener(message_name=args.message_name)
     except KeyboardInterrupt:
         print('subscriber stopped cleanly')
     except BaseException:


### PR DESCRIPTION
Publishers in python and c++ don't wait the same time between messages and message bursts.
This PR makes them have the same behavior e.g. send message burst every 100ms and stop publishing after 10s.
Can't say for sure that it reduce the number of failing/flaky pub/sub tests but will at least help to narrow it down.
Should also prevent test to timeout with missing results