### PR TITLE
call rclcpp::shutdown in all tests

### DIFF
--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -120,7 +120,9 @@ int main(int argc, char ** argv)
       node, service, get_services_primitives());
   } else {
     fprintf(stderr, "Unknown service argument '%s'\n", service.c_str());
+    rclcpp::shutdown();
     return 1;
   }
+  rclcpp::shutdown();
   return rc;
 }

--- a/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
+++ b/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
@@ -77,5 +77,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_client_scope_client.cpp
+++ b/test_rclcpp/test/test_client_scope_client.cpp
@@ -94,5 +94,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_client_scope_consistency_client.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_client.cpp
@@ -126,5 +126,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_executor.cpp
+++ b/test_rclcpp/test/test_executor.cpp
@@ -228,5 +228,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_intra_process.cpp
+++ b/test_rclcpp/test/test_intra_process.cpp
@@ -165,4 +165,5 @@ TEST(CLASSNAME(test_intra_process_within_one_node, RMW_IMPLEMENTATION), nominal_
   printf("spin_node_some() - no callbacks expected\n");
   executor.spin_node_some(node);
   ASSERT_EQ(5, counter);
+  rclcpp::shutdown();
 }

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -408,5 +408,7 @@ int main(int argc, char ** argv)
   // NOTE: use custom main to ensure that rclcpp::init is called only once
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_multiple_service_calls.cpp
+++ b/test_rclcpp/test/test_multiple_service_calls.cpp
@@ -144,5 +144,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -330,5 +330,7 @@ int main(int argc, char ** argv)
   // use custom main to ensure that rclcpp::init is called only once
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_publisher.cpp
+++ b/test_rclcpp/test/test_publisher.cpp
@@ -72,5 +72,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_remote_parameters.cpp
+++ b/test_rclcpp/test/test_remote_parameters.cpp
@@ -56,5 +56,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_repeated_publisher_subscriber.cpp
+++ b/test_rclcpp/test/test_repeated_publisher_subscriber.cpp
@@ -94,4 +94,5 @@ TEST(CLASSNAME(test_repeated_publisher_subscriber, RMW_IMPLEMENTATION), subscrip
     printf("Destroying publisher and subscriber...\n");
     fflush(stdout);
   }
+  rclcpp::shutdown();
 }

--- a/test_rclcpp/test/test_services_client.cpp
+++ b/test_rclcpp/test/test_services_client.cpp
@@ -100,5 +100,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_services_in_constructor.cpp
+++ b/test_rclcpp/test/test_services_in_constructor.cpp
@@ -79,5 +79,7 @@ int main(int argc, char ** argv)
   // NOTE: use custom main to ensure that rclcpp::init is called only once
   rclcpp::init(0, nullptr);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_spin.cpp
+++ b/test_rclcpp/test/test_spin.cpp
@@ -210,5 +210,7 @@ int main(int argc, char ** argv)
   // NOTE: use custom main to ensure that rclcpp::init is called only once
   rclcpp::init(0, nullptr);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -382,5 +382,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/test_rclcpp/test/test_timeout_subscriber.cpp
+++ b/test_rclcpp/test/test_timeout_subscriber.cpp
@@ -70,6 +70,7 @@ TEST(CLASSNAME(test_timeout_subscriber, RMW_IMPLEMENTATION), timeout_subscriber)
     EXPECT_LT(blocking_diff, blocking_timeout + tolerance);
   }
 
+  rclcpp::shutdown();
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
   std::cout << "subscribed for " << diff.count() << " seconds" << std::endl;

--- a/test_rclcpp/test/test_timer.cpp
+++ b/test_rclcpp/test/test_timer.cpp
@@ -170,5 +170,7 @@ int main(int argc, char ** argv)
   // NOTE: use custom main to ensure that rclcpp::init is called only once
   rclcpp::init(0, nullptr);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }


### PR DESCRIPTION
follow up of https://github.com/ros2/system_tests/pull/220

redo of the [shutdown](https://github.com/ros2/system_tests/tree/shutdown) stale branch

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3155)](http://ci.ros2.org/job/ci_linux/3155/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=496)](http://ci.ros2.org/job/ci_linux-aarch64/496/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2512)](http://ci.ros2.org/job/ci_osx/2512/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3207)](http://ci.ros2.org/job/ci_windows/3207/)