### PR TITLE
destroy node before shutdown

### DIFF
--- a/test_communication/test/replier_py.py
+++ b/test_communication/test/replier_py.py
@@ -56,6 +56,7 @@ def replier(service_name, number_of_cycles):
         rclpy.spin_once(node, timeout_sec=2)
         spin_count += 1
         print('spin_count: ' + str(spin_count))
+    node.destroy_node()
     rclpy.shutdown()
 
 

--- a/test_communication/test/requester_py.py
+++ b/test_communication/test/requester_py.py
@@ -52,6 +52,7 @@ def requester(service_name, number_of_cycles):
             spin_count += 1
             print('spin_count: ' + str(spin_count))
         break
+    node.destroy_node()
     rclpy.shutdown()
     assert len(received_replies) == len(srv_fixtures), \
         'Should have received %d responsed from replier' % len(srv_fixtures)

--- a/test_communication/test/subscriber_py.py
+++ b/test_communication/test/subscriber_py.py
@@ -69,6 +69,7 @@ def listener(message_name):
         rclpy.spin_once(node)
         spin_count += 1
         print('spin_count: ' + str(spin_count))
+    node.destroy_node()
     rclpy.shutdown()
 
     assert len(received_messages) == len(expected_msgs),\


### PR DESCRIPTION
Right now all tests involving rclpy exit gracefully on success (see trace below), this cleans up the nodes before shutting down rcl.

*before:*
```
subscriber: beginning loop
received message #1 of 4
spin_count: 2
received message #2 of 4
spin_count: 3
received message #3 of 4
spin_count: 4
received message #4 of 4
spin_count: 5

>>> [rcutils|error_handling.c:148] rcutils_set_error_state()
This error state is being overwritten:

  'rcl node is invalid, rcl instance id does not match, at /home/mikael/work/tb2_beta2_ws/src/ros2/rcl/rcl/src/rcl/node.c:346'

with this new error message:

  'node handle is null'

rcutils_reset_error() should be called after error handling to avoid this.
<<<
Exception ignored in: <bound method Node.__del__ of <rclpy.node.Node object at 0x7fb0ae8a4d30>>
Traceback (most recent call last):
  File "/home/mikael/work/tb2_beta2_ws/install_isolated/rclpy/lib/python3.5/site-packages/rclpy/node.py", line 243, in __del__
    self.destroy_node()
  File "/home/mikael/work/tb2_beta2_ws/install_isolated/rclpy/lib/python3.5/site-packages/rclpy/node.py", line 212, in destroy_node
    'subscription', sub.subscription_handle, self.handle)
SystemError: <built-in function rclpy_destroy_node_entity> returned a result with an error set
```

*after:*
```
subscriber: beginning loop
received message #1 of 4
spin_count: 2
received message #2 of 4
spin_count: 3
received message #3 of 4
spin_count: 4
received message #4 of 4
spin_count: 5
```

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2784)](http://ci.ros2.org/job/ci_linux/2784/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=311)](http://ci.ros2.org/job/ci_linux-aarch64/311/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2256)](http://ci.ros2.org/job/ci_osx/2256/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2921)](http://ci.ros2.org/job/ci_windows/2921/)