### PR TITLE
Replaces "std::cout<<" with "printf"

### DIFF
--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -54,7 +54,7 @@ void publish(
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  printf("published for %lf seconds\n", diff.count());
+  printf("published for %f seconds\n", diff.count());
 }
 
 int main(int argc, char ** argv)

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-#include <iostream>
 #include <string>
 #include <vector>
 
@@ -44,7 +43,7 @@ void publish(
     size_t message_index = 0;
     // publish all messages one by one, shorter sleep between each message
     while (rclcpp::ok() && message_index < messages.size()) {
-      std::cout << "publishing message #" << (message_index + 1) << std::endl;
+      printf("publishing message #%zu\n", message_index + 1);
       publisher->publish(messages[message_index]);
       ++message_index;
       message_rate.sleep();
@@ -55,7 +54,7 @@ void publish(
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  std::cout << "published for " << diff.count() << " seconds" << std::endl;
+  printf("published for %lf seconds\n", diff.count());
 }
 
 int main(int argc, char ** argv)

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -192,7 +192,7 @@ int main(int argc, char ** argv)
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  printf("published and subscribed for %lf seconds\n", diff.count());
+  printf("published and subscribed for %f seconds\n", diff.count());
 
   for (auto received : received_messages) {
     if (!received) {

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-#include <iostream>
 #include <string>
 #include <vector>
 

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -42,7 +42,7 @@ void publish(
     size_t message_index = 0;
     // publish all messages one by one, shorter sleep between each message
     while (rclcpp::ok() && message_index < messages.size()) {
-      std::cout << "publishing message #" << (message_index + 1) << std::endl;
+      printf("publishing message #%zu\n", message_index + 1);
       publisher->publish(messages[message_index]);
       ++message_index;
       message_rate.sleep();
@@ -73,8 +73,7 @@ rclcpp::subscription::SubscriptionBase::SharedPtr subscribe(
       for (auto expected_message : expected_messages) {
         if (*received_message == *expected_message) {
           *received = true;
-          std::cout << "received message #" << (index + 1) << " of " <<
-            expected_messages.size() << std::endl;
+          printf("received message #%zu of %zu\n", index + 1, expected_messages.size());
           known_message = true;
           break;
         }
@@ -193,7 +192,7 @@ int main(int argc, char ** argv)
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  std::cout << "published and subscribed for " << diff.count() << " seconds" << std::endl;
+  printf("published and subscribed for %lf seconds\n", diff.count());
 
   for (auto received : received_messages) {
     if (!received) {

--- a/test_communication/test/test_replier.cpp
+++ b/test_communication/test/test_replier.cpp
@@ -91,7 +91,7 @@ int main(int argc, char ** argv)
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  printf("replied for %lf seconds\n", diff.count());
+  printf("replied for %f seconds\n", diff.count());
 
   rclcpp::shutdown();
   return 0;

--- a/test_communication/test/test_replier.cpp
+++ b/test_communication/test/test_replier.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -42,8 +41,7 @@ typename rclcpp::service::Service<T>::SharedPtr reply(
       size_t index = 0;
       for (auto expected_service : expected_services) {
         if (*received_request == *expected_service.first) {
-          std::cout << "received request #" << (index + 1) << " of " <<
-            expected_services.size() << std::endl;
+          printf("received request #%zu of %zu\n", index + 1, expected_services.size());
           *response = *expected_service.second;
           known_request = true;
           break;
@@ -93,7 +91,7 @@ int main(int argc, char ** argv)
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  std::cout << "replied for " << diff.count() << " seconds" << std::endl;
+  printf("replied for %lf seconds\n", diff.count());
 
   rclcpp::shutdown();
   return 0;

--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -52,7 +51,7 @@ int request(
   // publish the first request up to number_of_cycles times, longer sleep between each cycle
   // publish all requests one by one, shorter sleep between each request
   while (rclcpp::ok() && cycle_index < number_of_cycles && service_index < services.size()) {
-    std::cout << "publishing request #" << (service_index + 1) << std::endl;
+    printf("publishing request #%zu\n", service_index + 1);
     auto f = requester->async_send_request(services[service_index].first);
 
     auto wait_for_response_until = std::chrono::steady_clock::now() + wait_between_services;
@@ -67,8 +66,7 @@ int request(
 
     if (std::future_status::ready == status) {
       if (*f.get() == *services[service_index].second) {
-        std::cout << "received reply #" << (service_index + 1) << " of " <<
-          services.size() << std::endl;
+        printf("received reply #%zu of %zu\n", service_index + 1, service.size());
         ++service_index;
       } else {
         std::cerr << "received reply for request #" << (service_index + 1) <<
@@ -95,7 +93,7 @@ int request(
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  std::cout << "requested for " << diff.count() << " seconds" << std::endl;
+  printf("requested for %lf seconds\n", diff.count());
 
   return rc;
 }

--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -66,11 +66,11 @@ int request(
 
     if (std::future_status::ready == status) {
       if (*f.get() == *services[service_index].second) {
-        printf("received reply #%zu of %zu\n", service_index + 1, service.size());
+        printf("received reply #%zu of %zu\n", service_index + 1, services.size());
         ++service_index;
       } else {
-        std::cerr << "received reply for request #" << (service_index + 1) <<
-          " does not match the expected reply" << std::endl;
+        fprintf(stderr, "received reply for request #%zu does not match the expected reply\n",
+          service_index + 1);
         rc = 2;
         break;
       }

--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -93,7 +93,7 @@ int request(
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  printf("requested for %lf seconds\n", diff.count());
+  printf("requested for %f seconds\n", diff.count());
 
   return rc;
 }

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -140,7 +140,7 @@ int main(int argc, char ** argv)
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  printf("subscribed for %lf seconds", diff.count());
+  printf("subscribed for %f seconds", diff.count());
 
   rclcpp::shutdown();
   return 0;

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -42,8 +41,7 @@ rclcpp::subscription::SubscriptionBase::SharedPtr subscribe(
       for (auto expected_message : expected_messages) {
         if (*received_message == *expected_message) {
           *received = true;
-          std::cout << "received message #" << (index + 1) << " of " <<
-            expected_messages.size() << std::endl;
+          printf("received message #%zu of %zu\n", index + 1, expected_messages.size());
           known_message = true;
           break;
         }
@@ -142,7 +140,7 @@ int main(int argc, char ** argv)
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  std::cout << "subscribed for " << diff.count() << " seconds" << std::endl;
+  printf("subscribed for %lf seconds", diff.count());
 
   rclcpp::shutdown();
   return 0;

--- a/test_communication/test/test_subscription_valid_data.cpp
+++ b/test_communication/test/test_subscription_valid_data.cpp
@@ -70,7 +70,7 @@ int main(int argc, char ** argv)
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  printf("published and subscribed for %lf seconds\n", diff.count());
+  printf("published and subscribed for %f seconds\n", diff.count());
 
   rclcpp::shutdown();
   return 0;

--- a/test_communication/test/test_subscription_valid_data.cpp
+++ b/test_communication/test/test_subscription_valid_data.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-#include <iostream>
 #include <memory>
 #include <string>
 
@@ -71,7 +70,7 @@ int main(int argc, char ** argv)
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  std::cout << "published and subscribed for " << diff.count() << " seconds" << std::endl;
+  printf("published and subscribed for %lf seconds", diff.count());
 
   rclcpp::shutdown();
   return 0;

--- a/test_communication/test/test_subscription_valid_data.cpp
+++ b/test_communication/test/test_subscription_valid_data.cpp
@@ -70,7 +70,7 @@ int main(int argc, char ** argv)
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  printf("published and subscribed for %lf seconds", diff.count());
+  printf("published and subscribed for %lf seconds\n", diff.count());
 
   rclcpp::shutdown();
   return 0;

--- a/test_rclcpp/test/test_timeout_subscriber.cpp
+++ b/test_rclcpp/test/test_timeout_subscriber.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-#include <iostream>
 #include <stdexcept>
 #include <string>
 
@@ -73,5 +72,5 @@ TEST(CLASSNAME(test_timeout_subscriber, RMW_IMPLEMENTATION), timeout_subscriber)
   rclcpp::shutdown();
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  std::cout << "subscribed for " << diff.count() << " seconds" << std::endl;
+  printf("subscribed for %lf seconds", diff.count());
 }

--- a/test_rclcpp/test/test_timeout_subscriber.cpp
+++ b/test_rclcpp/test/test_timeout_subscriber.cpp
@@ -72,5 +72,5 @@ TEST(CLASSNAME(test_timeout_subscriber, RMW_IMPLEMENTATION), timeout_subscriber)
   rclcpp::shutdown();
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  printf("subscribed for %lf seconds", diff.count());
+  printf("subscribed for %f seconds", diff.count());
 }

--- a/test_security/test/test_secure_publisher.cpp
+++ b/test_security/test/test_secure_publisher.cpp
@@ -55,7 +55,7 @@ int8_t attempt_publish(
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
-  printf("published for %lf seconds\n", diff.count());
+  printf("published for %f seconds\n", diff.count());
 
   return 0;
 }


### PR DESCRIPTION
follow up of https://github.com/ros2/system_tests/pull/230#discussion_r144608837

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3336)](http://ci.ros2.org/job/ci_linux/3336/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=596)](http://ci.ros2.org/job/ci_linux-aarch64/596/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2666)](http://ci.ros2.org/job/ci_osx/2666/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3385)](http://ci.ros2.org/job/ci_windows/3385/) (unrelated test failure)