### PR TITLE
add test for avoid_ros_namespace_conventions qos

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -96,6 +96,9 @@ if(BUILD_TESTING)
     custom_gtest(gtest_publisher
       "test/test_publisher.cpp"
       TIMEOUT 15)
+    custom_gtest(gtest_avoid_ros_namespace_conventions_qos
+      "test/test_avoid_ros_namespace_conventions_qos.cpp"
+      TIMEOUT 15)
     custom_gtest(gtest_client_wait_for_service_shutdown
       "test/test_client_wait_for_service_shutdown.cpp"
       TIMEOUT 15)

--- a/test_rclcpp/test/pub_sub_fixtures.hpp
+++ b/test_rclcpp/test/pub_sub_fixtures.hpp
@@ -38,6 +38,7 @@ single_message_pub_sub_fixture(
   std::function<
     void(typename rclcpp::Publisher<MessageT>::SharedPtr, typename MessageT::SharedPtr)
   > publish_func,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
   std::function<void(rclcpp::executors::SingleThreadedExecutor &)> pre_subscription_hook = nullptr,
   size_t max_retries = 3,  // number of times it will try to publish
   size_t max_loops = 200,  // number of times it will check for data
@@ -46,7 +47,7 @@ single_message_pub_sub_fixture(
   auto node = rclcpp::Node::make_shared(topic_name + "_node");
 
   auto publisher = node->create_publisher<MessageT>(
-    topic_name, rmw_qos_profile_default);
+    topic_name, custom_qos);
 
   auto msg = std::make_shared<MessageT>();
   msg->data = 0;

--- a/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
+++ b/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
@@ -1,0 +1,81 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <iostream>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "test_rclcpp/msg/u_int32.hpp"
+#include "test_rclcpp/utils.hpp"
+
+#include "./pub_sub_fixtures.hpp"
+
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+// Test communciation works with the avoid_ros_namespace_conventions QoS enabled.
+TEST(
+  CLASSNAME(test_avoid_ros_namespace_conventions_qos, RMW_IMPLEMENTATION),
+  pub_sub_works
+) {
+  // topic name
+  std::string topic_name = "test_avoid_ros_namespace_conventions_qos";
+  // code to create the callback and subscription
+  int counter = 0;
+  auto callback =
+    [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg,
+      const rmw_message_info_t & info) -> void
+    {
+      ++counter;
+      printf("  callback() %d with message data %u\n", counter, msg->data);
+      ASSERT_FALSE(info.from_intra_process);
+    };
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
+  custom_qos.avoid_ros_namespace_conventions = true;
+  auto create_subscription_func =
+    [&callback, &custom_qos](
+    rclcpp::Node::SharedPtr node,
+    const std::string & topic_name) -> rclcpp::Subscription<test_rclcpp::msg::UInt32>::SharedPtr
+    {
+      auto subscriber = node->create_subscription<test_rclcpp::msg::UInt32>(
+        topic_name, callback, custom_qos);
+      return subscriber;
+    };
+  // code to do the publish function
+  auto publish_func =
+    [&custom_qos](
+    rclcpp::Publisher<test_rclcpp::msg::UInt32>::SharedPtr publisher,
+    test_rclcpp::msg::UInt32::SharedPtr msg)
+    {
+      publisher->publish(msg);
+    };
+  // call the test template
+  single_message_pub_sub_fixture<test_rclcpp::msg::UInt32>(
+    topic_name, counter, create_subscription_func, publish_func, custom_qos);
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test_rclcpp/test/test_client_scope_consistency_client.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_client.cpp
@@ -41,7 +41,8 @@ TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_consistency_reg
     RMW_QOS_POLICY_HISTORY_KEEP_LAST,
     10,
     RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE
+    RMW_QOS_POLICY_DURABILITY_VOLATILE,
+    false
   };
   rclcpp::executor::FutureReturnCode ret1;
 

--- a/test_rclcpp/test/test_client_scope_consistency_server.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_server.cpp
@@ -39,7 +39,8 @@ int main(int argc, char ** argv)
     RMW_QOS_POLICY_HISTORY_KEEP_LAST,
     10,
     RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE
+    RMW_QOS_POLICY_DURABILITY_VOLATILE,
+    false
   };
   auto service = node->create_service<test_rclcpp::srv::AddTwoInts>(
     "client_scope", handle_add_two_ints, rmw_qos_profile);

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -362,7 +362,8 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), spin_before_subscription)
     };
   // call the test template
   single_message_pub_sub_fixture<test_rclcpp::msg::UInt32>(
-    topic_name, counter, create_subscription_func, publish_func, pre_subscription_hook);
+    topic_name, counter, create_subscription_func, publish_func,
+    rmw_qos_profile_default, pre_subscription_hook);
 }
 
 // Test of the queue size create_subscription signature.


### PR DESCRIPTION
New test based on @dhood's suggestion. This should be enough to put the rest of the connected pr's in review without waiting to refactor topic names and types.

Connects to ros2/rmw#106