### PR TITLE
update char type mapping, update to use separated action types

### DIFF
--- a/test_communication/test/action_client_py.py
+++ b/test_communication/test/action_client_py.py
@@ -96,7 +96,8 @@ def generate_fibonacci_goal_tests():
 
     test = ActionClientTest(goal)
 
-    def is_feedback_valid(feedback):
+    def is_feedback_valid(feedback_message):
+        feedback = feedback_message.feedback
         if len(feedback.sequence) > (order + 1):
             print('Feedback sequence is greater than goal order', file=sys.stderr)
             return False
@@ -107,7 +108,8 @@ def generate_fibonacci_goal_tests():
                 return False
         return True
 
-    def is_result_valid(result):
+    def is_result_valid(get_result_response):
+        result = get_result_response.result
         if len(result.sequence) != (order + 1):
             print('Result sequence does not equal goal order', file=sys.stderr)
             return False
@@ -138,7 +140,8 @@ def generate_nested_message_goal_tests():
 
     test = ActionClientTest(goal)
 
-    def is_feedback_valid(feedback):
+    def is_feedback_valid(feedback_message):
+        feedback = feedback_message.feedback
         if feedback.nested_different_pkg.sec != expected_feedback_value:
             print('Expected feedback {} but got {} for initial value {}'.format(
                 expected_feedback_value, feedback.nested_different_pkg.sec, initial_value),
@@ -146,7 +149,8 @@ def generate_nested_message_goal_tests():
             return False
         return True
 
-    def is_result_valid(result):
+    def is_result_valid(get_result_response):
+        result = get_result_response.result
         if result.nested_field.int32_value != expected_result_value:
             print('Expected result {} but got {} for initial value {}'.format(
                 expected_result_value, result.nested_field.int32_value, initial_value),

--- a/test_communication/test/test_action_client.cpp
+++ b/test_communication/test/test_action_client.cpp
@@ -94,7 +94,7 @@ send_goals(
       return 1;
     }
 
-    if (!goal_tests[test_index].result_is_valid(result_future.get().response)) {
+    if (!goal_tests[test_index].result_is_valid(result_future.get().result)) {
       RCLCPP_ERROR(logger, "invalid goal result");
       return 1;
     }

--- a/test_communication/test/test_action_server.cpp
+++ b/test_communication/test/test_action_server.cpp
@@ -123,13 +123,11 @@ generate_expected_fibonacci_goals(rclcpp::Logger logger)
         const auto goal = goal_handle->get_goal();
         rclcpp::Rate loop_rate(10);
 
-        auto feedback = std::make_shared<
-          test_msgs::action::Fibonacci::Impl::FeedbackMessage>();
-        feedback->feedback.sequence.push_back(0);
-        feedback->feedback.sequence.push_back(1);
+        auto feedback = std::make_shared<test_msgs::action::Fibonacci::Feedback>();
+        feedback->sequence.push_back(0);
+        feedback->sequence.push_back(1);
 
-        auto result = std::make_shared<
-          test_msgs::action::Fibonacci::Impl::GetResultService::Response>();
+        auto result = std::make_shared<test_msgs::action::Fibonacci::Result>();
 
         if (goal->order <= 0) {
           RCLCPP_ERROR(logger, "expected a goal > 0, got %d", goal->order);
@@ -143,14 +141,14 @@ generate_expected_fibonacci_goals(rclcpp::Logger logger)
           }
           // Check if the goal was canceled.
           if (goal_handle->is_canceling()) {
-            result->result.sequence = feedback->feedback.sequence;
+            result->sequence = feedback->sequence;
             goal_handle->set_canceled(result);
             RCLCPP_INFO(logger, "goal was canceled");
             return;
           }
           // Update the sequence.
-          feedback->feedback.sequence.push_back(
-            feedback->feedback.sequence[i] + feedback->feedback.sequence[i - 1]);
+          feedback->sequence.push_back(
+            feedback->sequence[i] + feedback->sequence[i - 1]);
           // Publish the current state as feedback.
           goal_handle->publish_feedback(feedback);
           RCLCPP_INFO(logger, "publishing feedback for goal");
@@ -158,7 +156,7 @@ generate_expected_fibonacci_goals(rclcpp::Logger logger)
           loop_rate.sleep();
         }
 
-        result->result.sequence = feedback->feedback.sequence;
+        result->sequence = feedback->sequence;
         goal_handle->set_succeeded(result);
         RCLCPP_INFO(logger, "goal succeeded");
       };
@@ -198,9 +196,9 @@ generate_expected_nested_message_goals(rclcpp::Logger logger)
         const int32_t feedback_value = 2 * initial_value;
         const int32_t result_value = 4 * initial_value;
 
-        auto feedback = std::make_shared<test_msgs::action::NestedMessage::Impl::FeedbackMessage>();
+        auto feedback = std::make_shared<test_msgs::action::NestedMessage::Feedback>();
 
-        auto response = std::make_shared<test_msgs::action::NestedMessage::Impl::GetResultService::Response>();
+        auto result = std::make_shared<test_msgs::action::NestedMessage::Result>();
 
         if (initial_value <= 0) {
           RCLCPP_ERROR(logger, "expected a goal > 0, got %d", initial_value);
@@ -214,13 +212,13 @@ generate_expected_nested_message_goals(rclcpp::Logger logger)
           }
           // Check if the goal was canceled.
           if (goal_handle->is_canceling()) {
-            response->result.nested_field.int32_value = result_value;
-            goal_handle->set_canceled(response);
+            result->nested_field.int32_value = result_value;
+            goal_handle->set_canceled(result);
             RCLCPP_INFO(logger, "goal was canceled");
             return;
           }
           // Update the feedback;
-          feedback->feedback.nested_different_pkg.sec = feedback_value;
+          feedback->nested_different_pkg.sec = feedback_value;
           // Publish the current state as feedback.
           goal_handle->publish_feedback(feedback);
           RCLCPP_INFO(logger, "publishing feedback for goal");
@@ -228,8 +226,8 @@ generate_expected_nested_message_goals(rclcpp::Logger logger)
           loop_rate.sleep();
         }
 
-        response->result.nested_field.int32_value = result_value;
-        goal_handle->set_succeeded(response);
+        result->nested_field.int32_value = result_value;
+        goal_handle->set_succeeded(result);
         RCLCPP_INFO(logger, "goal succeeded");
       };
 

--- a/test_communication/test/test_action_server.cpp
+++ b/test_communication/test/test_action_server.cpp
@@ -198,9 +198,9 @@ generate_expected_nested_message_goals(rclcpp::Logger logger)
         const int32_t feedback_value = 2 * initial_value;
         const int32_t result_value = 4 * initial_value;
 
-        auto feedback = std::make_shared<test_msgs::action::NestedMessage::Feedback>();
+        auto feedback = std::make_shared<test_msgs::action::NestedMessage::Impl::FeedbackMessage>();
 
-        auto result = std::make_shared<test_msgs::action::NestedMessage::Result>();
+        auto response = std::make_shared<test_msgs::action::NestedMessage::Impl::GetResultService::Response>();
 
         if (initial_value <= 0) {
           RCLCPP_ERROR(logger, "expected a goal > 0, got %d", initial_value);
@@ -214,13 +214,13 @@ generate_expected_nested_message_goals(rclcpp::Logger logger)
           }
           // Check if the goal was canceled.
           if (goal_handle->is_canceling()) {
-            result->nested_field.int32_value = result_value;
-            goal_handle->set_canceled(result);
+            response->result.nested_field.int32_value = result_value;
+            goal_handle->set_canceled(response);
             RCLCPP_INFO(logger, "goal was canceled");
             return;
           }
           // Update the feedback;
-          feedback->nested_different_pkg.sec = feedback_value;
+          feedback->feedback.nested_different_pkg.sec = feedback_value;
           // Publish the current state as feedback.
           goal_handle->publish_feedback(feedback);
           RCLCPP_INFO(logger, "publishing feedback for goal");
@@ -228,8 +228,8 @@ generate_expected_nested_message_goals(rclcpp::Logger logger)
           loop_rate.sleep();
         }
 
-        result->nested_field.int32_value = result_value;
-        goal_handle->set_succeeded(result);
+        response->result.nested_field.int32_value = result_value;
+        goal_handle->set_succeeded(response);
         RCLCPP_INFO(logger, "goal succeeded");
       };
 

--- a/test_communication/test/test_action_server.cpp
+++ b/test_communication/test/test_action_server.cpp
@@ -123,11 +123,13 @@ generate_expected_fibonacci_goals(rclcpp::Logger logger)
         const auto goal = goal_handle->get_goal();
         rclcpp::Rate loop_rate(10);
 
-        auto feedback = std::make_shared<test_msgs::action::Fibonacci::Feedback>();
-        feedback->sequence.push_back(0);
-        feedback->sequence.push_back(1);
+        auto feedback = std::make_shared<
+          test_msgs::action::Fibonacci::Impl::FeedbackMessage>();
+        feedback->feedback.sequence.push_back(0);
+        feedback->feedback.sequence.push_back(1);
 
-        auto result = std::make_shared<test_msgs::action::Fibonacci::Result>();
+        auto result = std::make_shared<
+          test_msgs::action::Fibonacci::Impl::GetResultService::Response>();
 
         if (goal->order <= 0) {
           RCLCPP_ERROR(logger, "expected a goal > 0, got %d", goal->order);
@@ -141,13 +143,14 @@ generate_expected_fibonacci_goals(rclcpp::Logger logger)
           }
           // Check if the goal was canceled.
           if (goal_handle->is_canceling()) {
-            result->sequence = feedback->sequence;
+            result->result.sequence = feedback->feedback.sequence;
             goal_handle->set_canceled(result);
             RCLCPP_INFO(logger, "goal was canceled");
             return;
           }
           // Update the sequence.
-          feedback->sequence.push_back(feedback->sequence[i] + feedback->sequence[i - 1]);
+          feedback->feedback.sequence.push_back(
+            feedback->feedback.sequence[i] + feedback->feedback.sequence[i - 1]);
           // Publish the current state as feedback.
           goal_handle->publish_feedback(feedback);
           RCLCPP_INFO(logger, "publishing feedback for goal");
@@ -155,7 +158,7 @@ generate_expected_fibonacci_goals(rclcpp::Logger logger)
           loop_rate.sleep();
         }
 
-        result->sequence = feedback->sequence;
+        result->result.sequence = feedback->feedback.sequence;
         goal_handle->set_succeeded(result);
         RCLCPP_INFO(logger, "goal succeeded");
       };

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -473,9 +473,9 @@ void get_message(test_msgs__msg__StaticArrayPrimitives * msg, size_t msg_num)
     msg->byte_values[0] = 0;
     msg->byte_values[1] = 0xff;
     msg->byte_values[2] = 0;
-    msg->char_values[0] = '\0';
-    msg->char_values[1] = '\x7f';
-    msg->char_values[2] = '\0';
+    msg->char_values[0] = 0;
+    msg->char_values[1] = 255;
+    msg->char_values[2] = 0;
     msg->float32_values[0] = 0.0f;
     msg->float32_values[1] = 1.125f;
     msg->float32_values[2] = -2.125f;
@@ -640,7 +640,7 @@ void get_message(test_msgs__msg__DynamicArrayPrimitives * msg, size_t msg_num)
 
       msg->bool_values.data[0] = true;
       msg->byte_values.data[0] = 0xff;
-      msg->char_values.data[0] = '\x7f';
+      msg->char_values.data[0] = 255;
       msg->float32_values.data[0] = 1.125f;
       msg->float64_values.data[0] = 1.125;
       msg->int8_values.data[0] = (std::numeric_limits<int8_t>::max)();
@@ -674,8 +674,8 @@ void get_message(test_msgs__msg__DynamicArrayPrimitives * msg, size_t msg_num)
       msg->bool_values.data[1] = true;
       msg->byte_values.data[0] = 0x00;
       msg->byte_values.data[1] = 0xff;
-      msg->char_values.data[0] = '\0';
-      msg->char_values.data[1] = '\x7f';
+      msg->char_values.data[0] = 0;
+      msg->char_values.data[1] = 255;
       msg->float32_values.data[0] = 0.0f;
       msg->float32_values.data[1] = 1.125f;
       msg->float32_values.data[2] = -2.125f;
@@ -953,9 +953,9 @@ void get_message(test_msgs__msg__BoundedArrayPrimitives * msg, size_t msg_num)
       msg->byte_values.data[0] = 0x00;
       msg->byte_values.data[1] = 0x01;
       msg->byte_values.data[2] = 0xff;
-      msg->char_values.data[0] = '\0';
-      msg->char_values.data[1] = '\1';
-      msg->char_values.data[2] = '\255';
+      msg->char_values.data[0] = 0;
+      msg->char_values.data[1] = 1;
+      msg->char_values.data[2] = 255;
       msg->float32_values.data[0] = 0.0f;
       msg->float32_values.data[1] = 1.125f;
       msg->float32_values.data[2] = -2.125f;

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -608,7 +608,7 @@ void get_message(test_msgs__msg__DynamicArrayPrimitives * msg, size_t msg_num)
     case 0:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, 0);
       rosidl_generator_c__byte__Sequence__init(&msg->byte_values, 0);
-      rosidl_generator_c__char__Sequence__init(&msg->char_values, 0);
+      rosidl_generator_c__uint8__Sequence__init(&msg->char_values, 0);
       rosidl_generator_c__float32__Sequence__init(&msg->float32_values, 0);
       rosidl_generator_c__float64__Sequence__init(&msg->float64_values, 0);
       rosidl_generator_c__int8__Sequence__init(&msg->int8_values, 0);
@@ -625,7 +625,7 @@ void get_message(test_msgs__msg__DynamicArrayPrimitives * msg, size_t msg_num)
     case 1:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, 1);
       rosidl_generator_c__byte__Sequence__init(&msg->byte_values, 1);
-      rosidl_generator_c__char__Sequence__init(&msg->char_values, 1);
+      rosidl_generator_c__uint8__Sequence__init(&msg->char_values, 1);
       rosidl_generator_c__float32__Sequence__init(&msg->float32_values, 1);
       rosidl_generator_c__float64__Sequence__init(&msg->float64_values, 1);
       rosidl_generator_c__int8__Sequence__init(&msg->int8_values, 1);
@@ -657,7 +657,7 @@ void get_message(test_msgs__msg__DynamicArrayPrimitives * msg, size_t msg_num)
     case 2:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, 2);
       rosidl_generator_c__byte__Sequence__init(&msg->byte_values, 2);
-      rosidl_generator_c__char__Sequence__init(&msg->char_values, 2);
+      rosidl_generator_c__uint8__Sequence__init(&msg->char_values, 2);
       rosidl_generator_c__float32__Sequence__init(&msg->float32_values, 3);
       rosidl_generator_c__float64__Sequence__init(&msg->float64_values, 3);
       rosidl_generator_c__int8__Sequence__init(&msg->int8_values, 3);
@@ -710,7 +710,7 @@ void get_message(test_msgs__msg__DynamicArrayPrimitives * msg, size_t msg_num)
     case 3:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, size);
       rosidl_generator_c__byte__Sequence__init(&msg->byte_values, size);
-      rosidl_generator_c__char__Sequence__init(&msg->char_values, size);
+      rosidl_generator_c__uint8__Sequence__init(&msg->char_values, size);
       rosidl_generator_c__float32__Sequence__init(&msg->float32_values, size);
       rosidl_generator_c__float64__Sequence__init(&msg->float64_values, size);
       rosidl_generator_c__int8__Sequence__init(&msg->int8_values, size);
@@ -749,7 +749,7 @@ void get_message(test_msgs__msg__DynamicArrayPrimitives * msg, size_t msg_num)
     case 4:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, 0);
       rosidl_generator_c__byte__Sequence__init(&msg->byte_values, 0);
-      rosidl_generator_c__char__Sequence__init(&msg->char_values, 0);
+      rosidl_generator_c__uint8__Sequence__init(&msg->char_values, 0);
       rosidl_generator_c__float32__Sequence__init(&msg->float32_values, 0);
       rosidl_generator_c__float64__Sequence__init(&msg->float64_values, 0);
       rosidl_generator_c__int8__Sequence__init(&msg->int8_values, 0);
@@ -934,7 +934,7 @@ void get_message(test_msgs__msg__BoundedArrayPrimitives * msg, size_t msg_num)
     case 0:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, 3);
       rosidl_generator_c__byte__Sequence__init(&msg->byte_values, 3);
-      rosidl_generator_c__char__Sequence__init(&msg->char_values, 3);
+      rosidl_generator_c__uint8__Sequence__init(&msg->char_values, 3);
       rosidl_generator_c__float32__Sequence__init(&msg->float32_values, 3);
       rosidl_generator_c__float64__Sequence__init(&msg->float64_values, 3);
       rosidl_generator_c__int8__Sequence__init(&msg->int8_values, 3);
@@ -994,7 +994,7 @@ void get_message(test_msgs__msg__BoundedArrayPrimitives * msg, size_t msg_num)
     case 1:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, 0);
       rosidl_generator_c__byte__Sequence__init(&msg->byte_values, 0);
-      rosidl_generator_c__char__Sequence__init(&msg->char_values, 0);
+      rosidl_generator_c__uint8__Sequence__init(&msg->char_values, 0);
       rosidl_generator_c__float32__Sequence__init(&msg->float32_values, 0);
       rosidl_generator_c__float64__Sequence__init(&msg->float64_values, 0);
       rosidl_generator_c__int8__Sequence__init(&msg->int8_values, 0);


### PR DESCRIPTION
Connected to ros2/rosidl#334.

`char` in `.msg` files has a value range of `[0, 255]` according to the ROS 1 docs. Therefore it is being mapped to `uint8` according to https://github.com/ros2/design/blob/gh-pages/articles/143_legacy_interface_definition.md#mapping-to-idl-types