### PR TITLE
Use wait_for_service after creating parameters_client

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -140,7 +140,7 @@ if(BUILD_TESTING)
       TIMEOUT 70)
     custom_gtest(gtest_local_parameters
       "test/test_local_parameters.cpp"
-      TIMEOUT 300)
+      TIMEOUT 90)
     custom_gtest(gtest_services_in_constructor
       "test/test_services_in_constructor.cpp"
       TIMEOUT 30)

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -140,7 +140,7 @@ if(BUILD_TESTING)
       TIMEOUT 70)
     custom_gtest(gtest_local_parameters
       "test/test_local_parameters.cpp"
-      TIMEOUT 30)
+      TIMEOUT 300)
     custom_gtest(gtest_services_in_constructor
       "test/test_services_in_constructor.cpp"
       TIMEOUT 30)
@@ -148,7 +148,7 @@ if(BUILD_TESTING)
     # Parameter tests single implementation
     custom_launch_test(test_parameter_server_cpp
       test_parameters_server_cpp test_remote_parameters_cpp
-      TIMEOUT 15)
+      TIMEOUT 30)
 
     # Service tests single implementation
     custom_launch_test(test_services_cpp

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -140,7 +140,7 @@ if(BUILD_TESTING)
       TIMEOUT 70)
     custom_gtest(gtest_local_parameters
       "test/test_local_parameters.cpp"
-      TIMEOUT 90)
+      TIMEOUT 300)
     custom_gtest(gtest_services_in_constructor
       "test/test_services_in_constructor.cpp"
       TIMEOUT 30)

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -140,7 +140,7 @@ if(BUILD_TESTING)
       TIMEOUT 70)
     custom_gtest(gtest_local_parameters
       "test/test_local_parameters.cpp"
-      TIMEOUT 90)
+      TIMEOUT 30)
     custom_gtest(gtest_services_in_constructor
       "test/test_services_in_constructor.cpp"
       TIMEOUT 30)

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -140,7 +140,7 @@ if(BUILD_TESTING)
       TIMEOUT 70)
     custom_gtest(gtest_local_parameters
       "test/test_local_parameters.cpp"
-      TIMEOUT 30)
+      TIMEOUT 90)
     custom_gtest(gtest_services_in_constructor
       "test/test_services_in_constructor.cpp"
       TIMEOUT 30)

--- a/test_rclcpp/test/parameter_fixtures.hpp
+++ b/test_rclcpp/test/parameter_fixtures.hpp
@@ -30,6 +30,7 @@ const double test_epsilon = 1e-6;
 void set_test_parameters(
   std::shared_ptr<rclcpp::parameter_client::SyncParametersClient> parameters_client)
 {
+  printf("Setting parameters\n");
   // Set several differnet types of parameters.
   auto set_parameters_results = parameters_client->set_parameters({
     rclcpp::parameter::ParameterVariant("foo", 2),
@@ -40,6 +41,8 @@ void set_test_parameters(
     rclcpp::parameter::ParameterVariant("foo.second", 42),
     rclcpp::parameter::ParameterVariant("foobar", true),
   });
+  printf("Got set_parameters result\n");
+
 
   // Check to see if they were set.
   for (auto & result : set_parameters_results) {
@@ -51,6 +54,7 @@ void verify_set_parameters_async(
   std::shared_ptr<rclcpp::Node> node,
   std::shared_ptr<rclcpp::parameter_client::AsyncParametersClient> parameters_client)
 {
+  printf("Setting parameters\n");
   // Set several differnet types of parameters.
   auto set_parameters_results = parameters_client->set_parameters({
     rclcpp::parameter::ParameterVariant("foo", 2),
@@ -62,6 +66,8 @@ void verify_set_parameters_async(
     rclcpp::parameter::ParameterVariant("foobar", true),
   });
   rclcpp::spin_until_future_complete(node, set_parameters_results);  // Wait for the results.
+  printf("Got set_parameters result\n");
+
   // Check to see if they were set.
   for (auto & result : set_parameters_results.get()) {
     ASSERT_TRUE(result.successful);
@@ -71,6 +77,7 @@ void verify_set_parameters_async(
 void verify_test_parameters(
   std::shared_ptr<rclcpp::parameter_client::SyncParametersClient> parameters_client)
 {
+  printf("Listing parameters with recursive depth\n");
   // Test recursive depth (=0)
   auto parameters_and_prefixes = parameters_client->list_parameters({"foo", "bar"},
       rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);
@@ -81,6 +88,7 @@ void verify_test_parameters(
     EXPECT_STREQ("foo", prefix.c_str());
   }
 
+  printf("Listing parameters with depth of 1\n");
   // Test different depth
   auto parameters_and_prefixes4 = parameters_client->list_parameters({"foo"}, 1);
   for (auto & name : parameters_and_prefixes4.names) {
@@ -90,6 +98,7 @@ void verify_test_parameters(
     EXPECT_STREQ("foo", prefix.c_str());
   }
 
+  printf("Listing parameters with depth of 2\n");
   // Test different depth
   auto parameters_and_prefixes5 = parameters_client->list_parameters({"foo"}, 2);
   for (auto & name : parameters_and_prefixes5.names) {
@@ -99,6 +108,7 @@ void verify_test_parameters(
     EXPECT_STREQ("foo", prefix.c_str());
   }
 
+  printf("Getting parameters\n");
   // Get a few of the parameters just set.
   for (auto & parameter : parameters_client->get_parameters({"foo", "bar", "baz"})) {
     // std::cout << "Parameter is:" << std::endl << parameter.to_yaml() << std::endl;
@@ -120,11 +130,13 @@ void verify_test_parameters(
     }
   }
 
+  printf("Getting nonexistent parameters\n");
   // Get a few non existant parameters
   for (auto & parameter : parameters_client->get_parameters({"not_foo", "not_baz"})) {
     EXPECT_STREQ("There should be no matches", parameter.get_name().c_str());
   }
 
+  printf("Listing parameters with recursive depth\n");
   // List all of the parameters, using an empty prefix list and depth=0
   parameters_and_prefixes = parameters_client->list_parameters({},
       rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);
@@ -139,6 +151,7 @@ void verify_test_parameters(
         name),
       parameters_and_prefixes.names.cend());
   }
+  printf("Listing parameters with depth 100\n");
   // List all of the parameters, using an empty prefix list and large depth
   parameters_and_prefixes = parameters_client->list_parameters({}, 100);
   EXPECT_EQ(parameters_and_prefixes.names.size(), all_names.size());
@@ -149,6 +162,7 @@ void verify_test_parameters(
         name),
       parameters_and_prefixes.names.cend());
   }
+  printf("Listing parameters with depth 1\n");
   // List most of the parameters, using an empty prefix list and depth=1
   parameters_and_prefixes = parameters_client->list_parameters({}, 1);
   std::vector<std::string> depth_one_names = {
@@ -168,6 +182,7 @@ void verify_get_parameters_async(
   std::shared_ptr<rclcpp::Node> node,
   std::shared_ptr<rclcpp::parameter_client::AsyncParametersClient> parameters_client)
 {
+  printf("Listing parameters with recursive depth\n");
   // Test recursive depth (=0)
   auto result = parameters_client->list_parameters({"foo", "bar"},
       rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);
@@ -180,6 +195,7 @@ void verify_get_parameters_async(
     EXPECT_STREQ("foo", prefix.c_str());
   }
 
+  printf("Listing parameters with depth 1\n");
   // Test different depth
   auto result4 = parameters_client->list_parameters({"foo"}, 1);
   rclcpp::spin_until_future_complete(node, result4);
@@ -192,6 +208,7 @@ void verify_get_parameters_async(
   }
 
   // Test different depth
+  printf("Listing parameters with depth 2\n");
   auto result4a = parameters_client->list_parameters({"foo"}, 2);
   rclcpp::spin_until_future_complete(node, result4a);
   auto parameters_and_prefixes4a = result4a.get();
@@ -203,6 +220,7 @@ void verify_get_parameters_async(
   }
 
 
+  printf("Getting parameters\n");
   // Get a few of the parameters just set.
   auto result2 = parameters_client->get_parameters({"foo", "bar", "baz"});
   rclcpp::spin_until_future_complete(node, result2);
@@ -226,6 +244,7 @@ void verify_get_parameters_async(
     }
   }
 
+  printf("Getting nonexistent parameters\n");
   // Get a few non existant parameters
   auto result3 = parameters_client->get_parameters({"not_foo", "not_baz"});
   rclcpp::spin_until_future_complete(node, result3);
@@ -233,6 +252,7 @@ void verify_get_parameters_async(
     EXPECT_STREQ("There should be no matches", parameter.get_name().c_str());
   }
 
+  printf("Listing parameters with recursive depth\n");
   // List all of the parameters, using an empty prefix list
   auto result5 = parameters_client->list_parameters({},
       rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -24,6 +24,8 @@
 
 #include "parameter_fixtures.hpp"
 
+using namespace std::chrono_literals;
+
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
 # define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
@@ -67,6 +69,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous) {
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   set_test_parameters(parameters_client);
   verify_test_parameters(parameters_client);
 }
@@ -76,6 +81,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous_rep
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   set_test_parameters(parameters_client);
   for (int i = 0; i < 10; ++i) {
     printf("iteration: %d\n", i);
@@ -88,6 +96,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_asynchronous) {
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   verify_set_parameters_async(node, parameters_client);
   verify_get_parameters_async(node, parameters_client);
 }
@@ -97,6 +108,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   auto set_parameters_results = parameters_client->set_parameters({
     rclcpp::parameter::ParameterVariant("foo", 2),
     rclcpp::parameter::ParameterVariant("bar", "hello"),
@@ -199,6 +213,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_primiti
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   auto set_parameters_results = parameters_client->set_parameters({
     rclcpp::parameter::ParameterVariant("foo", 2),
     rclcpp::parameter::ParameterVariant("bar", "hello"),
@@ -263,6 +280,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_variant
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   auto set_parameters_results = parameters_client->set_parameters({
     ParameterVariant("foo", 2),
     ParameterVariant("bar", "hello"),

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -403,8 +403,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), set_parameter_if_not_
 
 int main(int argc, char ** argv)
 {
-  // NOTE: use custom main to ensure that rclcpp::init is called only once
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+
+  // NOTE: use custom main to ensure that rclcpp::init is called only once
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -24,8 +24,6 @@
 
 #include "parameter_fixtures.hpp"
 
-using namespace std::chrono_literals;
-
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
 # define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
@@ -69,9 +67,6 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous) {
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
-  if (!parameters_client->wait_for_service(20s)) {
-    ASSERT_TRUE(false) << "service not available after waiting";
-  }
   set_test_parameters(parameters_client);
   verify_test_parameters(parameters_client);
 }
@@ -81,9 +76,6 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous_rep
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
-  if (!parameters_client->wait_for_service(20s)) {
-    ASSERT_TRUE(false) << "service not available after waiting";
-  }
   set_test_parameters(parameters_client);
   for (int i = 0; i < 10; ++i) {
     printf("iteration: %d\n", i);
@@ -96,9 +88,6 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_asynchronous) {
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
-  if (!parameters_client->wait_for_service(20s)) {
-    ASSERT_TRUE(false) << "service not available after waiting";
-  }
   verify_set_parameters_async(node, parameters_client);
   verify_get_parameters_async(node, parameters_client);
 }
@@ -108,9 +97,6 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
-  if (!parameters_client->wait_for_service(20s)) {
-    ASSERT_TRUE(false) << "service not available after waiting";
-  }
   auto set_parameters_results = parameters_client->set_parameters({
     rclcpp::parameter::ParameterVariant("foo", 2),
     rclcpp::parameter::ParameterVariant("bar", "hello"),
@@ -213,9 +199,6 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_primiti
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
-  if (!parameters_client->wait_for_service(20s)) {
-    ASSERT_TRUE(false) << "service not available after waiting";
-  }
   auto set_parameters_results = parameters_client->set_parameters({
     rclcpp::parameter::ParameterVariant("foo", 2),
     rclcpp::parameter::ParameterVariant("bar", "hello"),
@@ -280,9 +263,6 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_variant
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
-  if (!parameters_client->wait_for_service(20s)) {
-    ASSERT_TRUE(false) << "service not available after waiting";
-  }
   auto set_parameters_results = parameters_client->set_parameters({
     ParameterVariant("foo", 2),
     ParameterVariant("bar", "hello"),

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -24,6 +24,8 @@
 
 #include "parameter_fixtures.hpp"
 
+using namespace std::chrono_literals;
+
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
 # define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
@@ -67,6 +69,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous) {
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   set_test_parameters(parameters_client);
   verify_test_parameters(parameters_client);
 }
@@ -76,6 +81,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous_rep
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   set_test_parameters(parameters_client);
   for (int i = 0; i < 10; ++i) {
     printf("iteration: %d\n", i);
@@ -88,6 +96,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_asynchronous) {
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   verify_set_parameters_async(node, parameters_client);
   verify_get_parameters_async(node, parameters_client);
 }
@@ -97,6 +108,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   auto set_parameters_results = parameters_client->set_parameters({
     rclcpp::parameter::ParameterVariant("foo", 2),
     rclcpp::parameter::ParameterVariant("bar", "hello"),
@@ -198,6 +212,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_primiti
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   auto set_parameters_results = parameters_client->set_parameters({
     rclcpp::parameter::ParameterVariant("foo", 2),
     rclcpp::parameter::ParameterVariant("bar", "hello"),
@@ -261,6 +278,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_variant
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
   auto set_parameters_results = parameters_client->set_parameters({
     ParameterVariant("foo", 2),
     ParameterVariant("bar", "hello"),

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -119,6 +119,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
     rclcpp::parameter::ParameterVariant("foobar", true),
     rclcpp::parameter::ParameterVariant("barfoo", std::vector<uint8_t>{0, 1, 2}),
   });
+  printf("Got set_parameters result\n");
 
   // Check to see if they were set.
   for (auto & result : set_parameters_results) {
@@ -223,6 +224,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_primiti
     rclcpp::parameter::ParameterVariant("foobar", true),
     rclcpp::parameter::ParameterVariant("barfoo", std::vector<uint8_t>{3, 4, 5}),
   });
+  printf("Got set_parameters result\n");
 
   // Check to see if they were set.
   for (auto & result : set_parameters_results) {
@@ -289,6 +291,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_variant
     ParameterVariant("foobar", true),
     ParameterVariant("barfoo", std::vector<uint8_t>{3, 4, 5}),
   });
+  printf("Got set_parameters result\n");
 
   // Check to see if they were set.
   for (auto & result : set_parameters_results) {
@@ -336,6 +339,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_parameter_or) {
   auto set_parameters_results = node->set_parameters({
     ParameterVariant("foo", 2),
   });
+  printf("Got set_parameters result\n");
 
   // Check to see if they were set.
   for (auto & result : set_parameters_results) {
@@ -371,6 +375,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), set_parameter_if_not_
   auto set_parameters_results = node->set_parameters({
     ParameterVariant("foo", 2),
   });
+  printf("Got set_parameters result\n");
 
   // Check to see if they were set.
   for (auto & result : set_parameters_results) {
@@ -399,6 +404,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), set_parameter_if_not_
 int main(int argc, char ** argv)
 {
   // NOTE: use custom main to ensure that rclcpp::init is called only once
+  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test_rclcpp/test/test_remote_parameters.cpp
+++ b/test_rclcpp/test/test_remote_parameters.cpp
@@ -40,15 +40,11 @@ TEST(CLASSNAME(parameters, rmw_implementation), test_remote_parameters) {
 
   auto node = rclcpp::Node::make_shared(std::string("test_remote_parameters"));
 
-  // TODO(wjwwood): remove this block when there is a wait_for_parameter_server option.
-  {
-    // This is requried specifically for FastRTPS, see:
-    //   https://github.com/eProsima/ROS-RMW-Fast-RTPS-cpp/pull/51#issuecomment-242872096
-    std::this_thread::sleep_for(1s);
-  }
-
   auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node,
       test_server_name);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
 
   verify_set_parameters_async(node, parameters_client);
 


### PR DESCRIPTION
connects to ros2/rclcpp#356 

I don't think it's necessary to do any waiting [when calling node->set_parameters](https://github.com/ros2/system_tests/blob/67efe8e319b997c389c266d9ac237b850807ba4e/test_rclcpp/test/test_local_parameters.cpp#L351) because FWIU there are no service calls involved (correct me if I'm wrong).
Also, now that we wait in so many places, the timeout has to be increased significantly (15 waits of 20s)

CI including other branches that add the implementation of wait_for_service and use it in demos:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3001)](http://ci.ros2.org/job/ci_linux/3001/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=428)](http://ci.ros2.org/job/ci_linux-aarch64/428/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2423)](http://ci.ros2.org/job/ci_osx/2423/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3099)](http://ci.ros2.org/job/ci_windows/3099/)


this should fix flaky tests e.g. http://ci.ros2.org/view/nightly/job/nightly_linux_repeated/744/testReport/junit/(root)/projectroot/gtest_local_parameters__rmw_fastrtps_cpp but it doesn't fix them completely yet (the test can hang while waiting for the service instead of the assertion being raised after max 20s [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3004)](http://ci.ros2.org/job/ci_linux/3004/))