### PR TITLE
Restore bigobj

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -10,6 +10,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # we dont use add_compile_options with pedantic in message packages
   # because the Python C extensions dont comply with it
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+elseif(MSVC)
+  # /bigobj is needed to avoid error C1128:
+  #   https://msdn.microsoft.com/en-us/library/8578y171.aspx
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 endif()
 
 find_package(ament_cmake_auto REQUIRED)

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -10,7 +10,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # we dont use add_compile_options with pedantic in message packages
   # because the Python C extensions dont comply with it
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
-elseif(MSVC)
+endif()
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND MSVC)
   # /bigobj is needed to avoid error C1128:
   #   https://msdn.microsoft.com/en-us/library/8578y171.aspx
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")

--- a/test_security/CMakeLists.txt
+++ b/test_security/CMakeLists.txt
@@ -8,6 +8,10 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
+elseif(MSVC)
+  # /bigobj is needed to avoid error C1128:
+  #   https://msdn.microsoft.com/en-us/library/8578y171.aspx
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 endif()
 
 find_package(ament_cmake_auto REQUIRED)

--- a/test_security/CMakeLists.txt
+++ b/test_security/CMakeLists.txt
@@ -8,7 +8,8 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
-elseif(MSVC)
+endif()
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND MSVC)
   # /bigobj is needed to avoid error C1128:
   #   https://msdn.microsoft.com/en-us/library/8578y171.aspx
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")


### PR DESCRIPTION
Looks like #239 broke master on windows Debug. This passes again `/bigobj` for the 2 packages that need it

* Windows Release [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3394)](http://ci.ros2.org/job/ci_windows/3394/) 
* Windows Debug [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3395)](http://ci.ros2.org/job/ci_windows/3395/)
* Windows RelWithDebInfo [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3392)](http://ci.ros2.org/job/ci_windows/3392/)