### PR TITLE
account for null-terminator character

### DIFF
--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -714,7 +714,7 @@ void get_message(test_msgs__msg__DynamicArrayPrimitives * msg, size_t msg_num)
         msg->uint32_values.data[i] = (uint32_t)i;
         msg->int64_values.data[i] = (int64_t)i;
         msg->uint64_values.data[i] = (uint64_t)i;
-        char tmpstr[4];
+        char tmpstr[5];
         snprintf(tmpstr, sizeof(tmpstr), "%zu", i);
         rosidl_generator_c__String__assign(&msg->string_values.data[i], tmpstr);
       }

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -714,7 +714,10 @@ void get_message(test_msgs__msg__DynamicArrayPrimitives * msg, size_t msg_num)
         msg->uint32_values.data[i] = (uint32_t)i;
         msg->int64_values.data[i] = (int64_t)i;
         msg->uint64_values.data[i] = (uint64_t)i;
-        char tmpstr[5];
+        // Here we use 21 to represent `size` as a string
+        // we need 20 characters to represent all size_t values (assuming it's 64bits)
+        // +1 character for the null-terminator
+        char tmpstr[21];
         snprintf(tmpstr, sizeof(tmpstr), "%zu", i);
         rosidl_generator_c__String__assign(&msg->string_values.data[i], tmpstr);
       }


### PR DESCRIPTION
This fixes a [gcc warning](https://ci.ros2.org/job/ci_packaging_linux/92/warnings23Result/package.-1552620408/) as the string to store can be up to 4 numeric characters + the null-terminator so the container should be of size 5.



related to https://github.com/ros2/ros2/issues/481