### PR TITLE
Ensure nodes have called rclcpp::shutdown before exiting

### DIFF
--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -60,11 +60,11 @@ void publish(
 
 int main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);
   if (argc != 2) {
     fprintf(stderr, "Wrong number of arguments, pass one message type\n");
     return 1;
   }
+  rclcpp::init(argc, argv);
 
   std::string message = argv[1];
   auto node = rclcpp::Node::make_shared(std::string("test_publisher_") + message);
@@ -100,7 +100,9 @@ int main(int argc, char ** argv)
     publish<test_communication::msg::Builtins>(node, message, get_messages_builtins());
   } else {
     fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());
+    rclcpp::shutdown();
     return 1;
   }
+  rclcpp::shutdown();
   return 0;
 }

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -185,6 +185,7 @@ int main(int argc, char ** argv)
     publish<test_communication::msg::Builtins>(node, message, messages_builtins);
   } else {
     fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());
+    rclcpp::shutdown();
     return 1;
   }
 

--- a/test_communication/test/test_replier.cpp
+++ b/test_communication/test/test_replier.cpp
@@ -63,11 +63,11 @@ typename rclcpp::service::Service<T>::SharedPtr reply(
 
 int main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);
   if (argc != 2) {
     fprintf(stderr, "Wrong number of arguments, pass one service type\n");
     return 1;
   }
+  rclcpp::init(argc, argv);
 
   auto start = std::chrono::steady_clock::now();
 
@@ -86,6 +86,7 @@ int main(int argc, char ** argv)
       node, service, services_primitives);
   } else {
     fprintf(stderr, "Unknown service argument '%s'\n", service.c_str());
+    rclcpp::shutdown();
     return 1;
   }
   rclcpp::spin(node);
@@ -94,5 +95,6 @@ int main(int argc, char ** argv)
   std::chrono::duration<float> diff = (end - start);
   std::cout << "replied for " << diff.count() << " seconds" << std::endl;
 
+  rclcpp::shutdown();
   return 0;
 }

--- a/test_communication/test/test_secure_publisher.cpp
+++ b/test_communication/test/test_secure_publisher.cpp
@@ -63,7 +63,6 @@ int8_t attempt_publish(
 
 int main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);
   if (argc != 2) {
     fprintf(
       stderr,
@@ -71,6 +70,7 @@ int main(int argc, char ** argv)
       "pass a message type\n");
     return 1;
   }
+  rclcpp::init(argc, argv);
   std::string message = argv[1];
   std::string node_name = "publisher";
   std::string topic_name = "chatter";
@@ -115,7 +115,9 @@ int main(int argc, char ** argv)
       node, topic_name, get_messages_builtins());
   } else {
     fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());
+    rclcpp::shutdown();
     return 1;
   }
+  rclcpp::shutdown();
   return ret;
 }

--- a/test_communication/test/test_secure_subscriber.cpp
+++ b/test_communication/test/test_secure_subscriber.cpp
@@ -115,7 +115,6 @@ rclcpp::TimerBase::SharedPtr create_timer(
 
 int main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);
   if (argc != 3) {
     fprintf(
       stderr,
@@ -128,11 +127,14 @@ int main(int argc, char ** argv)
   std::string topic_name = "chatter";
   bool should_timeout =
     ((0 == strcmp(argv[2], "false")) || (0 == strcmp(argv[2], "0"))) ? false : true;
+
+  rclcpp::init(argc, argv);
   std::shared_ptr<rclcpp::node::Node> node = nullptr;
   try {
     node = rclcpp::Node::make_shared(node_name);
   } catch (std::runtime_error &) {
     fprintf(stderr, "should not have thrown!");
+    rclcpp::shutdown();
     return 1;
   }
   rclcpp::subscription::SubscriptionBase::SharedPtr subscriber;
@@ -181,6 +183,7 @@ int main(int argc, char ** argv)
         node, topic_name, messages_builtins, received_messages);
     } else {
       fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());
+      rclcpp::shutdown();
       return 1;
     }
 
@@ -222,15 +225,18 @@ int main(int argc, char ** argv)
         node, topic_name, sub_callback_called, executor);
     } else {
       fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());
+      rclcpp::shutdown();
       return 1;
     }
     timer = create_timer(node, timer_callback_called, executor);
     executor.add_node(node);
     executor.spin();
     if (!timer_callback_called || sub_callback_called) {
+      rclcpp::shutdown();
       return 1;
     }
   }
 
+  rclcpp::shutdown();
   return 0;
 }

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -75,11 +75,11 @@ rclcpp::subscription::SubscriptionBase::SharedPtr subscribe(
 
 int main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);
   if (argc != 2) {
     fprintf(stderr, "Wrong number of arguments, pass one message type\n");
     return 1;
   }
+  rclcpp::init(argc, argv);
 
   auto start = std::chrono::steady_clock::now();
 
@@ -135,6 +135,7 @@ int main(int argc, char ** argv)
       node, message, messages_builtins, received_messages);
   } else {
     fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());
+    rclcpp::shutdown();
     return 1;
   }
   rclcpp::spin(node);
@@ -143,5 +144,6 @@ int main(int argc, char ** argv)
   std::chrono::duration<float> diff = (end - start);
   std::cout << "subscribed for " << diff.count() << " seconds" << std::endl;
 
+  rclcpp::shutdown();
   return 0;
 }

--- a/test_communication/test/test_subscription_valid_data.cpp
+++ b/test_communication/test/test_subscription_valid_data.cpp
@@ -73,5 +73,6 @@ int main(int argc, char ** argv)
   std::chrono::duration<float> diff = (end - start);
   std::cout << "published and subscribed for " << diff.count() << " seconds" << std::endl;
 
+  rclcpp::shutdown();
   return 0;
 }

--- a/test_rclcpp/test/test_client_scope_consistency_server.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_server.cpp
@@ -50,5 +50,6 @@ int main(int argc, char ** argv)
     rclcpp::spin_some(node);
     loop_rate.sleep();
   }
+  rclcpp::shutdown();
   return 0;
 }

--- a/test_rclcpp/test/test_client_scope_server.cpp
+++ b/test_rclcpp/test/test_client_scope_server.cpp
@@ -41,5 +41,6 @@ int main(int argc, char ** argv)
     rclcpp::spin_some(node);
     loop_rate.sleep();
   }
+  rclcpp::shutdown();
   return 0;
 }

--- a/test_rclcpp/test/test_parameters_server.cpp
+++ b/test_rclcpp/test/test_parameters_server.cpp
@@ -32,5 +32,6 @@ int main(int argc, char ** argv)
 
   rclcpp::spin(node);
 
+  rclcpp::shutdown();
   return 0;
 }

--- a/test_rclcpp/test/test_services_server.cpp
+++ b/test_rclcpp/test/test_services_server.cpp
@@ -51,5 +51,6 @@ int main(int argc, char ** argv)
 
   rclcpp::spin(node);
 
+  rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
this should fix flaky tests like http://ci.ros2.org/view/nightly/job/nightly_osx_repeated/771/testReport/junit/(root)/projectroot/test_client_scope_consistency_cpp__rmw_connext_cpp/ (referenced in https://github.com/ros2/build_cop/issues/41) which sometimes don't respond to SIGINT and are then sent SIGTERM:
```
...
[test_client_scope_consistency_client_cpp] received second result
[test_client_scope_consistency_client_cpp] received correct result
[test_client_scope_consistency_client_cpp] destroying second client
[test_client_scope_consistency_client_cpp] [       OK ] service_client__.client_scope_consistency_regression_test (3520 ms)
[test_client_scope_consistency_client_cpp] [----------] 1 test from service_client__ (3520 ms total)
[test_client_scope_consistency_client_cpp] 
[test_client_scope_consistency_client_cpp] [----------] Global test environment tear-down
[test_client_scope_consistency_client_cpp] [==========] 1 test from 1 test case ran. (3520 ms total)
[test_client_scope_consistency_client_cpp] [  PASSED  ] 1 test.
(test_client_scope_consistency_client_cpp) rc 0
() tear down
(test_client_scope_consistency_server_cpp) signal SIGINT
(test_client_scope_consistency_server_cpp) signal SIGTERM
(test_client_scope_consistency_server_cpp) rc -15
F
======================================================================
FAIL: test_client_scope_consistency_cpp__rmw_connext_cpp_.test_client_scope_consistency_cpp
```

see https://github.com/ros2/rmw_implementation/issues/25

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3005)](http://ci.ros2.org/job/ci_linux/3005/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=429)](http://ci.ros2.org/job/ci_linux-aarch64/429/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2426)](http://ci.ros2.org/job/ci_osx/2426/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3100)](http://ci.ros2.org/job/ci_windows/3100/) (known flaky test)

retesting only the test_client_scope_consistency_cpp__rmw_connext_cpp_ test 100 times: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2424)](http://ci.ros2.org/job/ci_osx/2424/)