### PR TITLE
Add new test message type DynamicArrayStaticArrayPrimitivesNested

### DIFF
--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -83,6 +83,9 @@ int main(int argc, char ** argv)
   } else if (message == "DynamicArrayPrimitivesNested") {
     publish<test_msgs::msg::DynamicArrayPrimitivesNested>(
       node, message, get_messages_dynamic_array_primitives_nested());
+  } else if (message == "DynamicArrayStaticArrayPrimitivesNested") {
+    publish<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
+      node, message, get_messages_dynamic_array_static_array_primitives_nested());
   } else if (message == "BoundedArrayPrimitives") {
     publish<test_msgs::msg::BoundedArrayPrimitives>(
       node, message, get_messages_bounded_array_primitives());

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -123,6 +123,8 @@ int main(int argc, char ** argv)
   auto messages_static_array_primitives = get_messages_static_array_primitives();
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
   auto messages_dynamic_array_primitives_nested = get_messages_dynamic_array_primitives_nested();
+  auto messages_dynamic_array_static_array_primitives_nested =
+    get_messages_dynamic_array_static_array_primitives_nested();
   auto messages_bounded_array_primitives = get_messages_bounded_array_primitives();
   auto messages_nested = get_messages_nested();
   auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
@@ -153,6 +155,11 @@ int main(int argc, char ** argv)
       node, message, messages_dynamic_array_primitives_nested, received_messages);
     publish<test_msgs::msg::DynamicArrayPrimitivesNested>(node, message,
       messages_dynamic_array_primitives_nested);
+  } else if (message == "DynamicArrayStaticArrayPrimitivesNested") {
+    subscriber = subscribe<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
+      node, message, messages_dynamic_array_static_array_primitives_nested, received_messages);
+    publish<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
+      node, message, get_messages_dynamic_array_static_array_primitives_nested());
   } else if (message == "BoundedArrayPrimitives") {
     subscriber = subscribe<test_msgs::msg::BoundedArrayPrimitives>(
       node, message, messages_bounded_array_primitives, received_messages);

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -91,6 +91,8 @@ int main(int argc, char ** argv)
   auto messages_static_array_primitives = get_messages_static_array_primitives();
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
   auto messages_dynamic_array_primitives_nested = get_messages_dynamic_array_primitives_nested();
+  auto messages_dynamic_array_static_array_primitives_nested =
+    get_messages_dynamic_array_static_array_primitives_nested();
   auto messages_bounded_array_primitives = get_messages_bounded_array_primitives();
   auto messages_nested = get_messages_nested();
   auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
@@ -115,6 +117,9 @@ int main(int argc, char ** argv)
   } else if (message == "DynamicArrayPrimitives") {
     subscriber = subscribe<test_msgs::msg::DynamicArrayPrimitives>(
       node, message, messages_dynamic_array_primitives, received_messages);
+  } else if (message == "DynamicArrayStaticArrayPrimitivesNested") {
+    subscriber = subscribe<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
+      node, message, messages_dynamic_array_static_array_primitives_nested, received_messages);
   } else if (message == "BoundedArrayPrimitives") {
     subscriber = subscribe<test_msgs::msg::BoundedArrayPrimitives>(
       node, message, messages_bounded_array_primitives, received_messages);


### PR DESCRIPTION
This resolves CI failures introduced by #43.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5361)](http://ci.ros2.org/job/ci_linux/5361/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2088)](http://ci.ros2.org/job/ci_linux-aarch64/2088/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4451)](http://ci.ros2.org/job/ci_osx/4451/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5321)](http://ci.ros2.org/job/ci_windows/5321/)