### PR TITLE
cmake 3.10 compatibility: pass absolute path to file(GENERATE) function

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -151,7 +151,7 @@ if(BUILD_TESTING)
         @ONLY
       )
       file(GENERATE
-        OUTPUT "test_publisher_subscriber${test_suffix}_$<CONFIG>.py"
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_publisher_subscriber${test_suffix}_$<CONFIG>.py"
         INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_publisher_subscriber${test_suffix}.py.configured"
       )
 
@@ -199,7 +199,7 @@ if(BUILD_TESTING)
         @ONLY
       )
       file(GENERATE
-        OUTPUT "test_requester_replier${test_suffix}_$<CONFIG>.py"
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_requester_replier${test_suffix}_$<CONFIG>.py"
         INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_requester_replier${test_suffix}.py.configured"
       )
 

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -83,7 +83,7 @@ if(BUILD_TESTING)
       @ONLY
     )
     file(GENERATE
-      OUTPUT "${test_name}${target_suffix}_$<CONFIG>.py"
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_name}${target_suffix}_$<CONFIG>.py"
       INPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_name}${target_suffix}.py.configure"
     )
     ament_add_pytest_test(${test_name}${target_suffix}
@@ -116,7 +116,7 @@ if(BUILD_TESTING)
       @ONLY
     )
     file(GENERATE
-      OUTPUT "${test_name}${target_suffix}_$<CONFIG>.py"
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_name}${target_suffix}_$<CONFIG>.py"
       INPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_name}${target_suffix}.py.configure"
     )
     ament_add_pytest_test(${test_name}${target_suffix}

--- a/test_security/CMakeLists.txt
+++ b/test_security/CMakeLists.txt
@@ -142,7 +142,7 @@ if(BUILD_TESTING)
             @ONLY
           )
           file(GENERATE
-            OUTPUT "test_secure_publisher_subscriber${test_suffix}_$<CONFIG>.py"
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_secure_publisher_subscriber${test_suffix}_$<CONFIG>.py"
             INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_secure_publisher_subscriber${test_suffix}.py.configured"
           )
           math(EXPR index "${index} + 1")
@@ -177,7 +177,7 @@ if(BUILD_TESTING)
             @ONLY
           )
           file(GENERATE
-            OUTPUT "test_secure_publisher_subscriber${test_suffix}_$<CONFIG>.py"
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_secure_publisher_subscriber${test_suffix}_$<CONFIG>.py"
             INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_secure_publisher_subscriber${test_suffix}.py.configured"
           )
           math(EXPR index "${index} + 1")
@@ -212,7 +212,7 @@ if(BUILD_TESTING)
             @ONLY
           )
           file(GENERATE
-            OUTPUT "test_secure_publisher_subscriber${test_suffix}_$<CONFIG>.py"
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_secure_publisher_subscriber${test_suffix}_$<CONFIG>.py"
             INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_secure_publisher_subscriber${test_suffix}.py.configured"
           )
           math(EXPR index "${index} + 1")


### PR DESCRIPTION
This is needed to support cmake 3.10. We could define the policy based on the version of CMake but I preferred updating the codebase to have something compliant with all cmake versions without relying on undefined behavior.

More details at https://cmake.org/cmake/help/git-stage/policy/CMP0070.html

Example of CMake warning without this patch:
```
Policy CMP0070 is not set: Define file(GENERATE) behavior for relative
paths.  Run "cmake --help-policy CMP0070" for policy details.  Use the
cmake_policy command to set the policy and suppress this warning.

file(GENERATE) given relative OUTPUT path:

  test/test_services__rmw_connext_cpp_RelWithDebInfo.py

This is not defined behavior unless CMP0070 is set to NEW.  For
compatibility with older versions of CMake, the previous undefined behavior
will be used.
```

connects to ros2/rcl#195