### PR TITLE
revert hack shortening node name

### DIFF
--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -77,7 +77,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous) {
 }
 
 TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous_repeated) {
-  auto node = rclcpp::Node::make_shared("test_parameters_local_synch_repeated");
+  auto node = rclcpp::Node::make_shared("test_parameters_local_synchronous_repeated");
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);


### PR DESCRIPTION
restore full name to confirm https://github.com/ros2/rmw_connext/issues/193 is fixed

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3173)](http://ci.ros2.org/job/ci_linux/3173/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=514)](http://ci.ros2.org/job/ci_linux-aarch64/514/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2539)](http://ci.ros2.org/job/ci_osx/2539/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3235)](http://ci.ros2.org/job/ci_windows/3235/)