### PR TITLE
Fix warnings

### DIFF
--- a/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
+++ b/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
@@ -62,7 +62,7 @@ TEST(
     };
   // code to do the publish function
   auto publish_func =
-    [&custom_qos](
+    [](
     rclcpp::Publisher<test_rclcpp::msg::UInt32>::SharedPtr publisher,
     test_rclcpp::msg::UInt32::SharedPtr msg)
     {

--- a/test_rclcpp/test/test_client_scope_consistency_client.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_client.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <inttypes.h>
+
 #include <chrono>
 #include <iostream>
 #include <memory>
@@ -71,7 +73,7 @@ TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_consistency_reg
         printf("received correct result\n");
         std::cout.flush();
       } else {
-        printf("received incorrect result: %zd\n", result1.get()->sum);
+        printf("received incorrect result: %" PRId64 "\n", result1.get()->sum);
         std::cout.flush();
       }
     } else {
@@ -107,7 +109,7 @@ TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_consistency_reg
         printf("received correct result\n");
         std::cout.flush();
       } else {
-        printf("received incorrect result: %zd\n", result2.get()->sum);
+        printf("received incorrect result: %" PRId64 "\n", result2.get()->sum);
         std::cout.flush();
       }
     } else {

--- a/test_rclcpp/test/test_multiple_service_calls.cpp
+++ b/test_rclcpp/test/test_multiple_service_calls.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <inttypes.h>
+
 #include <chrono>
 #include <iostream>
 #include <memory>
@@ -184,7 +186,7 @@ TEST(CLASSNAME(test_multiple_service_calls, RMW_IMPLEMENTATION), multiple_client
   for (uint32_t i = 0; i < results.size(); ++i) {
     ASSERT_EQ(std::future_status::ready, results[i].wait_for(std::chrono::seconds(0)));
     EXPECT_EQ(results[i].get()->sum, 2 * i + 1);
-    printf("Got response #%u with value %zd\n", i, results[i].get()->sum);
+    printf("Got response #%u with value %" PRId64 "\n", i, results[i].get()->sum);
     fflush(stdout);
   }
 }


### PR DESCRIPTION
This PR fixes some warnings that are being thrown by MacOS High Sierra and later.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5270)](http://ci.ros2.org/job/ci_linux/5270/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2026)](http://ci.ros2.org/job/ci_linux-aarch64/2026/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4386)](http://ci.ros2.org/job/ci_osx/4386/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5249)](http://ci.ros2.org/job/ci_windows/5249/)