### PR TITLE
removing /bigobj that doesnt seem to be necessary anymore

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -10,10 +10,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # we dont use add_compile_options with pedantic in message packages
   # because the Python C extensions dont comply with it
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
-elseif(MSVC)
-  # /bigobj is needed to avoid error C1128:
-  #   https://msdn.microsoft.com/en-us/library/8578y171.aspx
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 endif()
 
 find_package(ament_cmake_auto REQUIRED)

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -13,10 +13,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # once this is not a message package anymore
   # https://github.com/ros2/system_tests/issues/191
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
-elseif(MSVC)
-  # /bigobj is needed to avoid error C1128:
-  #   https://msdn.microsoft.com/en-us/library/8578y171.aspx
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 endif()
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
When cleaning up some cmake I wondered if passing /bigobj on windows is still necessary. CI seems happy without it. Maybe the new version of VS/MSVC behaves differently? (looks like this was added [2 years ago](https://github.com/ros2/system_tests/pull/35))

@wjwwood do you think it's safe to remove this ?

* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3375)](http://ci.ros2.org/job/ci_windows/3375/)