### PR TITLE
change timer with period of 0s to 1ms

### DIFF
--- a/test_rclcpp/test/test_executor.cpp
+++ b/test_rclcpp/test/test_executor.cpp
@@ -43,7 +43,7 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), recursive_spin_call) {
   rclcpp::executors::SingleThreadedExecutor executor;
   auto node = rclcpp::Node::make_shared("recursive_spin_call");
   auto timer = node->create_wall_timer(
-    0s,
+    1mss,
     [&executor]() {
       ASSERT_THROW(executor.spin_some(), std::runtime_error);
       ASSERT_THROW(executor.spin_once(), std::runtime_error);
@@ -70,7 +70,7 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), multithreaded_spin_call) {
       executor.cancel();
     });
   auto timer = node->create_wall_timer(
-    0s,
+    1ms,
     [&m, &cv, &ready]() {
       if (!ready) {
         {


### PR DESCRIPTION
Related to ros2/rcl#291.

A timer with a period of 0s is kind of weird. It implies an infinite frequency.