### PR TITLE
Ignore RCLError during Node constructor

### DIFF
--- a/test_rclcpp/test/node_with_name.cpp
+++ b/test_rclcpp/test/node_with_name.cpp
@@ -28,8 +28,17 @@ int main(int argc, char ** argv)
   printf("Starting node with name: %s\n", node_name.c_str());
   std::cout.flush();
 
-  auto node = rclcpp::Node::make_shared(node_name);
-  rclcpp::spin(node);
+  rclcpp::Node::SharedPtr node;
+  try {
+    node = rclcpp::Node::make_shared(node_name);
+  } catch (rclcpp::exceptions::RCLError) {
+    // test may pass and send SIGINT before node finishes initializing ros2/build_cop#153
+    printf("Likely received SIGINT before node initialization finished.\n");
+  };
+
+  if (node) {
+    rclcpp::spin(node);
+  }
   rclcpp::shutdown();
   return 0;
 }

--- a/test_rclcpp/test/node_with_name.cpp
+++ b/test_rclcpp/test/node_with_name.cpp
@@ -31,9 +31,9 @@ int main(int argc, char ** argv)
   rclcpp::Node::SharedPtr node;
   try {
     node = rclcpp::Node::make_shared(node_name);
-  } catch (rclcpp::exceptions::RCLError) {
+  } catch (rclcpp::exceptions::RCLError & e) {
     // test may pass and send SIGINT before node finishes initializing ros2/build_cop#153
-    printf("Likely received SIGINT before node initialization finished.\n");
+    printf("Ignoring RCLError: %s\n", e.what());
   };
 
   if (node) {


### PR DESCRIPTION
This should fix for ros2/build_cop#153 by ignoring `RCLError` raised in the node constructor.

When `node_with_name` is connext and `node_name_list` is fastrtps the listing node can start, see the node name it expects, and exit before `node_with_name` finishes constructing itself. The test sends `SIGINT` to `node_with_name` which shutsdown the context. That causes checks to fail when creating services/clients/etc in the node constructor for parameters and the time source.

