### PR TITLE
Skip python service tests only for connext dynamic

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -186,6 +186,10 @@ if(BUILD_TESTING)
       set(SKIP_TEST "SKIP_TEST")
     endif()
 
+    if(WIN32 AND client_library1 STREQUAL "rclcpp" AND client_library2 STREQUAL "rclpy")
+      set(SKIP_TEST "SKIP_TEST")
+    endif()
+
     set(REQUESTER_RMW ${rmw_implementation1})
     set(REPLIER_RMW ${rmw_implementation2})
     foreach(service_file ${service_files})

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -186,10 +186,6 @@ if(BUILD_TESTING)
       set(SKIP_TEST "SKIP_TEST")
     endif()
 
-    if(WIN32 AND client_library1 STREQUAL "rclcpp" AND client_library2 STREQUAL "rclpy")
-      set(SKIP_TEST "SKIP_TEST")
-    endif()
-
     set(REQUESTER_RMW ${rmw_implementation1})
     set(REPLIER_RMW ${rmw_implementation2})
     foreach(service_file ${service_files})

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -179,9 +179,9 @@ if(BUILD_TESTING)
       set(SKIP_TEST "SKIP_TEST")
     endif()
 
-    # TODO(mikaelarguedas) connext doesn't support C services for now
-    if((client_library1 STREQUAL "rclpy" OR client_library2 STREQUAL "rclpy") AND
-      (rmw_implementation1 MATCHES "(.*)connext(.*)" OR rmw_implementation2 MATCHES "(.*)connext(.*)")
+    # TODO(mikaelarguedas) connext_dynamic doesn't support C services for now
+    if((client_library1 STREQUAL "rclpy" AND rmw_implementation1 MATCHES "rmw_connext_dynamic_cpp") OR
+      (client_library2 STREQUAL "rclpy" AND rmw_implementation2 MATCHES "rmw_connext_dynamic_cpp")
     )
       set(SKIP_TEST "SKIP_TEST")
     endif()

--- a/test_communication/test/replier_py.py
+++ b/test_communication/test/replier_py.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('service_name', default='Primitives',
                         help='name of the ROS message')
-    parser.add_argument('-n', '--number_of_cycles', type=int, default=10,
+    parser.add_argument('-n', '--number_of_cycles', type=int, default=20,
                         help='number of sending attempts')
     args = parser.parse_args()
     try:


### PR DESCRIPTION
We actually have C/python service support for Fast-RTPS, Connext and Opensplice.
The only rmw implementationl not supporting C/Python services is connext_dynamic.

This PR reenables tests for connext. This should not be merged before #244 
The last commit is a workaround for testing as connext startup is too slow and #244 is not merged yet.

Job with only Fast-RTPS and Opensplice:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3620)](http://ci.ros2.org/job/ci_linux/3620/)

Job with only Fast-RTPS and Connext:
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3713)](http://ci.ros2.org/job/ci_windows/3713/)