### PR TITLE
use unbuffered Python in launch files

### DIFF
--- a/test_communication/test/test_publisher_subscriber.py.in
+++ b/test_communication/test/test_publisher_subscriber.py.in
@@ -13,12 +13,16 @@ def test_publisher_subscriber():
     publisher_cmd = ['@TEST_PUBLISHER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@']
     subscriber_cmd = ['@TEST_SUBSCRIBER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@']
 
+    publisher_env = dict(os.environ)
+    subscriber_env = dict(os.environ)
+
     if '@TEST_PUBLISHER_RCL@' == 'rclpy':
         publisher_cmd.insert(0, sys.executable)
+        publisher_env['PYTHONUNBUFFERED'] = '1'
     if '@TEST_SUBSCRIBER_RCL@' == 'rclpy':
         subscriber_cmd.insert(0, sys.executable)
+        subscriber_env['PYTHONUNBUFFERED'] = '1'
 
-    publisher_env = dict(os.environ)
     publisher_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@PUBLISHER_RMW@'
     publisher_env['RMW_IMPLEMENTATION'] = '@PUBLISHER_RMW@'
     ld.add_process(
@@ -27,7 +31,6 @@ def test_publisher_subscriber():
         env=publisher_env,
     )
 
-    subscriber_env = dict(os.environ)
     subscriber_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@SUBSCRIBER_RMW@'
     subscriber_env['RMW_IMPLEMENTATION'] = '@SUBSCRIBER_RMW@'
     ld.add_process(

--- a/test_communication/test/test_requester_replier.py.in
+++ b/test_communication/test/test_requester_replier.py.in
@@ -13,12 +13,16 @@ def test_requester_replier():
     requester_cmd = ['@TEST_REQUESTER_EXECUTABLE@', '@TEST_SERVICE_TYPE@']
     replier_cmd = ['@TEST_REPLIER_EXECUTABLE@', '@TEST_SERVICE_TYPE@']
 
+    replier_env = dict(os.environ)
+    requester_env = dict(os.environ)
+
     if '@TEST_REQUESTER_RCL@' == 'rclpy':
         requester_cmd.insert(0, sys.executable)
+        replier_env['PYTHONUNBUFFERED'] = '1'
     if '@TEST_REPLIER_RCL@' == 'rclpy':
         replier_cmd.insert(0, sys.executable)
+        requester_env['PYTHONUNBUFFERED'] = '1'
 
-    replier_env = dict(os.environ)
     replier_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@REPLIER_RMW@'
     replier_env['RMW_IMPLEMENTATION'] = '@REPLIER_RMW@'
     ld.add_process(
@@ -27,7 +31,6 @@ def test_requester_replier():
         env=replier_env,
     )
 
-    requester_env = dict(os.environ)
     requester_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@REQUESTER_RMW@'
     requester_env['RMW_IMPLEMENTATION'] = '@REQUESTER_RMW@'
     ld.add_process(

--- a/test_communication/test/test_secure_publisher_subscriber.py.in
+++ b/test_communication/test/test_secure_publisher_subscriber.py.in
@@ -18,13 +18,17 @@ def test_secure_publisher_subscriber():
         '@SUBSCRIBER_SHOULD_TIMEOUT@'
     ]
 
+    publisher_env = dict(os.environ)
+    subscriber_env = dict(os.environ)
+
     # TODO (mikaelarguedas) Do we want to test any of this across client libraries??
     # if '@TEST_PUBLISHER_RCL@' == 'rclpy':
     #     publisher_cmd.insert(0, sys.executable)
+    #     publisher_env['PYTHONUNBUFFERED'] = '1'
     # if '@TEST_SUBSCRIBER_RCL@' == 'rclpy':
     #     subscriber_cmd.insert(0, sys.executable)
+    #     subscriber_env['PYTHONUNBUFFERED'] = '1'
 
-    publisher_env = dict(os.environ)
     publisher_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@PUBLISHER_RMW@'
     publisher_env['RMW_IMPLEMENTATION'] = '@PUBLISHER_RMW@'
     publisher_env['ROS_SECURITY_ENABLE'] = '@PUBLISHER_ROS_SECURITY_ENABLE@'
@@ -36,7 +40,6 @@ def test_secure_publisher_subscriber():
         env=publisher_env,
     )
 
-    subscriber_env = dict(os.environ)
     subscriber_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@SUBSCRIBER_RMW@'
     subscriber_env['RMW_IMPLEMENTATION'] = '@SUBSCRIBER_RMW@'
     subscriber_env['ROS_SECURITY_ENABLE'] = '@SUBSCRIBER_ROS_SECURITY_ENABLE@'


### PR DESCRIPTION
This ensures that the output of the Python executables is visible when something goes south. That avoids speculations around why a test might have failed (see `test_publisher_subscriber__Nested__rclpy__rmw_fastrtps_cpp_.test_publisher_subscriber` in ros2/build_cop#41).

I don't plan to run CI for this simple change.