### PR TITLE
Remove unnecessary semicolon

### DIFF
--- a/test_rclcpp/test/node_with_name.cpp
+++ b/test_rclcpp/test/node_with_name.cpp
@@ -34,7 +34,7 @@ int main(int argc, char ** argv)
   } catch (rclcpp::exceptions::RCLError & e) {
     // test may pass and send SIGINT before node finishes initializing ros2/build_cop#153
     printf("Ignoring RCLError: %s\n", e.what());
-  };
+  }
 
   if (node) {
     rclcpp::spin(node);


### PR DESCRIPTION
Fixes a linter error introduced by ros2/system_tests#325

CI Linux testing `test_rclcpp` [![Build Status](https://ci.ros2.org/job/ci_linux/6065/badge/icon)](https://ci.ros2.org/job/ci_linux/6065/)