### PR TITLE
remove unnecessary working_dir and pythonpath tweaks

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -182,9 +182,7 @@ if(BUILD_TESTING)
 
       ament_add_nose_test(test_publisher_subscriber${test_suffix}
         "${CMAKE_CURRENT_BINARY_DIR}/test_publisher_subscriber${test_suffix}_$<CONFIG>.py"
-        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py"
         PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
-        APPEND_ENV PYTHONPATH="${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py:${CMAKE_CURRENT_SOURCE_DIR}:${CMAKE_CURRENT_BINARY_DIR}/../../rclpy"
         APPEND_LIBRARY_DIRS "${append_library_dirs}"
         TIMEOUT 15)
       set_tests_properties(
@@ -232,9 +230,7 @@ if(BUILD_TESTING)
 
       ament_add_nose_test(test_requester_replier${test_suffix}
         "${CMAKE_CURRENT_BINARY_DIR}/test_requester_replier${test_suffix}_$<CONFIG>.py"
-        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py"
         PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
-        APPEND_ENV PYTHONPATH="${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py:${CMAKE_CURRENT_SOURCE_DIR}:${CMAKE_CURRENT_BINARY_DIR}/../../rclpy"
         APPEND_LIBRARY_DIRS "${append_library_dirs}"
         TIMEOUT 30
         ${SKIP_TEST})


### PR DESCRIPTION
no need to tweak python path now that messages come from test_msgs.

Not setting the working directory should allow a cleaner test display on jenkins and the test_communication tests will not show up under rosidl_generator_py anymore (e.g. http://ci.ros2.org/view/nightly/job/nightly_osx_repeated/lastCompletedBuild/testReport/projectroot/rosidl_generator_py/)

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3281)](http://ci.ros2.org/job/ci_linux/3281/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=558)](http://ci.ros2.org/job/ci_linux-aarch64/558/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2614)](http://ci.ros2.org/job/ci_osx/2614/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3320)](http://ci.ros2.org/job/ci_windows/3320/) (warnings unrelated)