### PR TITLE
use new launch legacy namespace

### DIFF
--- a/test_cli_remapping/test/test_cli_remapping.py
+++ b/test_cli_remapping/test/test_cli_remapping.py
@@ -19,9 +19,9 @@ import random
 import sys
 import time
 
-from launch import LaunchDescriptor
-from launch.exit_handler import primary_exit_handler
-from launch.launcher import DefaultLauncher
+from launch.legacy import LaunchDescriptor
+from launch.legacy.exit_handler import primary_exit_handler
+from launch.legacy.launcher import DefaultLauncher
 import pytest
 import rclpy
 


### PR DESCRIPTION
follow up of https://github.com/ros2/launch/pull/73

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4546)](http://ci.ros2.org/job/ci_linux/4546/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1459)](http://ci.ros2.org/job/ci_linux-aarch64/1459/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3733)](http://ci.ros2.org/job/ci_osx/3733/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4621)](http://ci.ros2.org/job/ci_windows/4621/)