### PR TITLE
reenable Windows service tests: rclcpp requester <=> rclpy replier 

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -184,10 +184,6 @@ if(BUILD_TESTING)
       set(SKIP_TEST "SKIP_TEST")
     endif()
 
-    if(WIN32 AND client_library1 STREQUAL "rclcpp" AND client_library2 STREQUAL "rclpy")
-      set(SKIP_TEST "SKIP_TEST")
-    endif()
-
     set(REQUESTER_RMW ${rmw_implementation1})
     set(REPLIER_RMW ${rmw_implementation2})
     foreach(service_file ${service_files})


### PR DESCRIPTION
Should not be merged before #244 as there is a potential for flakiness without wait_for_service is available (although all tests passed first run in this particular job).

* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3704)](http://ci.ros2.org/job/ci_windows/3704/)