### PR TITLE
fixes a failing test introduced by the switch to array.array

### DIFF
--- a/test_cli/test/test_params_yaml.py
+++ b/test_cli/test/test_params_yaml.py
@@ -177,8 +177,8 @@ ia_params:
         assert 2 == len(resp.values)
         assert ParameterType.PARAMETER_INTEGER_ARRAY == resp.values[0].type
         assert ParameterType.PARAMETER_INTEGER_ARRAY == resp.values[1].type
-        assert resp.values[0].integer_array_value == [42, -27]
-        assert resp.values[1].integer_array_value == [1234, 5678]
+        assert resp.values[0].integer_array_value.tolist() == [42, -27]
+        assert resp.values[1].integer_array_value.tolist() == [1234, 5678]
 
 
 def test_double_array_params(node_fixture):


### PR DESCRIPTION
Related to ros2/rosidl_python#35.

https://ci.ros2.org/view/nightly/job/nightly_osx_debug/1202/testReport/test_cli.test/test_params_yaml/test_integer_array_params__Users_osrf_jenkins_agent_workspace_nightly_osx_debug_ws_src_ros2_system_tests_test_cli_test_initial_params_py_/

I just ran the test locally confirming it passed with the patch.