### PR TITLE
Test parameter behavior for rclpy nodes

### DIFF
--- a/test_cli/CMakeLists.txt
+++ b/test_cli/CMakeLists.txt
@@ -37,7 +37,7 @@ if(BUILD_TESTING)
     PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     ENV
       INITIAL_PARAMS_RCLCPP=$<TARGET_FILE:initial_params_rclcpp>
-      INITIAL_PARAMS_RCLPY=test/initial_params.py
+      INITIAL_PARAMS_RCLPY=${CMAKE_CURRENT_LIST_DIR}/test/initial_params.py
   )
   set_tests_properties(test_params_yaml
     PROPERTIES DEPENDS

--- a/test_cli/CMakeLists.txt
+++ b/test_cli/CMakeLists.txt
@@ -37,6 +37,7 @@ if(BUILD_TESTING)
     PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     ENV
       INITIAL_PARAMS_RCLCPP=$<TARGET_FILE:initial_params_rclcpp>
+      INITIAL_PARAMS_RCLPY=test/initial_params.py
   )
   set_tests_properties(test_params_yaml
     PROPERTIES DEPENDS

--- a/test_cli/test/initial_params.py
+++ b/test_cli/test/initial_params.py
@@ -1,0 +1,31 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+import rclpy
+
+
+def main(argv=sys.argv):
+    rclpy.init(args=argv)
+
+    node = rclpy.create_node('initial_params_node', namespace='/')
+    rclpy.spin(node)
+
+    rclpy.shutdown()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test_cli/test/test_params_yaml.py
+++ b/test_cli/test/test_params_yaml.py
@@ -25,6 +25,7 @@ from .utils import TemporaryFileWithContent
 
 CLIENT_LIBRARY_EXECUTABLES = (
     require_environment_variable('INITIAL_PARAMS_RCLCPP'),
+    require_environment_variable('INITIAL_PARAMS_RCLPY'),
 )
 
 

--- a/test_cli/test/utils.py
+++ b/test_cli/test/utils.py
@@ -40,6 +40,7 @@ class HelperCommand:
 
         # Execute python files using same python used to start this test
         if command[0][-3:] == '.py':
+            self._command = list(self._command)
             self._command.insert(0, sys.executable)
             self._env['PYTHONUNBUFFERED'] = '1'
 


### PR DESCRIPTION
Adds an rclpy node to the test fixtures so that our tests cover both client libraries.

For these tests to succeed they must be run along with https://github.com/ros2/rclpy/pull/225

Connects to ros2/rclpy#202