### PR TITLE
Install msgs and fixtures for use by other packages

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -14,13 +14,6 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-# get the rmw implementations ahead of time
-find_package(rmw_implementation_cmake REQUIRED)
-get_available_rmw_implementations(rmw_implementations2)
-foreach(rmw_implementation ${rmw_implementations2})
-  find_package("${rmw_implementation}" REQUIRED)
-endforeach()
-
 set(message_files
   "msg/BoundedArrayNested.msg"
   "msg/BoundedArrayPrimitives.msg"
@@ -51,6 +44,13 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  # get the rmw implementations ahead of time
+  find_package(rmw_implementation_cmake REQUIRED)
+  get_available_rmw_implementations(rmw_implementations2)
+  foreach(rmw_implementation ${rmw_implementations2})
+    find_package("${rmw_implementation}" REQUIRED)
+  endforeach()
 
   function(custom_test target with_message_argument)
     if(with_message_argument)

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -11,45 +11,46 @@ else()
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+# get the rmw implementations ahead of time
+find_package(rmw_implementation_cmake REQUIRED)
+get_available_rmw_implementations(rmw_implementations2)
+foreach(rmw_implementation ${rmw_implementations2})
+  find_package("${rmw_implementation}" REQUIRED)
+endforeach()
+
+set(message_files
+  "msg/BoundedArrayNested.msg"
+  "msg/BoundedArrayPrimitives.msg"
+  "msg/Builtins.msg"
+  "msg/DynamicArrayNested.msg"
+  "msg/DynamicArrayPrimitives.msg"
+  "msg/Empty.msg"
+  "msg/Nested.msg"
+  "msg/Primitives.msg"
+  "msg/StaticArrayNested.msg"
+  "msg/StaticArrayPrimitives.msg"
+)
+set(other_message_files
+  "msg/FieldsWithSameType.msg"
+  "msg/UInt32.msg"
+)
+set(service_files
+  "srv/Empty.srv"
+  "srv/Primitives.srv"
+)
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${message_files}
+  ${other_message_files}
+  ${service_files}
+  DEPENDENCIES builtin_interfaces
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-
-  # get the rmw implementations ahead of time
-  find_package(rmw_implementation_cmake REQUIRED)
-  get_available_rmw_implementations(rmw_implementations2)
-  foreach(rmw_implementation ${rmw_implementations2})
-    find_package("${rmw_implementation}" REQUIRED)
-  endforeach()
-
-  set(message_files
-    "msg/BoundedArrayNested.msg"
-    "msg/BoundedArrayPrimitives.msg"
-    "msg/Builtins.msg"
-    "msg/DynamicArrayNested.msg"
-    "msg/DynamicArrayPrimitives.msg"
-    "msg/Empty.msg"
-    "msg/Nested.msg"
-    "msg/Primitives.msg"
-    "msg/StaticArrayNested.msg"
-    "msg/StaticArrayPrimitives.msg"
-  )
-  set(other_message_files
-    "msg/FieldsWithSameType.msg"
-    "msg/UInt32.msg"
-  )
-  set(service_files
-    "srv/Empty.srv"
-    "srv/Primitives.srv"
-  )
-  rosidl_generate_interfaces(${PROJECT_NAME}
-    ${message_files}
-    ${other_message_files}
-    ${service_files}
-    DEPENDENCIES builtin_interfaces
-    SKIP_INSTALL
-  )
 
   function(custom_test target with_message_argument)
     if(with_message_argument)
@@ -322,5 +323,7 @@ if(BUILD_TESTING)
   call_for_each_rmw_implementation(targets)
 endif()  # BUILD_TESTING
 
-# TODO should not install anything
+install(FILES test/__init__.py test/message_fixtures.py
+  DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}")
+
 ament_package()

--- a/test_communication/package.xml
+++ b/test_communication/package.xml
@@ -13,13 +13,9 @@
 
   <build_depend>ament_cmake_auto</build_depend>
   <build_depend>builtin_interfaces</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclpy</build_depend>
-  <build_depend>rcl</build_depend>
   <build_depend>rmw_implementation</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>rosidl_default_generators</build_depend>
-  <build_depend>rosidl_default_runtime</build_depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
@@ -28,6 +24,11 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>launch</test_depend>
+  <test_depend>rclcpp</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>rcl</test_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/test_communication/package.xml
+++ b/test_communication/package.xml
@@ -11,21 +11,23 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>ament_cmake_auto</build_depend>
+  <build_depend>builtin_interfaces</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rclpy</build_depend>
+  <build_depend>rcl</build_depend>
+  <build_depend>rmw_implementation</build_depend>
+  <build_depend>rmw_implementation_cmake</build_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <build_depend>rosidl_default_runtime</build_depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>builtin_interfaces</test_depend>
   <test_depend>launch</test_depend>
-  <test_depend>rcl</test_depend>
-  <test_depend>rclcpp</test_depend>
-  <test_depend>rclpy</test_depend>
-  <test_depend>rmw_implementation</test_depend>
-  <test_depend>rmw_implementation_cmake</test_depend>
-  <test_depend>rosidl_default_generators</test_depend>
-  <test_depend>rosidl_default_runtime</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/test_communication/package.xml
+++ b/test_communication/package.xml
@@ -13,11 +13,11 @@
 
   <build_depend>ament_cmake_auto</build_depend>
   <build_depend>builtin_interfaces</build_depend>
-  <build_depend>rmw_implementation</build_depend>
-  <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
@@ -27,8 +27,8 @@
   <test_depend>rclcpp</test_depend>
   <test_depend>rclpy</test_depend>
   <test_depend>rcl</test_depend>
-
-  <exec_depend>rosidl_default_runtime</exec_depend>
+  <test_depend>rmw_implementation</test_depend>
+  <test_depend>rmw_implementation_cmake</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
When implementing tests for `rostopic_echo_py` (https://github.com/ros2/cli_tools/pull/5), I had need of a bunch of messages to push through the YAML and CSV converters. This PR installs the messages and related fixtures so that they can be used in testing other packages.

http://ci.ros2.org/job/ci_linux/2314/
http://ci.ros2.org/job/ci_osx/1769/
http://ci.ros2.org/job/ci_windows/2343/