### PR TITLE
Fix tests for many core machines

### DIFF
--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <chrono>
 #include <limits>
 #include <memory>
@@ -64,7 +65,7 @@ static inline void multi_consumer_pub_sub_test(bool intra_process)
 
   rclcpp::executors::MultiThreadedExecutor executor;
   // Try to saturate the MultithreadedExecutor's thread pool with subscriptions
-  for (uint32_t i = 0; i < executor.get_number_of_threads(); i++) {
+  for (uint32_t i = 0; i < std::min<unsigned int>(executor.get_number_of_threads(), 16); i++) {
     auto sub = node->create_subscription<test_rclcpp::msg::UInt32>(node_topic_name, 16, callback,
         callback_group);
     subscriptions.push_back(sub);
@@ -162,7 +163,7 @@ TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_clients) 
     };
 
   rmw_qos_profile_t qos_profile = rmw_qos_profile_services_default;
-  qos_profile.depth = executor.get_number_of_threads() * 2;
+  qos_profile.depth = std::min<unsigned int>(executor.get_number_of_threads(), 16) * 2;
   auto callback_group = node->create_callback_group(
     rclcpp::callback_group::CallbackGroupType::Reentrant);
   auto service = node->create_service<test_rclcpp::srv::AddTwoInts>(
@@ -175,7 +176,7 @@ TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_clients) 
 
 
   std::vector<ClientRequestPair> client_request_pairs;
-  for (uint32_t i = 0; i < 2 * executor.get_number_of_threads(); ++i) {
+  for (uint32_t i = 0; i < 2 * std::min<unsigned int>(executor.get_number_of_threads(), 16); ++i) {
     auto client = node->create_client<test_rclcpp::srv::AddTwoInts>(
       "multi_consumer_clients", qos_profile, callback_group);
     auto request = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
@@ -202,10 +203,11 @@ TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_clients) 
       }
       results.push_back(pair.first->async_send_request(pair.second));
     }
-    // Wait on the future produced by the first request
-    auto result = executor.spin_until_future_complete(results.back());
-
-    ASSERT_EQ(result, rclcpp::executor::FutureReturnCode::SUCCESS);
+    // Wait on each future
+    for (uint32_t i = 0; i < results.size(); i++) {
+      auto result = executor.spin_until_future_complete(results[i]);
+      ASSERT_EQ(result, rclcpp::executor::FutureReturnCode::SUCCESS);
+    }
 
     // Check the status of all futures
     for (uint32_t i = 0; i < results.size(); i++) {
@@ -265,7 +267,7 @@ static inline void multi_access_publisher(bool intra_process)
 
   rclcpp::executors::MultiThreadedExecutor executor;
 
-  const size_t num_messages = 5 * executor.get_number_of_threads();
+  const size_t num_messages = 5 * std::min<unsigned int>(executor.get_number_of_threads(), 16);
   auto pub = node->create_publisher<test_rclcpp::msg::UInt32>(node_topic_name, num_messages);
   // callback groups?
   auto msg = std::make_shared<test_rclcpp::msg::UInt32>();
@@ -295,7 +297,7 @@ static inline void multi_access_publisher(bool intra_process)
     };
   std::vector<rclcpp::timer::TimerBase::SharedPtr> timers;
   // timers will fire simultaneously in each thread
-  for (uint32_t i = 0; i < executor.get_number_of_threads(); i++) {
+  for (uint32_t i = 0; i < std::min<unsigned int>(executor.get_number_of_threads(), 16); i++) {
     timers.push_back(node->create_wall_timer(std::chrono::milliseconds(1), timer_callback));
   }
 
@@ -304,8 +306,8 @@ static inline void multi_access_publisher(bool intra_process)
       ++subscription_counter;
       printf("Subscription callback %u\n", subscription_counter.load());
     };
-  auto sub = node->create_subscription<test_rclcpp::msg::UInt32>(node_topic_name, sub_callback,
-      rmw_qos_profile_default,
+  auto sub = node->create_subscription<test_rclcpp::msg::UInt32>(node_topic_name, num_messages,
+      sub_callback,
       sub_callback_group);
   executor.add_node(node);
   executor.spin();


### PR DESCRIPTION
This PR addresses failures that have come up since we started running on 96-core ARM servers:

* In general, cap the internal test parallelism at 16, independent of how many cores the machine has.
* In one case, adjust the spin_until logic to wait for *all* futures to complete instead of waiting for just one (the old behavior is presumably reliable for a low level of parallelism, but it's not when you go wide).
* In one case, adjust the subscriber-side queue length to accommodate the expected number of messages (again, the old behavior is presumably reliable for low parallelism).