### PR TITLE
Add missing exec dep on builtin_interfaces

### DIFF
--- a/test_communication/package.xml
+++ b/test_communication/package.xml
@@ -16,8 +16,8 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/test_communication/package.xml
+++ b/test_communication/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
 
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
`test_communication` fixtures need `builtin_interfaces`. Unveiled by `cli_tools/test_primitives` using these for testing.
This should fix the failing `cli_tools/test_primitives` test on all nightlies: e.g http://ci.ros2.org/view/nightly/job/nightly_linux_release/lastSuccessfulBuild/testReport/(root)/test_primitives/test_primitives/