### PR TITLE
remove unused builtin_interfaces dependency

### DIFF
--- a/test_communication/package.xml
+++ b/test_communication/package.xml
@@ -11,13 +11,11 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
-  <build_depend>builtin_interfaces</build_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>python_cmake_module</buildtool_depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake</test_depend>


### PR DESCRIPTION
this is not required since Builtins.msg has been moved to the test_msgs package https://github.com/ros2/system_tests/pull/223

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4860)](http://ci.ros2.org/job/ci_linux/4860/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1713)](http://ci.ros2.org/job/ci_linux-aarch64/1713/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4049)](http://ci.ros2.org/job/ci_osx/4049/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4909)](http://ci.ros2.org/job/ci_windows/4909/)