### PR TITLE
Add communication tests for Python Actions

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -253,11 +253,6 @@ if(BUILD_TESTING)
     # Note: taking same exclusions as services since actions use services too
     # set(SKIP_TEST "")
 
-    # TODO(wjwwood): actions do not support python
-    if(client_library1 STREQUAL "rclpy" OR client_library2 STREQUAL "rclpy")
-      set(SKIP_TEST "SKIP_TEST")
-    endif()
-
     set(ACTION_CLIENT_RMW ${rmw_implementation1})
     set(ACTION_SERVER_RMW ${rmw_implementation2})
     foreach(action_file ${action_files})
@@ -317,7 +312,7 @@ if(BUILD_TESTING)
     if(_client_library1 STREQUAL "rclpy")
       set(TEST_PUBLISHER_EXECUTABLE "${CMAKE_CURRENT_SOURCE_DIR}/test/publisher_py.py")
       set(TEST_REQUESTER_EXECUTABLE "${CMAKE_CURRENT_SOURCE_DIR}/test/requester_py.py")
-      # TODO(wjwwood): actions do not support python
+      set(TEST_ACTION_CLIENT_EXECUTABLE "${CMAKE_CURRENT_SOURCE_DIR}/test/action_client_py.py")
     elseif(_client_library1 STREQUAL "rclcpp")
       set(TEST_PUBLISHER_EXECUTABLE "$<TARGET_FILE:test_publisher_cpp>")
       set(TEST_REQUESTER_EXECUTABLE "$<TARGET_FILE:test_requester_cpp>")
@@ -327,7 +322,7 @@ if(BUILD_TESTING)
     if(_client_library2 STREQUAL "rclpy")
       set(TEST_SUBSCRIBER_EXECUTABLE "${CMAKE_CURRENT_SOURCE_DIR}/test/subscriber_py.py")
       set(TEST_REPLIER_EXECUTABLE "${CMAKE_CURRENT_SOURCE_DIR}/test/replier_py.py")
-      # TODO(wjwwood): actions do not support python
+      set(TEST_ACTION_SERVER_EXECUTABLE "${CMAKE_CURRENT_SOURCE_DIR}/test/action_server_py.py")
     elseif(_client_library2 STREQUAL "rclcpp")
       set(TEST_SUBSCRIBER_EXECUTABLE "$<TARGET_FILE:test_subscriber_cpp>")
       set(TEST_REPLIER_EXECUTABLE "$<TARGET_FILE:test_replier_cpp>")

--- a/test_communication/test/action_client_py.py
+++ b/test_communication/test/action_client_py.py
@@ -1,0 +1,191 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from test_msgs.action import Fibonacci
+from test_msgs.action import NestedMessage
+
+
+class ActionClientTest:
+    def __init__(self, goal):
+        self.goal = goal
+
+    def is_feedback_valid(self, feedback):
+        raise NotImplementedError('is_feedback_valid() is not implemented')
+
+    def is_result_valid(self, result):
+        raise NotImplementedError('is_result_valid() is not implemented')
+
+
+def send_goals(node, action_type, tests):
+    import rclpy
+    from rclpy.action import ActionClient
+
+    action_client = ActionClient(node, action_type, 'test/action/' + action_type.__name__)
+
+    if not action_client.wait_for_server(20):
+        print('Action server not available after waiting', file=sys.stderr)
+        return 1
+
+    test_index = 0
+    while rclpy.ok() and test_index < len(tests):
+        print('Sending goal for test number {}'.format(test_index), file=sys.stderr)
+
+        test = tests[test_index]
+
+        invalid_feedback = False
+
+        # On feedback, check the feedback is valid
+        def feedback_callback(feedback):
+            nonlocal invalid_feedback
+            if not test.is_feedback_valid(feedback):
+                invalid_feedback = True
+
+        goal_handle_future = action_client.send_goal_async(
+            test.goal,
+            feedback_callback=feedback_callback)
+
+        rclpy.spin_until_future_complete(node, goal_handle_future)
+
+        goal_handle = goal_handle_future.result()
+        if not goal_handle.accepted:
+            print('Goal rejected', file=sys.stderr)
+            return 1
+
+        get_result_future = goal_handle.get_result_async()
+
+        rclpy.spin_until_future_complete(node, get_result_future)
+
+        result = get_result_future.result()
+
+        if not test.is_result_valid(result):
+            return 1
+
+        if invalid_feedback:
+            return 1
+
+        test_index += 1
+
+    return 0
+
+
+def generate_fibonacci_goal_tests():
+    tests = []
+
+    order = 10
+    goal = Fibonacci.Goal()
+    goal.order = order
+
+    valid_result_sequence = [0, 1]
+    for i in range(1, goal.order):
+        valid_result_sequence.append(valid_result_sequence[i] + valid_result_sequence[i-1])
+
+    test = ActionClientTest(goal)
+
+    def is_feedback_valid(feedback):
+        if len(feedback.sequence) > (order + 1):
+            print('Feedback sequence is greater than goal order', file=sys.stderr)
+            return False
+        for i in range(0, len(feedback.sequence)):
+            if feedback.sequence[i] != valid_result_sequence[i]:
+                print('Feedback sequence not correct, expected {} but got {} for order {}'.format(
+                    valid_result_sequence[i], feedback.sequence[i], order), file=sys.stderr)
+                return False
+        return True
+
+    def is_result_valid(result):
+        if len(result.sequence) != (order + 1):
+            print('Result sequence does not equal goal order', file=sys.stderr)
+            return False
+        for i in range(0, len(result.sequence)):
+            if result.sequence[i] != valid_result_sequence[i]:
+                print('Result sequence not correct, expected {} but got {} for order {}'.format(
+                    valid_result_sequence[i], result.sequence[i], order), file=sys.stderr)
+                return False
+        return True
+
+    test.is_feedback_valid = is_feedback_valid
+    test.is_result_valid = is_result_valid
+
+    tests.append(test)
+
+    return tests
+
+
+def generate_nested_message_goal_tests():
+    tests = []
+
+    initial_value = 123
+    expected_feedback_value = 2 * initial_value
+    expected_result_value = 4 * initial_value
+
+    goal = NestedMessage.Goal()
+    goal.nested_field_no_pkg.duration_value.sec = initial_value
+
+    test = ActionClientTest(goal)
+
+    def is_feedback_valid(feedback):
+        if feedback.nested_different_pkg.sec != expected_feedback_value:
+            print('Expected feedback {} but got {} for initial value {}'.format(
+                expected_feedback_value, feedback.nested_different_pkg.sec, initial_value),
+                file=sys.stderr)
+            return False
+        return True
+
+    def is_result_valid(result):
+        if result.nested_field.int32_value != expected_result_value:
+            print('Expected result {} but got {} for initial value {}'.format(
+                expected_result_value, result.nested_field.int32_value, initial_value),
+                file=sys.stderr)
+            return False
+        return True
+
+    test.is_feedback_valid = is_feedback_valid
+    test.is_result_valid = is_result_valid
+
+    tests.append(test)
+
+    return tests
+
+
+if __name__ == '__main__':
+    import rclpy
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('action_type', help='type of the ROS action')
+    parser.add_argument('namespace', help='namespace of the ROS node')
+    args = parser.parse_args()
+
+    rclpy.init(args=[])
+    node = rclpy.create_node('action_client', namespace=args.namespace)
+
+    rc = 1
+    try:
+        if 'Fibonacci' == args.action_type:
+            rc = send_goals(node, Fibonacci, generate_fibonacci_goal_tests())
+        elif 'NestedMessage' == args.action_type:
+            rc = send_goals(node, NestedMessage, generate_nested_message_goal_tests())
+        else:
+            print('Unknown action type {!r}'.format(args.action_type), file=sys.stderr)
+    except KeyboardInterrupt:
+        print('Action client stopped cleanly')
+    except BaseException:
+        print('Exception in action client:', file=sys.stderr)
+        raise
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+    sys.exit(rc)

--- a/test_communication/test/action_client_py.py
+++ b/test_communication/test/action_client_py.py
@@ -20,6 +20,7 @@ from test_msgs.action import NestedMessage
 
 
 class ActionClientTest:
+
     def __init__(self, goal):
         self.goal = goal
 

--- a/test_communication/test/action_server_py.py
+++ b/test_communication/test/action_server_py.py
@@ -1,0 +1,184 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import time
+import sys
+
+from test_msgs.action import Fibonacci
+from test_msgs.action import NestedMessage
+
+
+class ExpectedGoal:
+    def is_goal_expected(self, goal):
+        raise NotImplementedError('is_goal_expected() is not implemented')
+
+    def execute_goal(self, goal_handle):
+        raise NotImplementedError('execute_goal() is not implemented')
+
+
+def receive_goals(node, action_type, expected_goals):
+    from rclpy.action import ActionServer
+
+    def execute_callback(goal_handle):
+        for expected_goal in expected_goals:
+            if expected_goal.is_goal_expected(goal_handle.request):
+                return expected_goal.execute_goal(goal_handle)
+        # Not an expected goal (this should not happen)
+        print('Unexpected goal received by action server', file=sys.stderr)
+        goal_handle.set_aborted()
+        return action_type.Result()
+
+    action_name = 'test/action/' + action_type.__name__
+    return ActionServer(node, action_type, action_name, execute_callback)
+
+
+def generate_expected_fibonacci_goals():
+    import rclpy
+
+    expected_goals = []
+
+    def is_goal_expected(goal):
+        return (isinstance(goal, Fibonacci.Goal) and 10 == goal.order)
+
+    def execute_goal(goal_handle):
+        goal = goal_handle.request
+
+        feedback = Fibonacci.Feedback()
+        feedback.sequence = [0, 1]
+
+        for i in range(1, goal.order):
+            if not rclpy.ok():
+                goal_handle.set_aborted()
+                return Fibonacci.Result()
+
+            # Check if the goal was canceled
+            if goal_handle.is_cancel_requested:
+                goal_handle.set_canceled()
+                result = Fibonacci.Result()
+                result.sequence = feedback.sequence
+                print('Goal was canceled')
+                return result
+
+            # Update the sequence.
+            feedback.sequence.append(feedback.sequence[i] + feedback.sequence[i-1])
+
+            # Publish feedback
+            goal_handle.publish_feedback(feedback)
+            print('Publishing feedback')
+
+            # 10 Hz update rate
+            time.sleep(0.1)
+
+        # Send final result
+        result = Fibonacci.Result()
+        result.sequence = feedback.sequence
+        goal_handle.set_succeeded()
+        print('Goal succeeded')
+        return result
+
+    expected_goal = ExpectedGoal()
+    expected_goal.is_goal_expected = is_goal_expected
+    expected_goal.execute_goal = execute_goal
+
+    expected_goals.append(expected_goal)
+
+    return expected_goals
+
+
+def generate_expected_nested_message_goals():
+    import rclpy
+
+    expected_goals = []
+
+    def is_goal_expected(goal):
+        return (isinstance(goal, NestedMessage.Goal) and
+                goal.nested_field_no_pkg.duration_value.sec > 0)
+
+    def execute_goal(goal_handle):
+        goal = goal_handle.request
+
+        feedback = NestedMessage.Feedback()
+        feedback.nested_different_pkg.sec = 2 * goal.nested_field_no_pkg.duration_value.sec
+        result = NestedMessage.Result()
+        result.nested_field.int32_value = 4 * goal.nested_field_no_pkg.duration_value.sec
+
+        num_feedback = 10
+        for i in range(0, num_feedback):
+            if not rclpy.ok():
+                goal_handle.set_aborted()
+                return NestedMessage.Result()
+
+            # Check if the goal was canceled
+            if goal_handle.is_cancel_requested:
+                goal_handle.set_canceled()
+                print('Goal was canceled')
+                return result
+
+            # Publish feedback
+            goal_handle.publish_feedback(feedback)
+            print('Publishing feedback')
+
+            # 10 Hz update rate
+            time.sleep(0.1)
+
+        # Send final result
+        goal_handle.set_succeeded()
+        print('Goal succeeded')
+        return result
+
+    expected_goal = ExpectedGoal()
+    expected_goal.is_goal_expected = is_goal_expected
+    expected_goal.execute_goal = execute_goal
+
+    expected_goals.append(expected_goal)
+
+    return expected_goals
+
+
+if __name__ == '__main__':
+    import rclpy
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('action_type', help='type of the ROS action')
+    parser.add_argument('namespace', help='namespace of the ROS node')
+    args = parser.parse_args()
+
+    rclpy.init(args=[])
+    node = rclpy.create_node('action_server', namespace=args.namespace)
+
+    if 'Fibonacci' == args.action_type:
+        action_server = receive_goals(node, Fibonacci, generate_expected_fibonacci_goals())
+    elif 'NestedMessage' == args.action_type:
+        action_server = receive_goals(
+            node,
+            NestedMessage,
+            generate_expected_nested_message_goals(),
+        )
+    else:
+        print('Unknown action type {!r}'.format(args.action_type), file=sys.stderr)
+        node.destroy_node()
+        rclpy.shutdown()
+        sys.exit(1)
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        print('Action server stopped cleanly')
+    except BaseException:
+        print('Exception in action server:', file=sys.stderr)
+        raise
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/test_communication/test/action_server_py.py
+++ b/test_communication/test/action_server_py.py
@@ -13,14 +13,15 @@
 # limitations under the License.
 
 import argparse
-import time
 import sys
+import time
 
 from test_msgs.action import Fibonacci
 from test_msgs.action import NestedMessage
 
 
 class ExpectedGoal:
+
     def is_goal_expected(self, goal):
         raise NotImplementedError('is_goal_expected() is not implemented')
 


### PR DESCRIPTION
Resolves #332 

I more or less mimic'd the structure of the rclcpp Action tests.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6323)](http://ci.ros2.org/job/ci_linux/6323/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2737)](http://ci.ros2.org/job/ci_linux-aarch64/2737/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5205)](http://ci.ros2.org/job/ci_osx/5205/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6173)](http://ci.ros2.org/job/ci_windows/6173/)