### PR TITLE
Minimize the number of calls to message.__repr__()

### DIFF
--- a/test_communication/test/subscriber_py.py
+++ b/test_communication/test/subscriber_py.py
@@ -20,19 +20,19 @@ import sys
 
 def listener_cb(msg, received_messages, expected_msgs):
     known_msg = False
-    for exp in expected_msgs:
-        if msg.__repr__() == exp.__repr__():
-            print('received message #{} of {}'.format(
-                expected_msgs.index(exp) + 1, len(expected_msgs)))
+    msg_repr = repr(msg)
+    for num, exp in expected_msgs:
+        if msg_repr == exp:
+            print('received message #{} of {}'.format(num + 1, len(expected_msgs)))
             known_msg = True
             already_received = False
             for rmsg in received_messages:
-                if rmsg.__repr__() == msg.__repr__():
+                if rmsg == msg_repr:
                     already_received = True
                     break
 
             if not already_received:
-                received_messages.append(msg)
+                received_messages.append(msg_repr)
             break
     if known_msg is False:
         raise RuntimeError('received unexpected message %r' % msg)
@@ -51,7 +51,7 @@ def listener(message_name):
     node = rclpy.create_node('listener')
 
     received_messages = []
-    expected_msgs = get_test_msg(message_name)
+    expected_msgs = [(i, repr(msg)) for i, msg in enumerate(get_test_msg(message_name))]
 
     chatter_callback = functools.partial(
         listener_cb, received_messages=received_messages, expected_msgs=expected_msgs)


### PR DESCRIPTION
This fixes ros2/build_cop#59, a test failure on windows debug. It does so by minimizing the number of calls to `__repr__()` on a message instance.

The test failed because the python subscriber is too slow to consume messages. The 5th message in the subscriber's queue is overwritten before the subscriber can take it. cProfile shows the subscriber spends on average 0.068s cumulative in `__repr__` calls per call to `listener_cb` on windows debug. The messages are published 0.02s apart on average, so the subscriber queue is being overwhelmed.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3310)](http://ci.ros2.org/job/ci_linux/3310/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=575)](http://ci.ros2.org/job/ci_linux-aarch64/575/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2640)](http://ci.ros2.org/job/ci_osx/2640/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3348)](http://ci.ros2.org/job/ci_windows/3348/)