### PR TITLE
Update to be compatible with new rmw_qos_profile_t

### DIFF
--- a/test_rclcpp/test/test_client_scope_consistency_client.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_client.cpp
@@ -39,14 +39,7 @@ TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_consistency_reg
   auto node = rclcpp::Node::make_shared("client_scope_consistency_regression_test");
 
   // Replicate the settings that caused https://github.com/ros2/system_tests/issues/153
-  rmw_qos_profile_t rmw_qos_profile =
-  {
-    RMW_QOS_POLICY_HISTORY_KEEP_LAST,
-    10,
-    RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE,
-    false
-  };
+  rmw_qos_profile_t rmw_qos_profile = rmw_qos_profile_default;
   rclcpp::executor::FutureReturnCode ret1;
 
   // Extra scope so the first client will be deleted afterwards

--- a/test_rclcpp/test/test_client_scope_consistency_server.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_server.cpp
@@ -34,14 +34,7 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("client_scope_consistency_regression_test_server");
 
   // Replicate the settings that caused https://github.com/ros2/system_tests/issues/153
-  rmw_qos_profile_t rmw_qos_profile =
-  {
-    RMW_QOS_POLICY_HISTORY_KEEP_LAST,
-    10,
-    RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE,
-    false
-  };
+  rmw_qos_profile_t rmw_qos_profile = rmw_qos_profile_default;
   auto service = node->create_service<test_rclcpp::srv::AddTwoInts>(
     "client_scope", handle_add_two_ints, rmw_qos_profile);
 


### PR DESCRIPTION
Some new fields are being added to rmw_qos_profile_t, and this package needs to be updated to be compatible with the newer definition of the struct.

Connects to ros2/rmw#173