### PR TITLE
Regression test for set_parameters with bad callback reference

### DIFF
--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -103,6 +103,41 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_asynchronous) {
   verify_get_parameters_async(node, parameters_client);
 }
 
+TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_async_with_callback) {
+  using rclcpp::parameter::ParameterVariant;
+  using SetParametersResult =
+      std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>>;
+
+  auto node = rclcpp::Node::make_shared("test_parameters_local_async_with_callback");
+  // TODO(esteve): Make the parameter service automatically start with the node.
+  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+  auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
+  rclcpp::executors::SingleThreadedExecutor executor;
+  auto set_parameters_results = parameters_client->set_parameters({
+    ParameterVariant("foo", 2),
+    ParameterVariant("bar", "hello"),
+    ParameterVariant("barstr", std::string("hello_str")),
+    ParameterVariant("baz", 1.45),
+    ParameterVariant("foobar", true),
+    ParameterVariant("barfoo", std::vector<uint8_t>{3, 4, 5}),
+  },
+    [&executor](SetParametersResult future)
+    {
+        printf("Got set_parameters result\n");
+        // Check to see if they were set.
+        for (auto & result : future.get()) {
+          ASSERT_TRUE(result.successful);
+        }
+        executor.cancel();
+    }
+  );
+  executor.add_node(node);
+  executor.spin();
+}
+
 TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   auto node = rclcpp::Node::make_shared("test_parameters_local_helpers");
   // TODO(esteve): Make the parameter service automatically start with the node.

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -103,38 +103,58 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_asynchronous) {
   verify_get_parameters_async(node, parameters_client);
 }
 
-TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_async_with_callback) {
-  using rclcpp::parameter::ParameterVariant;
-  using SetParametersResult =
-      std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>>;
+class ParametersAsyncNode : public rclcpp::Node
+{
+public:
+  ParametersAsyncNode()
+  : Node("test_local_parameters_async_with_callback")
+  {
+  }
 
-  auto node = rclcpp::Node::make_shared("test_parameters_local_async_with_callback");
+  void queue_set_parameter_request(rclcpp::executors::SingleThreadedExecutor & executor)
+  {
+    using rclcpp::parameter::ParameterVariant;
+    using SetParametersResult =
+        std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>>;
+    auto set_parameters_results = parameters_client_->set_parameters({
+      ParameterVariant("foo", 2),
+      ParameterVariant("bar", "hello"),
+      ParameterVariant("barstr", std::string("hello_str")),
+      ParameterVariant("baz", 1.45),
+      ParameterVariant("foobar", true),
+      ParameterVariant("barfoo", std::vector<uint8_t>{3, 4, 5}),
+    },
+        [&executor](SetParametersResult future)
+        {
+          printf("Got set_parameters result\n");
+          // Check to see if they were set.
+          for (auto & result : future.get()) {
+            ASSERT_TRUE(result.successful);
+          }
+          executor.cancel();
+        }
+      );
+  }
+
+  rclcpp::AsyncParametersClient::SharedPtr parameters_client_;
+};
+
+// Regression test for calling parameter client async services, but having the specified callback
+// go out of scope before it gets called: see https://github.com/ros2/rclcpp/pull/414
+TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_async_with_callback) {
+  auto node = std::make_shared<ParametersAsyncNode>();
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
-  auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
-  if (!parameters_client->wait_for_service(20s)) {
+  // TODO(dhood): Make the parameter client constructable from Node subclass' constructor.
+  node->parameters_client_ =
+    std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
+  if (!node->parameters_client_->wait_for_service(20s)) {
     ASSERT_TRUE(false) << "service not available after waiting";
   }
   rclcpp::executors::SingleThreadedExecutor executor;
-  auto set_parameters_results = parameters_client->set_parameters({
-    ParameterVariant("foo", 2),
-    ParameterVariant("bar", "hello"),
-    ParameterVariant("barstr", std::string("hello_str")),
-    ParameterVariant("baz", 1.45),
-    ParameterVariant("foobar", true),
-    ParameterVariant("barfoo", std::vector<uint8_t>{3, 4, 5}),
-  },
-    [&executor](SetParametersResult future)
-    {
-        printf("Got set_parameters result\n");
-        // Check to see if they were set.
-        for (auto & result : future.get()) {
-          ASSERT_TRUE(result.successful);
-        }
-        executor.cancel();
-    }
-  );
   executor.add_node(node);
+  node->queue_set_parameter_request(executor);
+  // When the parameters client receives its response it will cancel the executor.
   executor.spin();
 }
 

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -109,6 +109,8 @@ public:
   ParametersAsyncNode()
   : Node("test_local_parameters_async_with_callback")
   {
+    parameters_client_ =
+      std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(this);
   }
 
   void queue_set_parameter_request(rclcpp::executors::SingleThreadedExecutor & executor)
@@ -145,9 +147,6 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_async_with_call
   auto node = std::make_shared<ParametersAsyncNode>();
   // TODO(esteve): Make the parameter service automatically start with the node.
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
-  // TODO(dhood): Make the parameter client constructable from Node subclass' constructor.
-  node->parameters_client_ =
-    std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
   if (!node->parameters_client_->wait_for_service(20s)) {
     ASSERT_TRUE(false) << "service not available after waiting";
   }


### PR DESCRIPTION
Connects to ros2/rclcpp#414
Regression test for https://github.com/ros2/rclcpp/pull/414

Without https://github.com/ros2/rclcpp/pull/414, the test will crash (I'm getting `C++ exception with description "std::bad_alloc" thrown in the test body.` but in https://github.com/ros2/demos/pull/203/files#diff-a5a151889abb3214250ba9db05358e4bR92 it would segfault).

CI including ros2/rclcpp#414
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3695)](http://ci.ros2.org/job/ci_linux/3695/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=862)](http://ci.ros2.org/job/ci_linux-aarch64/862/)
* macOS skipped because queue is busy
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3799
)](http://ci.ros2.org/job/ci_windows/3799/)