### PR TITLE
[test_communication] Unique namespaces

### DIFF
--- a/test_communication/test/publisher_py.py
+++ b/test_communication/test/publisher_py.py
@@ -18,7 +18,7 @@ import sys
 import time
 
 
-def talker(message_name, number_of_cycles):
+def talker(message_name, number_of_cycles, namespace):
     from test_msgs.message_fixtures import get_test_msg
     import rclpy
 
@@ -28,10 +28,10 @@ def talker(message_name, number_of_cycles):
 
     rclpy.init(args=[])
 
-    node = rclpy.create_node('talker')
+    node = rclpy.create_node('talker', namespace=namespace)
 
     chatter_pub = node.create_publisher(
-        msg_mod, 'test_message_' + message_name)
+        msg_mod, 'test/message/' + message_name)
 
     cycle_count = 0
     print('talker: beginning loop')
@@ -53,12 +53,15 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('message_name', default='Primitives',
                         help='name of the ROS message')
+    parser.add_argument('namespace', default='',
+                        help='namespace of the ROS node')
     parser.add_argument('-n', '--number_of_cycles', type=int, default=100,
                         help='number of sending attempts')
     args = parser.parse_args()
     try:
         talker(
             message_name=args.message_name,
+            namespace=args.namespace,
             number_of_cycles=args.number_of_cycles)
     except KeyboardInterrupt:
         print('talker stopped cleanly')

--- a/test_communication/test/publisher_py.py
+++ b/test_communication/test/publisher_py.py
@@ -51,10 +51,8 @@ def talker(message_name, number_of_cycles, namespace):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('message_name', default='Primitives',
-                        help='name of the ROS message')
-    parser.add_argument('namespace', default='',
-                        help='namespace of the ROS node')
+    parser.add_argument('message_name', help='name of the ROS message')
+    parser.add_argument('namespace', help='namespace of the ROS node')
     parser.add_argument('-n', '--number_of_cycles', type=int, default=100,
                         help='number of sending attempts')
     args = parser.parse_args()

--- a/test_communication/test/replier_py.py
+++ b/test_communication/test/replier_py.py
@@ -58,12 +58,10 @@ def replier(service_name, number_of_cycles, namespace):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('service_name', default='Primitives',
-                        help='name of the ROS message')
+    parser.add_argument('service_name', help='name of the ROS message')
+    parser.add_argument('namespace', help='namespace of the ROS node')
     parser.add_argument('-n', '--number_of_cycles', type=int, default=20,
                         help='number of sending attempts')
-    parser.add_argument('namespace', default='',
-                        help='namespace of the ROS node')
     args = parser.parse_args()
     try:
         replier(

--- a/test_communication/test/replier_py.py
+++ b/test_communication/test/replier_py.py
@@ -26,7 +26,7 @@ def replier_callback(request, response, srv_fixtures):
             return resp
 
 
-def replier(service_name, number_of_cycles):
+def replier(service_name, number_of_cycles, namespace):
     from test_msgs.service_fixtures import get_test_srv
     import rclpy
 
@@ -36,7 +36,7 @@ def replier(service_name, number_of_cycles):
 
     rclpy.init(args=[])
 
-    node = rclpy.create_node('replier')
+    node = rclpy.create_node('replier', namespace=namespace)
 
     srv_fixtures = get_test_srv(service_name)
 
@@ -44,7 +44,7 @@ def replier(service_name, number_of_cycles):
         replier_callback, srv_fixtures=srv_fixtures)
 
     node.create_service(
-        srv_mod, 'test_service_' + service_name, chatter_callback)
+        srv_mod, 'test/service/' + service_name, chatter_callback)
 
     spin_count = 1
     print('replier: beginning loop')
@@ -62,11 +62,15 @@ if __name__ == '__main__':
                         help='name of the ROS message')
     parser.add_argument('-n', '--number_of_cycles', type=int, default=20,
                         help='number of sending attempts')
+    parser.add_argument('namespace', default='',
+                        help='namespace of the ROS node')
     args = parser.parse_args()
     try:
         replier(
             service_name=args.service_name,
-            number_of_cycles=args.number_of_cycles)
+            number_of_cycles=args.number_of_cycles,
+            namespace=args.namespace
+        )
     except KeyboardInterrupt:
         print('server stopped cleanly')
     except BaseException:

--- a/test_communication/test/requester_py.py
+++ b/test_communication/test/requester_py.py
@@ -17,7 +17,7 @@ import importlib
 import sys
 
 
-def requester(service_name):
+def requester(service_name, namespace):
     import rclpy
     from test_msgs.service_fixtures import get_test_srv
 
@@ -27,11 +27,11 @@ def requester(service_name):
     srv_mod = getattr(module, service_name)
 
     srv_fixtures = get_test_srv(service_name)
-    service_name = 'test_service_' + service_name
+    service_name = 'test/service/' + service_name
 
     rclpy.init(args=[])
     try:
-        node = rclpy.create_node('requester')
+        node = rclpy.create_node('requester', namespace=namespace)
         try:
             # wait for the service to be available
             client = node.create_client(srv_mod, service_name)
@@ -60,9 +60,11 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('service_name', default='Primitives',
                         help='name of the ROS message')
+    parser.add_argument('namespace', default='',
+                        help='namespace of the ROS node')
     args = parser.parse_args()
     try:
-        requester(service_name=args.service_name)
+        requester(service_name=args.service_name, namespace=args.namespace)
     except KeyboardInterrupt:
         print('requester stopped cleanly')
     except BaseException:

--- a/test_communication/test/requester_py.py
+++ b/test_communication/test/requester_py.py
@@ -58,10 +58,8 @@ def requester(service_name, namespace):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('service_name', default='Primitives',
-                        help='name of the ROS message')
-    parser.add_argument('namespace', default='',
-                        help='namespace of the ROS node')
+    parser.add_argument('service_name', help='name of the ROS message')
+    parser.add_argument('namespace', help='namespace of the ROS node')
     args = parser.parse_args()
     try:
         requester(service_name=args.service_name, namespace=args.namespace)

--- a/test_communication/test/subscriber_py.py
+++ b/test_communication/test/subscriber_py.py
@@ -74,10 +74,8 @@ def listener(message_name, namespace):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('message_name', default='Primitives',
-                        help='name of the ROS message')
-    parser.add_argument('namespace', default='',
-                        help='namespace of the ROS node')
+    parser.add_argument('message_name', help='name of the ROS message')
+    parser.add_argument('namespace', help='namespace of the ROS node')
     args = parser.parse_args()
     try:
         listener(message_name=args.message_name, namespace=args.namespace)

--- a/test_communication/test/subscriber_py.py
+++ b/test_communication/test/subscriber_py.py
@@ -38,7 +38,7 @@ def listener_cb(msg, received_messages, expected_msgs):
         raise RuntimeError('received unexpected message %r' % msg)
 
 
-def listener(message_name):
+def listener(message_name, namespace):
     from test_msgs.message_fixtures import get_test_msg
     import rclpy
 
@@ -48,7 +48,7 @@ def listener(message_name):
 
     rclpy.init(args=[])
 
-    node = rclpy.create_node('listener')
+    node = rclpy.create_node('listener', namespace=namespace)
 
     received_messages = []
     expected_msgs = [(i, repr(msg)) for i, msg in enumerate(get_test_msg(message_name))]
@@ -57,7 +57,7 @@ def listener(message_name):
         listener_cb, received_messages=received_messages, expected_msgs=expected_msgs)
 
     node.create_subscription(
-        msg_mod, 'test_message_' + message_name, chatter_callback)
+        msg_mod, 'test/message/' + message_name, chatter_callback)
 
     spin_count = 1
     print('subscriber: beginning loop')
@@ -76,9 +76,11 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('message_name', default='Primitives',
                         help='name of the ROS message')
+    parser.add_argument('namespace', default='',
+                        help='namespace of the ROS node')
     args = parser.parse_args()
     try:
-        listener(message_name=args.message_name)
+        listener(message_name=args.message_name, namespace=args.namespace)
     except KeyboardInterrupt:
         print('subscriber stopped cleanly')
     except BaseException:

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -33,7 +33,7 @@ void publish(
   custom_qos_profile.depth = messages.size();
 
   auto publisher = node->create_publisher<T>(
-    std::string("test_message_") + message_type, custom_qos_profile);
+    std::string("test/message/") + message_type, custom_qos_profile);
 
   rclcpp::WallRate cycle_rate(10);
   rclcpp::WallRate message_rate(100);
@@ -59,14 +59,16 @@ void publish(
 
 int main(int argc, char ** argv)
 {
-  if (argc != 2) {
+  if (argc != 3) {
     fprintf(stderr, "Wrong number of arguments, pass one message type\n");
     return 1;
   }
   rclcpp::init(argc, argv);
 
   std::string message = argv[1];
-  auto node = rclcpp::Node::make_shared(std::string("test_publisher_") + message);
+  std::string namespace_ = argv[2];
+  auto node = rclcpp::Node::make_shared(
+    std::string("test_publisher_") + message, namespace_);
 
   if (message == "Empty") {
     publish<test_msgs::msg::Empty>(node, message, get_messages_empty());

--- a/test_communication/test/test_publisher_subscriber.py.in
+++ b/test_communication/test/test_publisher_subscriber.py.in
@@ -10,7 +10,7 @@ from launch.launcher import DefaultLauncher
 
 
 def test_publisher_subscriber():
-    namespace = '/test_time_%s' % time.strftime("%H_%M_%S", time.gmtime())
+    namespace = '/test_time_%s' % time.strftime('%H_%M_%S', time.gmtime())
     ld = LaunchDescriptor()
     publisher_cmd = ['@TEST_PUBLISHER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@', namespace]
     subscriber_cmd = ['@TEST_SUBSCRIBER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@', namespace]

--- a/test_communication/test/test_publisher_subscriber.py.in
+++ b/test_communication/test/test_publisher_subscriber.py.in
@@ -1,8 +1,8 @@
 # generated from test_communication/test/test_publisher_subscriber.py.in
 
-import datetime
 import os
 import sys
+import time
 
 from launch import LaunchDescriptor
 from launch.exit_handler import primary_exit_handler
@@ -10,8 +10,7 @@ from launch.launcher import DefaultLauncher
 
 
 def test_publisher_subscriber():
-    now = datetime.datetime.now()
-    namespace = '/test_time_{0}_{1}_{2}'.format(now.hour, now.minute, now.second)
+    namespace = '/test_time_%s' % time.strftime("%H_%M_%S", time.gmtime())
     ld = LaunchDescriptor()
     publisher_cmd = ['@TEST_PUBLISHER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@', namespace]
     subscriber_cmd = ['@TEST_SUBSCRIBER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@', namespace]

--- a/test_communication/test/test_publisher_subscriber.py.in
+++ b/test_communication/test/test_publisher_subscriber.py.in
@@ -1,5 +1,6 @@
 # generated from test_communication/test/test_publisher_subscriber.py.in
 
+import datetime
 import os
 import sys
 
@@ -9,9 +10,11 @@ from launch.launcher import DefaultLauncher
 
 
 def test_publisher_subscriber():
+    now = datetime.datetime.now()
+    namespace = '/test_time_{0}_{1}_{2}'.format(now.hour, now.minute, now.second)
     ld = LaunchDescriptor()
-    publisher_cmd = ['@TEST_PUBLISHER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@']
-    subscriber_cmd = ['@TEST_SUBSCRIBER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@']
+    publisher_cmd = ['@TEST_PUBLISHER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@', namespace]
+    subscriber_cmd = ['@TEST_SUBSCRIBER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@', namespace]
 
     publisher_env = dict(os.environ)
     subscriber_env = dict(os.environ)

--- a/test_communication/test/test_replier.cpp
+++ b/test_communication/test/test_replier.cpp
@@ -73,8 +73,7 @@ int main(int argc, char ** argv)
   std::string namespace_ = argv[2];
   auto node = rclcpp::Node::make_shared(
     std::string("test_replier_") + service,
-    namespace_
-  );
+    namespace_);
 
   auto services_empty = get_services_empty();
   auto services_primitives = get_services_primitives();

--- a/test_communication/test/test_replier.cpp
+++ b/test_communication/test/test_replier.cpp
@@ -56,12 +56,12 @@ typename rclcpp::Service<T>::SharedPtr reply(
     };
   // *INDENT-ON*
 
-  return node->create_service<T>(std::string("test_service_") + service_type, callback);
+  return node->create_service<T>(std::string("test/service/") + service_type, callback);
 }
 
 int main(int argc, char ** argv)
 {
-  if (argc != 2) {
+  if (argc != 3) {
     fprintf(stderr, "Wrong number of arguments, pass one service type\n");
     return 1;
   }
@@ -70,7 +70,11 @@ int main(int argc, char ** argv)
   auto start = std::chrono::steady_clock::now();
 
   std::string service = argv[1];
-  auto node = rclcpp::Node::make_shared(std::string("test_replier_") + service);
+  std::string namespace_ = argv[2];
+  auto node = rclcpp::Node::make_shared(
+    std::string("test_replier_") + service,
+    namespace_
+  );
 
   auto services_empty = get_services_empty();
   auto services_primitives = get_services_primitives();

--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -38,7 +38,7 @@ int request(
   size_t number_of_cycles = 10)
 {
   int rc = 0;
-  auto requester = node->create_client<T>(std::string("test_service_") + service_type);
+  auto requester = node->create_client<T>(std::string("test/service/") + service_type);
   if (!requester->wait_for_service(20s)) {
     throw std::runtime_error("requester service not available after waiting");
   }
@@ -101,13 +101,17 @@ int request(
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  if (argc != 2) {
+  if (argc != 3) {
     fprintf(stderr, "Wrong number of arguments, pass one service type\n");
     return 1;
   }
 
   std::string service = argv[1];
-  auto node = rclcpp::Node::make_shared(std::string("test_requester_") + service);
+  std::string namespace_ = argv[2];
+  auto node = rclcpp::Node::make_shared(
+    std::string("test_requester_") + service,
+    namespace_
+  );
 
   int rc;
   if (service == "Empty") {

--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -110,8 +110,7 @@ int main(int argc, char ** argv)
   std::string namespace_ = argv[2];
   auto node = rclcpp::Node::make_shared(
     std::string("test_requester_") + service,
-    namespace_
-  );
+    namespace_);
 
   int rc;
   if (service == "Empty") {

--- a/test_communication/test/test_requester_replier.py.in
+++ b/test_communication/test/test_requester_replier.py.in
@@ -1,5 +1,6 @@
 # generated from test_communication/test/test_requester_replier.py.in
 
+import datetime
 import os
 import sys
 
@@ -9,9 +10,12 @@ from launch.launcher import DefaultLauncher
 
 
 def test_requester_replier():
+    now = datetime.datetime.now()
+    namespace = '/test_time_{0}_{1}_{2}'.format(now.hour, now.minute, now.second)
+
     ld = LaunchDescriptor()
-    requester_cmd = ['@TEST_REQUESTER_EXECUTABLE@', '@TEST_SERVICE_TYPE@']
-    replier_cmd = ['@TEST_REPLIER_EXECUTABLE@', '@TEST_SERVICE_TYPE@']
+    requester_cmd = ['@TEST_REQUESTER_EXECUTABLE@', '@TEST_SERVICE_TYPE@', namespace]
+    replier_cmd = ['@TEST_REPLIER_EXECUTABLE@', '@TEST_SERVICE_TYPE@', namespace]
 
     replier_env = dict(os.environ)
     requester_env = dict(os.environ)

--- a/test_communication/test/test_requester_replier.py.in
+++ b/test_communication/test/test_requester_replier.py.in
@@ -10,7 +10,7 @@ from launch.launcher import DefaultLauncher
 
 
 def test_requester_replier():
-    namespace = '/test_time_%s' % time.strftime("%H_%M_%S", time.gmtime())
+    namespace = '/test_time_%s' % time.strftime('%H_%M_%S', time.gmtime())
 
     ld = LaunchDescriptor()
     requester_cmd = ['@TEST_REQUESTER_EXECUTABLE@', '@TEST_SERVICE_TYPE@', namespace]

--- a/test_communication/test/test_requester_replier.py.in
+++ b/test_communication/test/test_requester_replier.py.in
@@ -1,8 +1,8 @@
 # generated from test_communication/test/test_requester_replier.py.in
 
-import datetime
 import os
 import sys
+import time
 
 from launch import LaunchDescriptor
 from launch.exit_handler import primary_exit_handler
@@ -10,8 +10,7 @@ from launch.launcher import DefaultLauncher
 
 
 def test_requester_replier():
-    now = datetime.datetime.now()
-    namespace = '/test_time_{0}_{1}_{2}'.format(now.hour, now.minute, now.second)
+    namespace = '/test_time_%s' % time.strftime("%H_%M_%S", time.gmtime())
 
     ld = LaunchDescriptor()
     requester_cmd = ['@TEST_REQUESTER_EXECUTABLE@', '@TEST_SERVICE_TYPE@', namespace]

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -67,13 +67,13 @@ rclcpp::SubscriptionBase::SharedPtr subscribe(
   custom_qos_profile.depth = expected_messages.size();
 
   auto subscriber = node->create_subscription<T>(
-    std::string("test_message_") + message_type, callback, custom_qos_profile);
+    std::string("test/message/") + message_type, callback, custom_qos_profile);
   return subscriber;
 }
 
 int main(int argc, char ** argv)
 {
-  if (argc != 2) {
+  if (argc != 3) {
     fprintf(stderr, "Wrong number of arguments, pass one message type\n");
     return 1;
   }
@@ -82,7 +82,9 @@ int main(int argc, char ** argv)
   auto start = std::chrono::steady_clock::now();
 
   std::string message = argv[1];
-  auto node = rclcpp::Node::make_shared(std::string("test_subscriber_") + message);
+  std::string namespace_ = argv[2];
+  auto node = rclcpp::Node::make_shared(
+    std::string("test_subscriber_") + message, namespace_);
 
   auto messages_empty = get_messages_empty();
   auto messages_primitives = get_messages_primitives();

--- a/test_security/test/test_secure_publisher_subscriber.py.in
+++ b/test_security/test/test_secure_publisher_subscriber.py.in
@@ -10,7 +10,7 @@ from launch.launcher import DefaultLauncher
 
 
 def test_secure_publisher_subscriber():
-    namespace = '/test_time_%s' % time.strftime("%H_%M_%S", time.gmtime())
+    namespace = '/test_time_%s' % time.strftime('%H_%M_%S', time.gmtime())
 
     ld = LaunchDescriptor()
     publisher_cmd = [

--- a/test_security/test/test_secure_publisher_subscriber.py.in
+++ b/test_security/test/test_secure_publisher_subscriber.py.in
@@ -1,8 +1,8 @@
 # generated from test_communication/test/test_secure_publisher_subscriber.py.in
 
-import datetime
 import os
 # import sys
+import time
 
 from launch import LaunchDescriptor
 from launch.exit_handler import primary_exit_handler
@@ -10,8 +10,7 @@ from launch.launcher import DefaultLauncher
 
 
 def test_secure_publisher_subscriber():
-    now = datetime.datetime.now()
-    namespace = '/test_time_{0}_{1}_{2}'.format(now.hour, now.minute, now.second)
+    namespace = '/test_time_%s' % time.strftime("%H_%M_%S", time.gmtime())
 
     ld = LaunchDescriptor()
     publisher_cmd = [


### PR DESCRIPTION
equivalent of #243 for test_communication

This adds unique namespace to all nodes pub/sub nodes as well as add slashes to the topic / service names.
This will regression test https://github.com/ros2/rmw_opensplice/issues/220 as well as making sure to avoid cross talk when repeating tests.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3780)](http://ci.ros2.org/job/ci_linux/3780/) (incudes linter fix commit)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=918)](http://ci.ros2.org/job/ci_linux-aarch64/918/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3116)](http://ci.ros2.org/job/ci_osx/3116/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3867)](http://ci.ros2.org/job/ci_windows/3867/)