### PR TITLE
Longer timeout for tests with two clients

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -192,11 +192,11 @@ if(BUILD_TESTING)
 
     custom_launch_test_two_executables(test_client_scope_cpp
       test_client_scope_server_cpp test_client_scope_client_cpp
-      TIMEOUT 30)
+      TIMEOUT 60)
 
     custom_launch_test_two_executables(test_client_scope_consistency_cpp
       test_client_scope_consistency_server_cpp test_client_scope_consistency_client_cpp
-      TIMEOUT 30)
+      TIMEOUT 60)
 
     # Note (dhood): signal handler tests will be skipped on Windows because there is no opportunity
     # for signal handling once shutdown is triggered by launch_testing.


### PR DESCRIPTION
Fixes https://github.com/ros2/system_tests/issues/212

Linux CI with `ament_test_args: --only test_rclcpp --retest-until-fail 150 --ctest-args -R client_scope`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4030)](https://ci.ros2.org/job/ci_linux/4030/)