### PR TITLE
Use debug python executable on windows

### DIFF
--- a/test_cli/CMakeLists.txt
+++ b/test_cli/CMakeLists.txt
@@ -5,6 +5,9 @@ project(test_cli)
 find_package(ament_cmake_auto REQUIRED)
 
 if(BUILD_TESTING)
+  # Provides PYTHON_EXECUTABLE_DEBUG
+  find_package(python_cmake_module REQUIRED)
+  find_package(PythonExtra REQUIRED)
   set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
   if(WIN32)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/test_cli/CMakeLists.txt
+++ b/test_cli/CMakeLists.txt
@@ -5,6 +5,13 @@ project(test_cli)
 find_package(ament_cmake_auto REQUIRED)
 
 if(BUILD_TESTING)
+  set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+  if(WIN32)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+      set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
+    endif()
+  endif()
+
   # Default to C++14
   if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 14)
@@ -24,6 +31,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(test_params_yaml
     test/test_params_yaml.py
+    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     ENV
       INITIAL_PARAMS_RCLCPP=$<TARGET_FILE:initial_params_rclcpp>
   )

--- a/test_cli/package.xml
+++ b/test_cli/package.xml
@@ -10,6 +10,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <build_depend>ament_cmake</build_depend>
 

--- a/test_cli_remapping/CMakeLists.txt
+++ b/test_cli_remapping/CMakeLists.txt
@@ -5,6 +5,9 @@ project(test_cli_remapping)
 find_package(ament_cmake_auto REQUIRED)
 
 if(BUILD_TESTING)
+  # Provides PYTHON_EXECUTABLE_DEBUG
+  find_package(python_cmake_module REQUIRED)
+  find_package(PythonExtra REQUIRED)
   set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
   if(WIN32)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/test_cli_remapping/CMakeLists.txt
+++ b/test_cli_remapping/CMakeLists.txt
@@ -5,6 +5,13 @@ project(test_cli_remapping)
 find_package(ament_cmake_auto REQUIRED)
 
 if(BUILD_TESTING)
+  set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+  if(WIN32)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+      set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
+    endif()
+  endif()
+
   # Default to C++14
   if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 14)
@@ -26,6 +33,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(test_cli_remapping
     test/test_cli_remapping.py
+    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     ENV
       NAME_MAKER_RCLCPP=$<TARGET_FILE:name_maker_rclcpp>
       NAME_MAKER_RCLPY=${CMAKE_CURRENT_SOURCE_DIR}/test/name_maker.py

--- a/test_cli_remapping/package.xml
+++ b/test_cli_remapping/package.xml
@@ -10,6 +10,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <build_depend>ament_cmake</build_depend>
 

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -57,6 +57,10 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_pytest REQUIRED)
 
+  # Provides PYTHON_EXECUTABLE_DEBUG
+  find_package(python_cmake_module REQUIRED)
+  find_package(PythonExtra REQUIRED)
+
   # get the rmw implementations ahead of time
   find_package(rmw_implementation_cmake REQUIRED)
   get_available_rmw_implementations(rmw_implementations2)

--- a/test_communication/package.xml
+++ b/test_communication/package.xml
@@ -15,6 +15,7 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>


### PR DESCRIPTION
Copies the logic from `test_communication` to use the debug python executable on windows when appropriate.

CI just windows debug [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4686)](https://ci.ros2.org/job/ci_windows/4686/)

context
* https://github.com/ros2/system_tests/pull/268#issuecomment-396023023
* https://github.com/ros2/system_tests/pull/274#issuecomment-396023045
