### PR TITLE
Find gtest only once

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -310,6 +310,10 @@ if(BUILD_TESTING)
     set(append_library_dirs "${append_library_dirs}/$<CONFIG>")
   endif()
 
+  # finding gtest once in the highest scope
+  # prevents finding it repeatedly in each local scope
+  ament_find_gtest()
+
   call_for_each_rmw_implementation(targets)
 endif()  # BUILD_TESTING
 

--- a/test_security/CMakeLists.txt
+++ b/test_security/CMakeLists.txt
@@ -254,6 +254,10 @@ if(BUILD_TESTING)
       set(append_library_dirs "${append_library_dirs}/$<CONFIG>")
     endif()
 
+    # finding gtest once in the highest scope
+    # prevents finding it repeatedly in each local scope
+    ament_find_gtest()
+
     call_for_each_rmw_implementation(targets)
   endif()
 endif()  # BUILD_TESTING


### PR DESCRIPTION
find gtest before macro invocation so that its not found at each macro invocation

similar to ros2/rcl#177

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3599)](http://ci.ros2.org/job/ci_linux/3599/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=790)](http://ci.ros2.org/job/ci_linux-aarch64/790/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2937)](http://ci.ros2.org/job/ci_osx/2937/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3689)](http://ci.ros2.org/job/ci_windows/3689/) (unrelated timing failures)