### PR TITLE
Re-enable cross-vendor tests for Fast-RTPS on Windows.

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -156,21 +156,6 @@ if(BUILD_TESTING)
       set(suffix "${suffix}__${rmw_implementation1}__${rmw_implementation2}")
     endif()
 
-    set(SKIP_TEST "")
-
-    # TODO(wjwwood): Connext and Fast-RTPS do not currently communicate over pub/sub
-    set(rmw_implementation1_is_fastrtps FALSE)
-    set(rmw_implementation2_is_fastrtps FALSE)
-    if(rmw_implementation1 MATCHES "(.*)fastrtps(.*)")
-      set(rmw_implementation1_is_fastrtps TRUE)
-    endif()
-    if(rmw_implementation2 MATCHES "(.*)fastrtps(.*)")
-      set(rmw_implementation2_is_fastrtps TRUE)
-    endif()
-    if(WIN32 AND (rmw_implementation1_is_fastrtps OR rmw_implementation2_is_fastrtps))
-      set(SKIP_TEST "SKIP_TEST")
-    endif()
-
     set(PUBLISHER_RMW ${rmw_implementation1})
     set(SUBSCRIBER_RMW ${rmw_implementation2})
     foreach(message_file ${message_files})
@@ -191,8 +176,7 @@ if(BUILD_TESTING)
         "${CMAKE_CURRENT_BINARY_DIR}/test_publisher_subscriber${test_suffix}_$<CONFIG>.py"
         PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
         APPEND_LIBRARY_DIRS "${append_library_dirs}"
-        TIMEOUT 15
-        ${SKIP_TEST})
+        TIMEOUT 15)
       if(TEST test_publisher_subscriber${test_suffix})
         set_tests_properties(
           test_publisher_subscriber${test_suffix}


### PR DESCRIPTION
Reverts the skip logic to allow tests to run.

This branch can be used to enable cross-vendor communications tests on Windows for investigating the issues further.

connects to ros2/rmw_fastrtps#246