### PR TITLE
Use new interface definitions

### DIFF
--- a/test_communication/msg/FieldsWithSameType.msg
+++ b/test_communication/msg/FieldsWithSameType.msg
@@ -1,2 +1,2 @@
-test_msgs/Primitives primitive_values1
-test_msgs/Primitives primitive_values2
+test_msgs/BasicTypes basic_types_values1
+test_msgs/BasicTypes basic_types_values2

--- a/test_communication/test/test_message_serialization.cpp
+++ b/test_communication/test/test_message_serialization.cpp
@@ -87,7 +87,7 @@ void fill_cpp_message(test_msgs::msg::BoundedSequences * bounded_sequences_msg_c
   basic_types_msg_cpp.uint32_value = 8;
   basic_types_msg_cpp.int64_value = 9;
   basic_types_msg_cpp.uint64_value = 10;
-  bounded_sequences_msg_cpp->basic_basic_types_values.push_back(basic_types_msg_cpp);
+  bounded_sequences_msg_cpp->basic_types_values.push_back(basic_types_msg_cpp);
 }
 
 TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), de_serialize_c) {

--- a/test_communication/test/test_message_serialization.cpp
+++ b/test_communication/test/test_message_serialization.cpp
@@ -103,7 +103,7 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), de_serialize_c) 
 
   ret = rmw_serialize(&bounded_sequences_msg_c, message_c_typesupport, &serialized_message_c);
   EXPECT_EQ(RMW_RET_OK, ret);
-  EXPECT_EQ(76u, serialized_message_c.buffer_length);  // measured from wireshark
+  EXPECT_EQ(196u, serialized_message_c.buffer_length);  // measured from wireshark
 
   printf("serialized data length: %zu\n", serialized_message_c.buffer_length);
   print_serialized_buffer(serialized_message_c, "serialized message c");
@@ -149,7 +149,7 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), de_serialize_cpp
   ret =
     rmw_serialize(&bounded_sequences_msg_cpp, message_cpp_typesupport, &serialized_message_cpp);
   EXPECT_EQ(RMW_RET_OK, ret);
-  EXPECT_EQ(76u, serialized_message_cpp.buffer_length);
+  EXPECT_EQ(196u, serialized_message_cpp.buffer_length);
   print_serialized_buffer(serialized_message_cpp, "serialized message cpp");
 
   test_msgs::msg::BoundedSequences bounded_sequences_cpp_reverse;

--- a/test_communication/test/test_message_serialization.cpp
+++ b/test_communication/test/test_message_serialization.cpp
@@ -18,10 +18,10 @@
 #include "rmw/serialized_message.h"
 #include "rmw/rmw.h"
 
-#include "test_msgs/msg/bounded_sequences.h"
-#include "test_msgs/msg/bounded_sequences.hpp"
 #include "test_msgs/msg/basic_types.h"
 #include "test_msgs/msg/basic_types.hpp"
+#include "test_msgs/msg/bounded_sequences.h"
+#include "test_msgs/msg/bounded_sequences.hpp"
 
 #include "rcutils/allocator.h"
 

--- a/test_communication/test/test_message_serialization.cpp
+++ b/test_communication/test/test_message_serialization.cpp
@@ -18,14 +18,12 @@
 #include "rmw/serialized_message.h"
 #include "rmw/rmw.h"
 
-#include "test_msgs/msg/bounded_array_nested.h"
-#include "test_msgs/msg/bounded_array_nested.hpp"
-#include "test_msgs/msg/primitives.h"
-#include "test_msgs/msg/primitives.hpp"
+#include "test_msgs/msg/bounded_sequences.h"
+#include "test_msgs/msg/bounded_sequences.hpp"
+#include "test_msgs/msg/basic_types.h"
+#include "test_msgs/msg/basic_types.hpp"
 
 #include "rcutils/allocator.h"
-
-#include "rosidl_generator_c/string_functions.h"
 
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
 
@@ -54,45 +52,42 @@ void print_serialized_buffer(
   printf("\n");
 }
 
-void fill_c_message(test_msgs__msg__BoundedArrayNested * bounded_array_nested_msg_c)
+void fill_c_message(test_msgs__msg__BoundedSequences * bounded_sequences_msg_c)
 {
-  test_msgs__msg__BoundedArrayNested__init(bounded_array_nested_msg_c);
-  test_msgs__msg__Primitives__Sequence__init(&bounded_array_nested_msg_c->primitive_values, 1);
-  bounded_array_nested_msg_c->primitive_values.data[0].bool_value = true;
-  bounded_array_nested_msg_c->primitive_values.data[0].byte_value = 255;
-  bounded_array_nested_msg_c->primitive_values.data[0].char_value = 'k';
-  bounded_array_nested_msg_c->primitive_values.data[0].float32_value = 1;
-  bounded_array_nested_msg_c->primitive_values.data[0].float64_value = 2;
-  bounded_array_nested_msg_c->primitive_values.data[0].int8_value = 3;
-  bounded_array_nested_msg_c->primitive_values.data[0].uint8_value = 4;
-  bounded_array_nested_msg_c->primitive_values.data[0].int16_value = 5;
-  bounded_array_nested_msg_c->primitive_values.data[0].uint16_value = 6;
-  bounded_array_nested_msg_c->primitive_values.data[0].int32_value = 7;
-  bounded_array_nested_msg_c->primitive_values.data[0].uint32_value = 8;
-  bounded_array_nested_msg_c->primitive_values.data[0].int64_value = 9;
-  bounded_array_nested_msg_c->primitive_values.data[0].uint64_value = 10;
-  rosidl_generator_c__String__assign(
-    &bounded_array_nested_msg_c->primitive_values.data[0].string_value, "hello world");
+  test_msgs__msg__BoundedSequences__init(bounded_sequences_msg_c);
+  test_msgs__msg__BasicTypes__Sequence__init(&bounded_sequences_msg_c->basic_types_values, 1);
+  bounded_sequences_msg_c->basic_types_values.data[0].bool_value = true;
+  bounded_sequences_msg_c->basic_types_values.data[0].byte_value = 255;
+  bounded_sequences_msg_c->basic_types_values.data[0].char_value = 'k';
+  bounded_sequences_msg_c->basic_types_values.data[0].float32_value = 1;
+  bounded_sequences_msg_c->basic_types_values.data[0].float64_value = 2;
+  bounded_sequences_msg_c->basic_types_values.data[0].int8_value = 3;
+  bounded_sequences_msg_c->basic_types_values.data[0].uint8_value = 4;
+  bounded_sequences_msg_c->basic_types_values.data[0].int16_value = 5;
+  bounded_sequences_msg_c->basic_types_values.data[0].uint16_value = 6;
+  bounded_sequences_msg_c->basic_types_values.data[0].int32_value = 7;
+  bounded_sequences_msg_c->basic_types_values.data[0].uint32_value = 8;
+  bounded_sequences_msg_c->basic_types_values.data[0].int64_value = 9;
+  bounded_sequences_msg_c->basic_types_values.data[0].uint64_value = 10;
 }
 
-void fill_cpp_message(test_msgs::msg::BoundedArrayNested * bounded_array_nested_msg_cpp)
+void fill_cpp_message(test_msgs::msg::BoundedSequences * bounded_sequences_msg_cpp)
 {
-  test_msgs::msg::Primitives primitive_msg_cpp;
-  primitive_msg_cpp.bool_value = true;
-  primitive_msg_cpp.byte_value = 255;
-  primitive_msg_cpp.char_value = 'k';
-  primitive_msg_cpp.float32_value = 1;
-  primitive_msg_cpp.float64_value = 2;
-  primitive_msg_cpp.int8_value = 3;
-  primitive_msg_cpp.uint8_value = 4;
-  primitive_msg_cpp.int16_value = 5;
-  primitive_msg_cpp.uint16_value = 6;
-  primitive_msg_cpp.int32_value = 7;
-  primitive_msg_cpp.uint32_value = 8;
-  primitive_msg_cpp.int64_value = 9;
-  primitive_msg_cpp.uint64_value = 10;
-  primitive_msg_cpp.string_value = "hello world";
-  bounded_array_nested_msg_cpp->primitive_values.push_back(primitive_msg_cpp);
+  test_msgs::msg::BasicTypes basic_types_msg_cpp;
+  basic_types_msg_cpp.bool_value = true;
+  basic_types_msg_cpp.byte_value = 255;
+  basic_types_msg_cpp.char_value = 'k';
+  basic_types_msg_cpp.float32_value = 1;
+  basic_types_msg_cpp.float64_value = 2;
+  basic_types_msg_cpp.int8_value = 3;
+  basic_types_msg_cpp.uint8_value = 4;
+  basic_types_msg_cpp.int16_value = 5;
+  basic_types_msg_cpp.uint16_value = 6;
+  basic_types_msg_cpp.int32_value = 7;
+  basic_types_msg_cpp.uint32_value = 8;
+  basic_types_msg_cpp.int64_value = 9;
+  basic_types_msg_cpp.uint64_value = 10;
+  bounded_sequences_msg_cpp->basic_basic_types_values.push_back(basic_types_msg_cpp);
 }
 
 TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), de_serialize_c) {
@@ -102,40 +97,38 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), de_serialize_c) 
   auto ret = rmw_serialized_message_init(&serialized_message_c, 0, &allocator);
   ASSERT_EQ(RMW_RET_OK, ret);
 
-  auto message_c_typesupport = ROSIDL_GET_MSG_TYPE_SUPPORT(test_msgs, msg, BoundedArrayNested);
-  test_msgs__msg__BoundedArrayNested bounded_array_nested_msg_c;
-  fill_c_message(&bounded_array_nested_msg_c);
+  auto message_c_typesupport = ROSIDL_GET_MSG_TYPE_SUPPORT(test_msgs, msg, BoundedSequences);
+  test_msgs__msg__BoundedSequences bounded_sequences_msg_c;
+  fill_c_message(&bounded_sequences_msg_c);
 
-  ret = rmw_serialize(&bounded_array_nested_msg_c, message_c_typesupport, &serialized_message_c);
+  ret = rmw_serialize(&bounded_sequences_msg_c, message_c_typesupport, &serialized_message_c);
   EXPECT_EQ(RMW_RET_OK, ret);
   EXPECT_EQ(76u, serialized_message_c.buffer_length);  // measured from wireshark
 
   printf("serialized data length: %zu\n", serialized_message_c.buffer_length);
   print_serialized_buffer(serialized_message_c, "serialized message c");
 
-  test_msgs__msg__BoundedArrayNested bounded_array_nested_c_reverse;
-  test_msgs__msg__BoundedArrayNested__init(&bounded_array_nested_c_reverse);
+  test_msgs__msg__BoundedSequences bounded_sequences_c_reverse;
+  test_msgs__msg__BoundedSequences__init(&bounded_sequences_c_reverse);
   ret =
-    rmw_deserialize(&serialized_message_c, message_c_typesupport, &bounded_array_nested_c_reverse);
+    rmw_deserialize(&serialized_message_c, message_c_typesupport, &bounded_sequences_c_reverse);
   EXPECT_EQ(RMW_RET_OK, ret);
-  EXPECT_EQ(true, bounded_array_nested_c_reverse.primitive_values.data[0].bool_value);
-  EXPECT_EQ(255, bounded_array_nested_c_reverse.primitive_values.data[0].byte_value);
-  EXPECT_EQ('k', bounded_array_nested_c_reverse.primitive_values.data[0].char_value);
-  EXPECT_EQ(1, bounded_array_nested_c_reverse.primitive_values.data[0].float32_value);
-  EXPECT_EQ(2, bounded_array_nested_c_reverse.primitive_values.data[0].float64_value);
-  EXPECT_EQ(3, bounded_array_nested_c_reverse.primitive_values.data[0].int8_value);
-  EXPECT_EQ(4u, bounded_array_nested_c_reverse.primitive_values.data[0].uint8_value);
-  EXPECT_EQ(5, bounded_array_nested_c_reverse.primitive_values.data[0].int16_value);
-  EXPECT_EQ(6u, bounded_array_nested_c_reverse.primitive_values.data[0].uint16_value);
-  EXPECT_EQ(7, bounded_array_nested_c_reverse.primitive_values.data[0].int32_value);
-  EXPECT_EQ(8u, bounded_array_nested_c_reverse.primitive_values.data[0].uint32_value);
-  EXPECT_EQ(9, bounded_array_nested_c_reverse.primitive_values.data[0].int64_value);
-  EXPECT_EQ(10u, bounded_array_nested_c_reverse.primitive_values.data[0].uint64_value);
-  EXPECT_STREQ(
-    "hello world", bounded_array_nested_c_reverse.primitive_values.data[0].string_value.data);
+  EXPECT_EQ(true, bounded_sequences_c_reverse.basic_types_values.data[0].bool_value);
+  EXPECT_EQ(255, bounded_sequences_c_reverse.basic_types_values.data[0].byte_value);
+  EXPECT_EQ('k', bounded_sequences_c_reverse.basic_types_values.data[0].char_value);
+  EXPECT_EQ(1, bounded_sequences_c_reverse.basic_types_values.data[0].float32_value);
+  EXPECT_EQ(2, bounded_sequences_c_reverse.basic_types_values.data[0].float64_value);
+  EXPECT_EQ(3, bounded_sequences_c_reverse.basic_types_values.data[0].int8_value);
+  EXPECT_EQ(4u, bounded_sequences_c_reverse.basic_types_values.data[0].uint8_value);
+  EXPECT_EQ(5, bounded_sequences_c_reverse.basic_types_values.data[0].int16_value);
+  EXPECT_EQ(6u, bounded_sequences_c_reverse.basic_types_values.data[0].uint16_value);
+  EXPECT_EQ(7, bounded_sequences_c_reverse.basic_types_values.data[0].int32_value);
+  EXPECT_EQ(8u, bounded_sequences_c_reverse.basic_types_values.data[0].uint32_value);
+  EXPECT_EQ(9, bounded_sequences_c_reverse.basic_types_values.data[0].int64_value);
+  EXPECT_EQ(10u, bounded_sequences_c_reverse.basic_types_values.data[0].uint64_value);
 
-  test_msgs__msg__BoundedArrayNested__fini(&bounded_array_nested_c_reverse);
-  test_msgs__msg__BoundedArrayNested__fini(&bounded_array_nested_msg_c);
+  test_msgs__msg__BoundedSequences__fini(&bounded_sequences_c_reverse);
+  test_msgs__msg__BoundedSequences__fini(&bounded_sequences_msg_c);
   ret = rmw_serialized_message_fini(&serialized_message_c);
   ASSERT_EQ(RMW_RET_OK, ret);
 }
@@ -148,36 +141,34 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), de_serialize_cpp
   ASSERT_EQ(RMW_RET_OK, ret);
 
   auto message_cpp_typesupport =
-    rosidl_typesupport_cpp::get_message_type_support_handle<test_msgs::msg::BoundedArrayNested>();
+    rosidl_typesupport_cpp::get_message_type_support_handle<test_msgs::msg::BoundedSequences>();
 
-  test_msgs::msg::BoundedArrayNested bounded_array_nested_msg_cpp;
-  fill_cpp_message(&bounded_array_nested_msg_cpp);
+  test_msgs::msg::BoundedSequences bounded_sequences_msg_cpp;
+  fill_cpp_message(&bounded_sequences_msg_cpp);
 
   ret =
-    rmw_serialize(&bounded_array_nested_msg_cpp, message_cpp_typesupport, &serialized_message_cpp);
+    rmw_serialize(&bounded_sequences_msg_cpp, message_cpp_typesupport, &serialized_message_cpp);
   EXPECT_EQ(RMW_RET_OK, ret);
   EXPECT_EQ(76u, serialized_message_cpp.buffer_length);
   print_serialized_buffer(serialized_message_cpp, "serialized message cpp");
 
-  test_msgs::msg::BoundedArrayNested bounded_array_nested_cpp_reverse;
+  test_msgs::msg::BoundedSequences bounded_sequences_cpp_reverse;
   ret = rmw_deserialize(
-    &serialized_message_cpp, message_cpp_typesupport, &bounded_array_nested_cpp_reverse);
+    &serialized_message_cpp, message_cpp_typesupport, &bounded_sequences_cpp_reverse);
   EXPECT_EQ(RMW_RET_OK, ret);
-  EXPECT_EQ(true, bounded_array_nested_cpp_reverse.primitive_values[0].bool_value);
-  EXPECT_EQ(255, bounded_array_nested_cpp_reverse.primitive_values[0].byte_value);
-  EXPECT_EQ('k', bounded_array_nested_cpp_reverse.primitive_values[0].char_value);
-  EXPECT_EQ(1, bounded_array_nested_cpp_reverse.primitive_values[0].float32_value);
-  EXPECT_EQ(2, bounded_array_nested_cpp_reverse.primitive_values[0].float64_value);
-  EXPECT_EQ(3, bounded_array_nested_cpp_reverse.primitive_values[0].int8_value);
-  EXPECT_EQ(4u, bounded_array_nested_cpp_reverse.primitive_values[0].uint8_value);
-  EXPECT_EQ(5, bounded_array_nested_cpp_reverse.primitive_values[0].int16_value);
-  EXPECT_EQ(6u, bounded_array_nested_cpp_reverse.primitive_values[0].uint16_value);
-  EXPECT_EQ(7, bounded_array_nested_cpp_reverse.primitive_values[0].int32_value);
-  EXPECT_EQ(8u, bounded_array_nested_cpp_reverse.primitive_values[0].uint32_value);
-  EXPECT_EQ(9, bounded_array_nested_cpp_reverse.primitive_values[0].int64_value);
-  EXPECT_EQ(10u, bounded_array_nested_cpp_reverse.primitive_values[0].uint64_value);
-  EXPECT_STREQ(
-    "hello world", bounded_array_nested_cpp_reverse.primitive_values[0].string_value.c_str());
+  EXPECT_EQ(true, bounded_sequences_cpp_reverse.basic_types_values[0].bool_value);
+  EXPECT_EQ(255, bounded_sequences_cpp_reverse.basic_types_values[0].byte_value);
+  EXPECT_EQ('k', bounded_sequences_cpp_reverse.basic_types_values[0].char_value);
+  EXPECT_EQ(1, bounded_sequences_cpp_reverse.basic_types_values[0].float32_value);
+  EXPECT_EQ(2, bounded_sequences_cpp_reverse.basic_types_values[0].float64_value);
+  EXPECT_EQ(3, bounded_sequences_cpp_reverse.basic_types_values[0].int8_value);
+  EXPECT_EQ(4u, bounded_sequences_cpp_reverse.basic_types_values[0].uint8_value);
+  EXPECT_EQ(5, bounded_sequences_cpp_reverse.basic_types_values[0].int16_value);
+  EXPECT_EQ(6u, bounded_sequences_cpp_reverse.basic_types_values[0].uint16_value);
+  EXPECT_EQ(7, bounded_sequences_cpp_reverse.basic_types_values[0].int32_value);
+  EXPECT_EQ(8u, bounded_sequences_cpp_reverse.basic_types_values[0].uint32_value);
+  EXPECT_EQ(9, bounded_sequences_cpp_reverse.basic_types_values[0].int64_value);
+  EXPECT_EQ(10u, bounded_sequences_cpp_reverse.basic_types_values[0].uint64_value);
 
   ret = rmw_serialized_message_fini(&serialized_message_cpp);
   ASSERT_EQ(RMW_RET_OK, ret);
@@ -194,15 +185,15 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), cdr_integrity) {
   ret = rmw_serialized_message_init(&serialized_message_cpp, 0, &allocator);
   ASSERT_EQ(RMW_RET_OK, ret);
 
-  auto message_c_typesupport = ROSIDL_GET_MSG_TYPE_SUPPORT(test_msgs, msg, BoundedArrayNested);
+  auto message_c_typesupport = ROSIDL_GET_MSG_TYPE_SUPPORT(test_msgs, msg, BoundedSequences);
   auto message_cpp_typesupport =
-    rosidl_typesupport_cpp::get_message_type_support_handle<test_msgs::msg::BoundedArrayNested>();
+    rosidl_typesupport_cpp::get_message_type_support_handle<test_msgs::msg::BoundedSequences>();
 
-  test_msgs__msg__BoundedArrayNested msg_c;
-  test_msgs__msg__BoundedArrayNested__init(&msg_c);
+  test_msgs__msg__BoundedSequences msg_c;
+  test_msgs__msg__BoundedSequences__init(&msg_c);
   fill_c_message(&msg_c);
 
-  test_msgs::msg::BoundedArrayNested msg_cpp;
+  test_msgs::msg::BoundedSequences msg_cpp;
   fill_cpp_message(&msg_cpp);
 
   ret = rmw_serialize(&msg_c, message_c_typesupport, &serialized_message_c);
@@ -213,16 +204,16 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), cdr_integrity) {
   print_serialized_buffer(serialized_message_c, "serialized message c");
   print_serialized_buffer(serialized_message_cpp, "serialized message cpp");
 
-  test_msgs__msg__BoundedArrayNested msg_c_reverse;
-  test_msgs__msg__BoundedArrayNested__init(&msg_c_reverse);
-  test_msgs::msg::BoundedArrayNested msg_cpp_reverse;
+  test_msgs__msg__BoundedSequences msg_c_reverse;
+  test_msgs__msg__BoundedSequences__init(&msg_c_reverse);
+  test_msgs::msg::BoundedSequences msg_cpp_reverse;
   ret = rmw_deserialize(&serialized_message_cpp, message_c_typesupport, &msg_c_reverse);
   EXPECT_EQ(RMW_RET_OK, ret);
   ret = rmw_deserialize(&serialized_message_c, message_cpp_typesupport, &msg_cpp_reverse);
   EXPECT_EQ(RMW_RET_OK, ret);
 
-  test_msgs__msg__BoundedArrayNested__fini(&msg_c);
-  test_msgs__msg__BoundedArrayNested__fini(&msg_c_reverse);
+  test_msgs__msg__BoundedSequences__fini(&msg_c);
+  test_msgs__msg__BoundedSequences__fini(&msg_c_reverse);
   ret = rmw_serialized_message_fini(&serialized_message_c);
   ASSERT_EQ(RMW_RET_OK, ret);
   ret = rmw_serialized_message_fini(&serialized_message_cpp);

--- a/test_communication/test/test_message_serialization.cpp
+++ b/test_communication/test/test_message_serialization.cpp
@@ -52,42 +52,53 @@ void print_serialized_buffer(
   printf("\n");
 }
 
+void fill_c_message(test_msgs__msg__BasicTypes * basic_types_msg_c)
+{
+  test_msgs__msg__BasicTypes__init(basic_types_msg_c);
+  basic_types_msg_c->bool_value = true;
+  basic_types_msg_c->byte_value = 255;
+  basic_types_msg_c->char_value = 'k';
+  basic_types_msg_c->float32_value = 1;
+  basic_types_msg_c->float64_value = 2;
+  basic_types_msg_c->int8_value = 3;
+  basic_types_msg_c->uint8_value = 4;
+  basic_types_msg_c->int16_value = 5;
+  basic_types_msg_c->uint16_value = 6;
+  basic_types_msg_c->int32_value = 7;
+  basic_types_msg_c->uint32_value = 8;
+  basic_types_msg_c->int64_value = 9;
+  basic_types_msg_c->uint64_value = 10;
+}
+
 void fill_c_message(test_msgs__msg__BoundedSequences * bounded_sequences_msg_c)
 {
   test_msgs__msg__BoundedSequences__init(bounded_sequences_msg_c);
   test_msgs__msg__BasicTypes__Sequence__init(&bounded_sequences_msg_c->basic_types_values, 1);
-  bounded_sequences_msg_c->basic_types_values.data[0].bool_value = true;
-  bounded_sequences_msg_c->basic_types_values.data[0].byte_value = 255;
-  bounded_sequences_msg_c->basic_types_values.data[0].char_value = 'k';
-  bounded_sequences_msg_c->basic_types_values.data[0].float32_value = 1;
-  bounded_sequences_msg_c->basic_types_values.data[0].float64_value = 2;
-  bounded_sequences_msg_c->basic_types_values.data[0].int8_value = 3;
-  bounded_sequences_msg_c->basic_types_values.data[0].uint8_value = 4;
-  bounded_sequences_msg_c->basic_types_values.data[0].int16_value = 5;
-  bounded_sequences_msg_c->basic_types_values.data[0].uint16_value = 6;
-  bounded_sequences_msg_c->basic_types_values.data[0].int32_value = 7;
-  bounded_sequences_msg_c->basic_types_values.data[0].uint32_value = 8;
-  bounded_sequences_msg_c->basic_types_values.data[0].int64_value = 9;
-  bounded_sequences_msg_c->basic_types_values.data[0].uint64_value = 10;
+  fill_c_message(&bounded_sequences_msg_c->basic_types_values.data[0]);
+}
+
+void fill_cpp_message(test_msgs::msg::BasicTypes * basic_types_msg_cpp)
+{
+  basic_types_msg_cpp->bool_value = true;
+  basic_types_msg_cpp->byte_value = 255;
+  basic_types_msg_cpp->char_value = 'k';
+  basic_types_msg_cpp->float32_value = 1;
+  basic_types_msg_cpp->float64_value = 2;
+  basic_types_msg_cpp->int8_value = 3;
+  basic_types_msg_cpp->uint8_value = 4;
+  basic_types_msg_cpp->int16_value = 5;
+  basic_types_msg_cpp->uint16_value = 6;
+  basic_types_msg_cpp->int32_value = 7;
+  basic_types_msg_cpp->uint32_value = 8;
+  basic_types_msg_cpp->int64_value = 9;
+  basic_types_msg_cpp->uint64_value = 10;
 }
 
 void fill_cpp_message(test_msgs::msg::BoundedSequences * bounded_sequences_msg_cpp)
 {
-  test_msgs::msg::BasicTypes basic_types_msg_cpp;
-  basic_types_msg_cpp.bool_value = true;
-  basic_types_msg_cpp.byte_value = 255;
-  basic_types_msg_cpp.char_value = 'k';
-  basic_types_msg_cpp.float32_value = 1;
-  basic_types_msg_cpp.float64_value = 2;
-  basic_types_msg_cpp.int8_value = 3;
-  basic_types_msg_cpp.uint8_value = 4;
-  basic_types_msg_cpp.int16_value = 5;
-  basic_types_msg_cpp.uint16_value = 6;
-  basic_types_msg_cpp.int32_value = 7;
-  basic_types_msg_cpp.uint32_value = 8;
-  basic_types_msg_cpp.int64_value = 9;
-  basic_types_msg_cpp.uint64_value = 10;
-  bounded_sequences_msg_cpp->basic_types_values.push_back(basic_types_msg_cpp);
+  test_msgs::msg::BasicTypes basic_types;
+  fill_cpp_message(&basic_types);
+  bounded_sequences_msg_cpp->basic_types_values.push_back(basic_types);
 }
 
 TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), de_serialize_c) {
@@ -97,38 +108,38 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), de_serialize_c) 
   auto ret = rmw_serialized_message_init(&serialized_message_c, 0, &allocator);
   ASSERT_EQ(RMW_RET_OK, ret);
 
-  auto message_c_typesupport = ROSIDL_GET_MSG_TYPE_SUPPORT(test_msgs, msg, BoundedSequences);
-  test_msgs__msg__BoundedSequences bounded_sequences_msg_c;
-  fill_c_message(&bounded_sequences_msg_c);
+  auto message_c_typesupport = ROSIDL_GET_MSG_TYPE_SUPPORT(test_msgs, msg, BasicTypes);
+  test_msgs__msg__BasicTypes basic_types_msg_c;
+  fill_c_message(&basic_types_msg_c);
 
-  ret = rmw_serialize(&bounded_sequences_msg_c, message_c_typesupport, &serialized_message_c);
+  ret = rmw_serialize(&basic_types_msg_c, message_c_typesupport, &serialized_message_c);
   EXPECT_EQ(RMW_RET_OK, ret);
-  EXPECT_EQ(196u, serialized_message_c.buffer_length);  // measured from wireshark
+  EXPECT_EQ(52u, serialized_message_c.buffer_length);  // measured from wireshark
 
   printf("serialized data length: %zu\n", serialized_message_c.buffer_length);
   print_serialized_buffer(serialized_message_c, "serialized message c");
 
-  test_msgs__msg__BoundedSequences bounded_sequences_c_reverse;
-  test_msgs__msg__BoundedSequences__init(&bounded_sequences_c_reverse);
+  test_msgs__msg__BasicTypes basic_types_c_reverse;
+  test_msgs__msg__BasicTypes__init(&basic_types_c_reverse);
   ret =
-    rmw_deserialize(&serialized_message_c, message_c_typesupport, &bounded_sequences_c_reverse);
+    rmw_deserialize(&serialized_message_c, message_c_typesupport, &basic_types_c_reverse);
   EXPECT_EQ(RMW_RET_OK, ret);
-  EXPECT_EQ(true, bounded_sequences_c_reverse.basic_types_values.data[0].bool_value);
-  EXPECT_EQ(255, bounded_sequences_c_reverse.basic_types_values.data[0].byte_value);
-  EXPECT_EQ('k', bounded_sequences_c_reverse.basic_types_values.data[0].char_value);
-  EXPECT_EQ(1, bounded_sequences_c_reverse.basic_types_values.data[0].float32_value);
-  EXPECT_EQ(2, bounded_sequences_c_reverse.basic_types_values.data[0].float64_value);
-  EXPECT_EQ(3, bounded_sequences_c_reverse.basic_types_values.data[0].int8_value);
-  EXPECT_EQ(4u, bounded_sequences_c_reverse.basic_types_values.data[0].uint8_value);
-  EXPECT_EQ(5, bounded_sequences_c_reverse.basic_types_values.data[0].int16_value);
-  EXPECT_EQ(6u, bounded_sequences_c_reverse.basic_types_values.data[0].uint16_value);
-  EXPECT_EQ(7, bounded_sequences_c_reverse.basic_types_values.data[0].int32_value);
-  EXPECT_EQ(8u, bounded_sequences_c_reverse.basic_types_values.data[0].uint32_value);
-  EXPECT_EQ(9, bounded_sequences_c_reverse.basic_types_values.data[0].int64_value);
-  EXPECT_EQ(10u, bounded_sequences_c_reverse.basic_types_values.data[0].uint64_value);
+  EXPECT_EQ(true, basic_types_c_reverse.bool_value);
+  EXPECT_EQ(255, basic_types_c_reverse.byte_value);
+  EXPECT_EQ('k', basic_types_c_reverse.char_value);
+  EXPECT_EQ(1, basic_types_c_reverse.float32_value);
+  EXPECT_EQ(2, basic_types_c_reverse.float64_value);
+  EXPECT_EQ(3, basic_types_c_reverse.int8_value);
+  EXPECT_EQ(4u, basic_types_c_reverse.uint8_value);
+  EXPECT_EQ(5, basic_types_c_reverse.int16_value);
+  EXPECT_EQ(6u, basic_types_c_reverse.uint16_value);
+  EXPECT_EQ(7, basic_types_c_reverse.int32_value);
+  EXPECT_EQ(8u, basic_types_c_reverse.uint32_value);
+  EXPECT_EQ(9, basic_types_c_reverse.int64_value);
+  EXPECT_EQ(10u, basic_types_c_reverse.uint64_value);
 
-  test_msgs__msg__BoundedSequences__fini(&bounded_sequences_c_reverse);
-  test_msgs__msg__BoundedSequences__fini(&bounded_sequences_msg_c);
+  test_msgs__msg__BasicTypes__fini(&basic_types_c_reverse);
+  test_msgs__msg__BasicTypes__fini(&basic_types_msg_c);
   ret = rmw_serialized_message_fini(&serialized_message_c);
   ASSERT_EQ(RMW_RET_OK, ret);
 }
@@ -141,34 +152,34 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), de_serialize_cpp
   ASSERT_EQ(RMW_RET_OK, ret);
 
   auto message_cpp_typesupport =
-    rosidl_typesupport_cpp::get_message_type_support_handle<test_msgs::msg::BoundedSequences>();
+    rosidl_typesupport_cpp::get_message_type_support_handle<test_msgs::msg::BasicTypes>();
 
-  test_msgs::msg::BoundedSequences bounded_sequences_msg_cpp;
-  fill_cpp_message(&bounded_sequences_msg_cpp);
+  test_msgs::msg::BasicTypes basic_types_msg_cpp;
+  fill_cpp_message(&basic_types_msg_cpp);
 
   ret =
-    rmw_serialize(&bounded_sequences_msg_cpp, message_cpp_typesupport, &serialized_message_cpp);
+    rmw_serialize(&basic_types_msg_cpp, message_cpp_typesupport, &serialized_message_cpp);
   EXPECT_EQ(RMW_RET_OK, ret);
-  EXPECT_EQ(196u, serialized_message_cpp.buffer_length);
+  EXPECT_EQ(52u, serialized_message_cpp.buffer_length);
   print_serialized_buffer(serialized_message_cpp, "serialized message cpp");
 
-  test_msgs::msg::BoundedSequences bounded_sequences_cpp_reverse;
+  test_msgs::msg::BasicTypes basic_types_cpp_reverse;
   ret = rmw_deserialize(
-    &serialized_message_cpp, message_cpp_typesupport, &bounded_sequences_cpp_reverse);
+    &serialized_message_cpp, message_cpp_typesupport, &basic_types_cpp_reverse);
   EXPECT_EQ(RMW_RET_OK, ret);
-  EXPECT_EQ(true, bounded_sequences_cpp_reverse.basic_types_values[0].bool_value);
-  EXPECT_EQ(255, bounded_sequences_cpp_reverse.basic_types_values[0].byte_value);
-  EXPECT_EQ('k', bounded_sequences_cpp_reverse.basic_types_values[0].char_value);
-  EXPECT_EQ(1, bounded_sequences_cpp_reverse.basic_types_values[0].float32_value);
-  EXPECT_EQ(2, bounded_sequences_cpp_reverse.basic_types_values[0].float64_value);
-  EXPECT_EQ(3, bounded_sequences_cpp_reverse.basic_types_values[0].int8_value);
-  EXPECT_EQ(4u, bounded_sequences_cpp_reverse.basic_types_values[0].uint8_value);
-  EXPECT_EQ(5, bounded_sequences_cpp_reverse.basic_types_values[0].int16_value);
-  EXPECT_EQ(6u, bounded_sequences_cpp_reverse.basic_types_values[0].uint16_value);
-  EXPECT_EQ(7, bounded_sequences_cpp_reverse.basic_types_values[0].int32_value);
-  EXPECT_EQ(8u, bounded_sequences_cpp_reverse.basic_types_values[0].uint32_value);
-  EXPECT_EQ(9, bounded_sequences_cpp_reverse.basic_types_values[0].int64_value);
-  EXPECT_EQ(10u, bounded_sequences_cpp_reverse.basic_types_values[0].uint64_value);
+  EXPECT_EQ(true, basic_types_cpp_reverse.bool_value);
+  EXPECT_EQ(255, basic_types_cpp_reverse.byte_value);
+  EXPECT_EQ('k', basic_types_cpp_reverse.char_value);
+  EXPECT_EQ(1, basic_types_cpp_reverse.float32_value);
+  EXPECT_EQ(2, basic_types_cpp_reverse.float64_value);
+  EXPECT_EQ(3, basic_types_cpp_reverse.int8_value);
+  EXPECT_EQ(4u, basic_types_cpp_reverse.uint8_value);
+  EXPECT_EQ(5, basic_types_cpp_reverse.int16_value);
+  EXPECT_EQ(6u, basic_types_cpp_reverse.uint16_value);
+  EXPECT_EQ(7, basic_types_cpp_reverse.int32_value);
+  EXPECT_EQ(8u, basic_types_cpp_reverse.uint32_value);
+  EXPECT_EQ(9, basic_types_cpp_reverse.int64_value);
+  EXPECT_EQ(10u, basic_types_cpp_reverse.uint64_value);
 
   ret = rmw_serialized_message_fini(&serialized_message_cpp);
   ASSERT_EQ(RMW_RET_OK, ret);

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -28,6 +28,8 @@
 
 #include "rcl/rcl.h"
 
+#include "test_msgs/msg/basic_types.h"
+
 #include "test_msgs/msg/bounded_array_nested.h"
 #include "test_msgs/msg/bounded_array_primitives.h"
 #include "test_msgs/msg/dynamic_array_nested.h"
@@ -255,22 +257,22 @@ void fini_message(MessageT * msg);
 
 // Define functions and test cases for each message type
 template<>
-size_t get_message_num(test_msgs__msg__Primitives * msg)
+size_t get_message_num(test_msgs__msg__BasicTypes * msg)
 {
   (void)msg;
   return 4;
 }
 
 template<>
-void init_message(test_msgs__msg__Primitives * msg)
+void init_message(test_msgs__msg__BasicTypes * msg)
 {
-  test_msgs__msg__Primitives__init(msg);
+  test_msgs__msg__BasicTypes__init(msg);
 }
 
 template<>
-void get_message(test_msgs__msg__Primitives * msg, size_t msg_num)
+void get_message(test_msgs__msg__BasicTypes * msg, size_t msg_num)
 {
-  test_msgs__msg__Primitives__init(msg);
+  test_msgs__msg__BasicTypes__init(msg);
   switch (msg_num) {
     case 0:
       msg->bool_value = false;
@@ -286,7 +288,7 @@ void get_message(test_msgs__msg__Primitives * msg, size_t msg_num)
       msg->uint32_value = 0;
       msg->int64_value = 0;
       msg->uint64_value = 0;
-      rosidl_generator_c__String__assign(&msg->string_value, "");
+      // rosidl_generator_c__String__assign(&msg->string_value, "");
       break;
     case 1:
       msg->bool_value = true;
@@ -302,7 +304,7 @@ void get_message(test_msgs__msg__Primitives * msg, size_t msg_num)
       msg->uint32_value = (std::numeric_limits<uint32_t>::max)();
       msg->int64_value = (std::numeric_limits<int64_t>::max)();
       msg->uint64_value = (std::numeric_limits<uint64_t>::max)();
-      rosidl_generator_c__String__assign(&msg->string_value, "max value");
+      // rosidl_generator_c__String__assign(&msg->string_value, "max value");
       break;
     case 2:
       msg->bool_value = false;
@@ -318,7 +320,7 @@ void get_message(test_msgs__msg__Primitives * msg, size_t msg_num)
       msg->uint32_value = 0;
       msg->int64_value = (std::numeric_limits<int64_t>::min)();
       msg->uint64_value = 0;
-      rosidl_generator_c__String__assign(&msg->string_value, "min value");
+      // rosidl_generator_c__String__assign(&msg->string_value, "min value");
       break;
     case 3:
       msg->bool_value = true;
@@ -334,19 +336,19 @@ void get_message(test_msgs__msg__Primitives * msg, size_t msg_num)
       msg->uint32_value = 1;
       msg->int64_value = 1;
       msg->uint64_value = 1;
-      char string_value[20000] = {};
-      for (uint32_t i = 0; i < 20000; i++) {
-        string_value[i] = '0' + (i % 10);
-      }
-      rosidl_generator_c__String__assignn(&msg->string_value, string_value, sizeof(string_value));
+      // char string_value[20000] = {};
+      // for (uint32_t i = 0; i < 20000; i++) {
+      //   string_value[i] = '0' + (i % 10);
+      // }
+      // rosidl_generator_c__String__assignn(&msg->string_value, string_value, sizeof(string_value));
       break;
   }
 }
 
 template<>
-void verify_message(test_msgs__msg__Primitives & message, size_t msg_num)
+void verify_message(test_msgs__msg__BasicTypes & message, size_t msg_num)
 {
-  test_msgs__msg__Primitives expected_msg;
+  test_msgs__msg__BasicTypes expected_msg;
   get_message(&expected_msg, msg_num);
   EXPECT_EQ(expected_msg.bool_value, message.bool_value);
   EXPECT_EQ(expected_msg.byte_value, message.byte_value);
@@ -361,14 +363,14 @@ void verify_message(test_msgs__msg__Primitives & message, size_t msg_num)
   EXPECT_EQ(expected_msg.uint32_value, message.uint32_value);
   EXPECT_EQ(expected_msg.int64_value, message.int64_value);
   EXPECT_EQ(expected_msg.uint64_value, message.uint64_value);
-  EXPECT_EQ(0, strcmp(expected_msg.string_value.data, message.string_value.data));
+  // EXPECT_EQ(0, strcmp(expected_msg.string_value.data, message.string_value.data));
 }
 
-DEFINE_FINI_MESSAGE(test_msgs__msg__Primitives)
-TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_primitives) {
+DEFINE_FINI_MESSAGE(test_msgs__msg__BasicTypes)
+TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_basic_types) {
   const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
-    test_msgs, msg, Primitives);
-  test_message_type<test_msgs__msg__Primitives>("test_primitives", ts, this->context_ptr);
+    test_msgs, msg, BasicTypes);
+  test_message_type<test_msgs__msg__BasicTypes>("test_basic_types", ts, this->context_ptr);
 }
 
 template<>

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -28,6 +28,7 @@
 
 #include "rcl/rcl.h"
 
+#include "test_msgs/msg/arrays.h"
 #include "test_msgs/msg/basic_types.h"
 
 #include "test_msgs/msg/bounded_array_nested.h"
@@ -39,7 +40,6 @@
 #include "test_msgs/msg/nested.h"
 #include "test_msgs/msg/primitives.h"
 #include "test_msgs/msg/static_array_nested.h"
-#include "test_msgs/msg/static_array_primitives.h"
 #include "test_msgs/msg/builtins.h"
 
 #include "rosidl_generator_c/string_functions.h"
@@ -452,22 +452,22 @@ TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_builtins) {
 
 
 template<>
-size_t get_message_num(test_msgs__msg__StaticArrayPrimitives * msg)
+size_t get_message_num(test_msgs__msg__Arrays * msg)
 {
   (void)msg;
   return 1;
 }
 
 template<>
-void init_message(test_msgs__msg__StaticArrayPrimitives * msg)
+void init_message(test_msgs__msg__Arrays * msg)
 {
-  test_msgs__msg__StaticArrayPrimitives__init(msg);
+  test_msgs__msg__Arrays__init(msg);
 }
 
 template<>
-void get_message(test_msgs__msg__StaticArrayPrimitives * msg, size_t msg_num)
+void get_message(test_msgs__msg__Arrays * msg, size_t msg_num)
 {
-  test_msgs__msg__StaticArrayPrimitives__init(msg);
+  test_msgs__msg__Arrays__init(msg);
   if (msg_num == 0) {
     msg->bool_values[0] = false;
     msg->bool_values[1] = true;
@@ -515,9 +515,9 @@ void get_message(test_msgs__msg__StaticArrayPrimitives * msg, size_t msg_num)
 }
 
 template<>
-void verify_message(test_msgs__msg__StaticArrayPrimitives & message, size_t msg_num)
+void verify_message(test_msgs__msg__Arrays & message, size_t msg_num)
 {
-  test_msgs__msg__StaticArrayPrimitives expected_msg;
+  test_msgs__msg__Arrays expected_msg;
   get_message(&expected_msg, msg_num);
   for (size_t i = 0; i < 3; ++i) {
     EXPECT_EQ(expected_msg.bool_values[i], message.bool_values[i]);
@@ -538,11 +538,11 @@ void verify_message(test_msgs__msg__StaticArrayPrimitives & message, size_t msg_
   }
 }
 
-DEFINE_FINI_MESSAGE(test_msgs__msg__StaticArrayPrimitives)
+DEFINE_FINI_MESSAGE(test_msgs__msg__Arrays)
 TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_staticarrayprimitives) {
   const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
-    test_msgs, msg, StaticArrayPrimitives);
-  test_message_type<test_msgs__msg__StaticArrayPrimitives>(
+    test_msgs, msg, Arrays);
+  test_message_type<test_msgs__msg__Arrays>(
     "test_staticarrayprimitives", ts, this->context_ptr);
 }
 

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -36,6 +36,7 @@
 #include "test_msgs/msg/empty.h"
 #include "test_msgs/msg/nested.h"
 #include "test_msgs/msg/builtins.h"
+#include "test_msgs/msg/strings.h"
 
 #include "rosidl_generator_c/string_functions.h"
 #include "rosidl_generator_c/primitives_sequence_functions.h"
@@ -283,7 +284,6 @@ void get_message(test_msgs__msg__BasicTypes * msg, size_t msg_num)
       msg->uint32_value = 0;
       msg->int64_value = 0;
       msg->uint64_value = 0;
-      // rosidl_generator_c__String__assign(&msg->string_value, "");
       break;
     case 1:
       msg->bool_value = true;
@@ -299,7 +299,6 @@ void get_message(test_msgs__msg__BasicTypes * msg, size_t msg_num)
       msg->uint32_value = (std::numeric_limits<uint32_t>::max)();
       msg->int64_value = (std::numeric_limits<int64_t>::max)();
       msg->uint64_value = (std::numeric_limits<uint64_t>::max)();
-      // rosidl_generator_c__String__assign(&msg->string_value, "max value");
       break;
     case 2:
       msg->bool_value = false;
@@ -315,7 +314,6 @@ void get_message(test_msgs__msg__BasicTypes * msg, size_t msg_num)
       msg->uint32_value = 0;
       msg->int64_value = (std::numeric_limits<int64_t>::min)();
       msg->uint64_value = 0;
-      // rosidl_generator_c__String__assign(&msg->string_value, "min value");
       break;
     case 3:
       msg->bool_value = true;
@@ -331,11 +329,6 @@ void get_message(test_msgs__msg__BasicTypes * msg, size_t msg_num)
       msg->uint32_value = 1;
       msg->int64_value = 1;
       msg->uint64_value = 1;
-      // char string_value[20000] = {};
-      // for (uint32_t i = 0; i < 20000; i++) {
-      //   string_value[i] = '0' + (i % 10);
-      // }
-      // rosidl_generator_c__String__assignn(&msg->string_value, string_value, sizeof(string_value));
       break;
   }
 }
@@ -358,7 +351,6 @@ void verify_message(test_msgs__msg__BasicTypes & message, size_t msg_num)
   EXPECT_EQ(expected_msg.uint32_value, message.uint32_value);
   EXPECT_EQ(expected_msg.int64_value, message.int64_value);
   EXPECT_EQ(expected_msg.uint64_value, message.uint64_value);
-  // EXPECT_EQ(0, strcmp(expected_msg.string_value.data, message.string_value.data));
 }
 
 DEFINE_FINI_MESSAGE(test_msgs__msg__BasicTypes)
@@ -366,6 +358,64 @@ TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_basic_types) {
   const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
     test_msgs, msg, BasicTypes);
   test_message_type<test_msgs__msg__BasicTypes>("test_basic_types", ts, this->context_ptr);
+}
+
+template<>
+size_t get_message_num(test_msgs__msg__Strings * msg)
+{
+  (void)msg;
+  return 3;
+}
+
+template<>
+void init_message(test_msgs__msg__Strings * msg)
+{
+  test_msgs__msg__Strings__init(msg);
+}
+
+template<>
+void get_message(test_msgs__msg__Strings * msg, size_t msg_num)
+{
+  test_msgs__msg__Strings__init(msg);
+  switch (msg_num) {
+    case 0:
+      rosidl_generator_c__String__assign(&msg->string_value, "");
+      rosidl_generator_c__String__assign(&msg->bounded_string_value, "");
+      break;
+    case 1:
+      rosidl_generator_c__String__assign(&msg->string_value, "Hello world!");
+      rosidl_generator_c__String__assign(&msg->bounded_string_value, "Hello world!");
+      break;
+    case 2:
+      char string_value[20000] = {};
+      for (uint32_t i = 0; i < 20000; i++) {
+        string_value[i] = '0' + (i % 10);
+      }
+      char bounded_string_value[22] = {};
+      for (uint32_t i = 0; i < 22; i++) {
+        bounded_string_value[i] = '0' + (i % 10);
+      }
+      rosidl_generator_c__String__assignn(&msg->string_value, string_value, sizeof(string_value));
+      rosidl_generator_c__String__assignn(
+        &msg->bounded_string_value, bounded_string_value, sizeof(bounded_string_value));
+      break;
+  }
+}
+
+template<>
+void verify_message(test_msgs__msg__Strings & message, size_t msg_num)
+{
+  test_msgs__msg__Strings expected_msg;
+  get_message(&expected_msg, msg_num);
+  EXPECT_EQ(0, strcmp(expected_msg.string_value.data, message.string_value.data));
+  EXPECT_EQ(0, strcmp(expected_msg.bounded_string_value.data, message.bounded_string_value.data));
+}
+
+DEFINE_FINI_MESSAGE(test_msgs__msg__Strings)
+TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_strings) {
+  const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
+    test_msgs, msg, Strings);
+  test_message_type<test_msgs__msg__Strings>("test_strings", ts, this->context_ptr);
 }
 
 template<>

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -385,13 +385,13 @@ template<>
 void get_message(test_msgs__msg__Nested * msg, size_t msg_num)
 {
   test_msgs__msg__Nested__init(msg);
-  get_message(&msg->primitive_values, msg_num);
+  get_message(&msg->basic_types_value, msg_num);
 }
 
 template<>
 void verify_message(test_msgs__msg__Nested & message, size_t msg_num)
 {
-  verify_message(message.primitive_values, msg_num);
+  verify_message(message.basic_types_value, msg_num);
 }
 
 DEFINE_FINI_MESSAGE(test_msgs__msg__Nested)
@@ -575,7 +575,7 @@ void get_message(test_msgs__msg__UnboundedSequences * msg, size_t msg_num)
       rosidl_generator_c__int64__Sequence__init(&msg->int64_values, 0);
       rosidl_generator_c__uint64__Sequence__init(&msg->uint64_values, 0);
       rosidl_generator_c__String__Sequence__init(&msg->string_values, 0);
-      msg->check = 0;
+      msg->alignment_check = 0;
       break;
     case 1:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, 1);
@@ -607,7 +607,7 @@ void get_message(test_msgs__msg__UnboundedSequences * msg, size_t msg_num)
       msg->int64_values.data[0] = (std::numeric_limits<int64_t>::max)();
       msg->uint64_values.data[0] = (std::numeric_limits<uint64_t>::max)();
       rosidl_generator_c__String__assign(&msg->string_values.data[0], "max value");
-      msg->check = 1;
+      msg->alignment_check = 1;
       break;
     case 2:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, 2);
@@ -660,7 +660,7 @@ void get_message(test_msgs__msg__UnboundedSequences * msg, size_t msg_num)
       rosidl_generator_c__String__assign(&msg->string_values.data[0], "");
       rosidl_generator_c__String__assign(&msg->string_values.data[1], "max value");
       rosidl_generator_c__String__assign(&msg->string_values.data[2], "optional min value");
-      msg->check = 2;
+      msg->alignment_check = 2;
       break;
     case 3:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, size);
@@ -699,7 +699,7 @@ void get_message(test_msgs__msg__UnboundedSequences * msg, size_t msg_num)
         snprintf(tmpstr, sizeof(tmpstr), "%zu", i);
         rosidl_generator_c__String__assign(&msg->string_values.data[i], tmpstr);
       }
-      msg->check = 3;
+      msg->alignment_check = 3;
       break;
     case 4:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, 0);
@@ -716,7 +716,7 @@ void get_message(test_msgs__msg__UnboundedSequences * msg, size_t msg_num)
       rosidl_generator_c__int64__Sequence__init(&msg->int64_values, 0);
       rosidl_generator_c__uint64__Sequence__init(&msg->uint64_values, 0);
       rosidl_generator_c__String__Sequence__init(&msg->string_values, 0);
-      msg->check = 4;
+      msg->alignment_check = 4;
       break;
   }
 }
@@ -868,7 +868,7 @@ void get_message(test_msgs__msg__BoundedSequences * msg, size_t msg_num)
       rosidl_generator_c__String__assign(&msg->string_values.data[0], "");
       rosidl_generator_c__String__assign(&msg->string_values.data[1], "max value");
       rosidl_generator_c__String__assign(&msg->string_values.data[2], "optional min value");
-      msg->check = 2;
+      msg->alignment_check = 2;
       break;
     case 1:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, 0);
@@ -885,7 +885,7 @@ void get_message(test_msgs__msg__BoundedSequences * msg, size_t msg_num)
       rosidl_generator_c__int64__Sequence__init(&msg->int64_values, 0);
       rosidl_generator_c__uint64__Sequence__init(&msg->uint64_values, 0);
       rosidl_generator_c__String__Sequence__init(&msg->string_values, 0);
-      msg->check = 4;
+      msg->alignment_check = 4;
       break;
   }
 }
@@ -979,7 +979,7 @@ void get_message(test_msgs__msg__MultiNested * msg, size_t msg_num)
 {
   size_t i;
   test_msgs__msg__MultiNested__init(msg);
-  test_msgs__msg__Array arrays;
+  test_msgs__msg__Arrays arrays;
   test_msgs__msg__BoundedSequences bounded_sequences;
   test_msgs__msg__UnboundedSequences unbounded_sequences;
   size_t num_arrays = get_message_num(&arrays);
@@ -1002,12 +1002,15 @@ void get_message(test_msgs__msg__MultiNested * msg, size_t msg_num)
       get_message(&msg->array_of_arrays[i], i % num_arrays);
       get_message(&msg->array_of_bounded_sequences[i], i % num_bounded_sequences);
       get_message(&msg->array_of_unbounded_sequences[i], i % num_unbounded_sequences);
-      get_message(&msg->bounded_sequence_of_arrays[i], i % num_arrays);
-      get_message(&msg->bounded_sequence_of_bounded_sequences[i], i % num_bounded_sequences);
-      get_message(&msg->bounded_sequence_of_unbounded_sequences[i], i % num_unbounded_sequences);
-      get_message(&msg->unbounded_sequence_of_arrays[i], i % num_arrays);
-      get_message(&msg->unbounded_sequence_of_bounded_sequences[i], i % num_bounded_sequences);
-      get_message(&msg->unbounded_sequence_of_unbounded_sequences[i], i % num_unbounded_sequences);
+      get_message(&msg->bounded_sequence_of_arrays.data[i], i % num_arrays);
+      get_message(&msg->bounded_sequence_of_bounded_sequences.data[i], i % num_bounded_sequences);
+      get_message(
+        &msg->bounded_sequence_of_unbounded_sequences.data[i], i % num_unbounded_sequences);
+      get_message(&msg->unbounded_sequence_of_arrays.data[i], i % num_arrays);
+      get_message(
+        &msg->unbounded_sequence_of_bounded_sequences.data[i], i % num_bounded_sequences);
+      get_message(
+        &msg->unbounded_sequence_of_unbounded_sequences.data[i], i % num_unbounded_sequences);
     }
   }
 }
@@ -1016,7 +1019,7 @@ template<>
 void verify_message(test_msgs__msg__MultiNested & message, size_t msg_num)
 {
   (void)msg_num;
-  test_msgs__msg__Array arrays;
+  test_msgs__msg__Arrays arrays;
   test_msgs__msg__BoundedSequences bounded_sequences;
   test_msgs__msg__UnboundedSequences unbounded_sequences;
   size_t num_arrays = get_message_num(&arrays);
@@ -1027,12 +1030,16 @@ void verify_message(test_msgs__msg__MultiNested & message, size_t msg_num)
      verify_message(message.array_of_arrays[i], i % num_arrays);
      verify_message(message.array_of_bounded_sequences[i], i % num_bounded_sequences);
      verify_message(message.array_of_unbounded_sequences[i], i % num_unbounded_sequences);
-     verify_message(message.bounded_sequence_of_arrays[i], i % num_arrays);
-     verify_message(message.bounded_sequence_of_bounded_sequences[i], i % num_bounded_sequences);
-     verify_message(message.bounded_sequence_of_unbounded_sequences[i], i % num_unbounded_sequences);
-     verify_message(message.unbounded_sequence_of_arrays[i], i % num_arrays);
-     verify_message(message.unbounded_sequence_of_bounded_sequences[i], i % num_bounded_sequences);
-     verify_message(message.unbounded_sequence_of_unbounded_sequences[i], i % num_unbounded_sequences);
+     verify_message(message.bounded_sequence_of_arrays.data[i], i % num_arrays);
+     verify_message(
+       message.bounded_sequence_of_bounded_sequences.data[i], i % num_bounded_sequences);
+     verify_message(
+       message.bounded_sequence_of_unbounded_sequences.data[i], i % num_unbounded_sequences);
+     verify_message(message.unbounded_sequence_of_arrays.data[i], i % num_arrays);
+     verify_message(
+       message.unbounded_sequence_of_bounded_sequences.data[i], i % num_bounded_sequences);
+     verify_message(
+       message.unbounded_sequence_of_unbounded_sequences.data[i], i % num_unbounded_sequences);
   }
 }
 

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -31,12 +31,12 @@
 #include "test_msgs/msg/arrays.h"
 #include "test_msgs/msg/basic_types.h"
 #include "test_msgs/msg/bounded_sequences.h"
-#include "test_msgs/msg/unbounded_sequences.h"
-#include "test_msgs/msg/multi_nested.h"
-#include "test_msgs/msg/empty.h"
-#include "test_msgs/msg/nested.h"
 #include "test_msgs/msg/builtins.h"
+#include "test_msgs/msg/empty.h"
+#include "test_msgs/msg/multi_nested.h"
+#include "test_msgs/msg/nested.h"
 #include "test_msgs/msg/strings.h"
+#include "test_msgs/msg/unbounded_sequences.h"
 
 #include "rosidl_generator_c/string_functions.h"
 #include "rosidl_generator_c/primitives_sequence_functions.h"
@@ -1077,19 +1077,19 @@ void verify_message(test_msgs__msg__MultiNested & message, size_t msg_num)
   size_t num_unbounded_sequences = get_message_num(&unbounded_sequences);
   const size_t size = 3u;
   for (size_t i = 0; i < size; ++i) {
-     verify_message(message.array_of_arrays[i], i % num_arrays);
-     verify_message(message.array_of_bounded_sequences[i], i % num_bounded_sequences);
-     verify_message(message.array_of_unbounded_sequences[i], i % num_unbounded_sequences);
-     verify_message(message.bounded_sequence_of_arrays.data[i], i % num_arrays);
-     verify_message(
-       message.bounded_sequence_of_bounded_sequences.data[i], i % num_bounded_sequences);
-     verify_message(
-       message.bounded_sequence_of_unbounded_sequences.data[i], i % num_unbounded_sequences);
-     verify_message(message.unbounded_sequence_of_arrays.data[i], i % num_arrays);
-     verify_message(
-       message.unbounded_sequence_of_bounded_sequences.data[i], i % num_bounded_sequences);
-     verify_message(
-       message.unbounded_sequence_of_unbounded_sequences.data[i], i % num_unbounded_sequences);
+    verify_message(message.array_of_arrays[i], i % num_arrays);
+    verify_message(message.array_of_bounded_sequences[i], i % num_bounded_sequences);
+    verify_message(message.array_of_unbounded_sequences[i], i % num_unbounded_sequences);
+    verify_message(message.bounded_sequence_of_arrays.data[i], i % num_arrays);
+    verify_message(
+      message.bounded_sequence_of_bounded_sequences.data[i], i % num_bounded_sequences);
+    verify_message(
+      message.bounded_sequence_of_unbounded_sequences.data[i], i % num_unbounded_sequences);
+    verify_message(message.unbounded_sequence_of_arrays.data[i], i % num_arrays);
+    verify_message(
+      message.unbounded_sequence_of_bounded_sequences.data[i], i % num_bounded_sequences);
+    verify_message(
+      message.unbounded_sequence_of_unbounded_sequences.data[i], i % num_unbounded_sequences);
   }
 }
 

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -31,10 +31,10 @@
 #include "test_msgs/msg/arrays.h"
 #include "test_msgs/msg/basic_types.h"
 #include "test_msgs/msg/bounded_sequences.h"
+#include "test_msgs/msg/unbounded_sequences.h"
 
 #include "test_msgs/msg/bounded_array_nested.h"
 #include "test_msgs/msg/dynamic_array_nested.h"
-#include "test_msgs/msg/dynamic_array_primitives.h"
 #include "test_msgs/msg/dynamic_array_primitives_nested.h"
 #include "test_msgs/msg/empty.h"
 #include "test_msgs/msg/nested.h"
@@ -589,22 +589,22 @@ TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_staticarrayneste
 }
 
 template<>
-size_t get_message_num(test_msgs__msg__DynamicArrayPrimitives * msg)
+size_t get_message_num(test_msgs__msg__UnboundedSequences * msg)
 {
   (void)msg;
   return 5;
 }
 
 template<>
-void init_message(test_msgs__msg__DynamicArrayPrimitives * msg)
+void init_message(test_msgs__msg__UnboundedSequences * msg)
 {
-  test_msgs__msg__DynamicArrayPrimitives__init(msg);
+  test_msgs__msg__UnboundedSequences__init(msg);
 }
 
 template<>
-void get_message(test_msgs__msg__DynamicArrayPrimitives * msg, size_t msg_num)
+void get_message(test_msgs__msg__UnboundedSequences * msg, size_t msg_num)
 {
-  test_msgs__msg__DynamicArrayPrimitives__init(msg);
+  test_msgs__msg__UnboundedSequences__init(msg);
   const size_t size = 2000;
   switch (msg_num) {
     case 0:
@@ -769,9 +769,9 @@ void get_message(test_msgs__msg__DynamicArrayPrimitives * msg, size_t msg_num)
 }
 
 template<>
-void verify_message(test_msgs__msg__DynamicArrayPrimitives & message, size_t msg_num)
+void verify_message(test_msgs__msg__UnboundedSequences & message, size_t msg_num)
 {
-  test_msgs__msg__DynamicArrayPrimitives expected_msg;
+  test_msgs__msg__UnboundedSequences expected_msg;
   get_message(&expected_msg, msg_num);
   for (size_t i = 0; i < expected_msg.bool_values.size; ++i) {
     EXPECT_EQ(expected_msg.bool_values.data[i],
@@ -831,12 +831,12 @@ void verify_message(test_msgs__msg__DynamicArrayPrimitives & message, size_t msg
   }
 }
 
-DEFINE_FINI_MESSAGE(test_msgs__msg__DynamicArrayPrimitives)
-TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_dynamicarrayprimitives) {
+DEFINE_FINI_MESSAGE(test_msgs__msg__UnboundedSequences)
+TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_unbounded_sequences) {
   const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
-    test_msgs, msg, DynamicArrayPrimitives);
-  test_message_type<test_msgs__msg__DynamicArrayPrimitives>(
-    "test_dynamicarrayprimitives", ts, this->context_ptr);
+    test_msgs, msg, UnboundedSequences);
+  test_message_type<test_msgs__msg__UnboundedSequences>(
+    "test_unbounded_sequences", ts, this->context_ptr);
 }
 
 template<>

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -32,14 +32,9 @@
 #include "test_msgs/msg/basic_types.h"
 #include "test_msgs/msg/bounded_sequences.h"
 #include "test_msgs/msg/unbounded_sequences.h"
-
-#include "test_msgs/msg/bounded_array_nested.h"
-#include "test_msgs/msg/dynamic_array_nested.h"
-#include "test_msgs/msg/dynamic_array_primitives_nested.h"
+#include "test_msgs/msg/multi_nested.h"
 #include "test_msgs/msg/empty.h"
 #include "test_msgs/msg/nested.h"
-#include "test_msgs/msg/primitives.h"
-#include "test_msgs/msg/static_array_nested.h"
 #include "test_msgs/msg/builtins.h"
 
 #include "rosidl_generator_c/string_functions.h"
@@ -539,53 +534,11 @@ void verify_message(test_msgs__msg__Arrays & message, size_t msg_num)
 }
 
 DEFINE_FINI_MESSAGE(test_msgs__msg__Arrays)
-TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_staticarrayprimitives) {
+TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_arrays) {
   const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
     test_msgs, msg, Arrays);
   test_message_type<test_msgs__msg__Arrays>(
-    "test_staticarrayprimitives", ts, this->context_ptr);
-}
-
-template<>
-size_t get_message_num(test_msgs__msg__StaticArrayNested * msg)
-{
-  (void)msg;
-  return 1;
-}
-
-template<>
-void init_message(test_msgs__msg__StaticArrayNested * msg)
-{
-  test_msgs__msg__StaticArrayNested__init(msg);
-}
-
-template<>
-void get_message(test_msgs__msg__StaticArrayNested * msg, size_t msg_num)
-{
-  test_msgs__msg__StaticArrayNested__init(msg);
-  test_msgs__msg__Primitives submsg;
-  if (msg_num == 0) {
-    for (size_t i = 0; i < get_message_num(&submsg); ++i) {
-      get_message(&msg->primitive_values[i], i);
-    }
-  }
-}
-
-template<>
-void verify_message(test_msgs__msg__StaticArrayNested & message, size_t msg_num)
-{
-  (void)msg_num;
-  for (size_t i = 0; i < 4; ++i) {
-    verify_message(message.primitive_values[i], i);
-  }
-}
-
-DEFINE_FINI_MESSAGE(test_msgs__msg__StaticArrayNested)
-TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_staticarraynested) {
-  const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
-    test_msgs, msg, StaticArrayNested);
-  test_message_type<test_msgs__msg__StaticArrayNested>(
-    "test_staticarraynested", ts, this->context_ptr);
+    "test_arrays", ts, this->context_ptr);
 }
 
 template<>
@@ -840,82 +793,6 @@ TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_unbounded_sequen
 }
 
 template<>
-size_t get_message_num(test_msgs__msg__DynamicArrayNested * msg)
-{
-  (void)msg;
-  return 1;
-}
-
-template<>
-void init_message(test_msgs__msg__DynamicArrayNested * msg)
-{
-  test_msgs__msg__DynamicArrayNested__init(msg);
-}
-
-template<>
-void get_message(test_msgs__msg__DynamicArrayNested * msg, size_t msg_num)
-{
-  test_msgs__msg__Primitives submsg;
-  const size_t size = get_message_num(&submsg);
-  test_msgs__msg__DynamicArrayNested__init(msg);
-  test_msgs__msg__Primitives__Sequence__init(&msg->primitive_values, size);
-  switch (msg_num) {
-    case 0:
-      for (size_t i = 0; i < size; ++i) {
-        get_message(&msg->primitive_values.data[i], i);
-      }
-      break;
-  }
-}
-
-template<>
-void verify_message(test_msgs__msg__DynamicArrayNested & message, size_t msg_num)
-{
-  test_msgs__msg__DynamicArrayNested expected_msg;
-  get_message(&expected_msg, msg_num);
-
-  for (size_t i = 0; i < expected_msg.primitive_values.size; ++i) {
-    EXPECT_EQ(expected_msg.primitive_values.data[i].bool_value,
-      message.primitive_values.data[i].bool_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].byte_value,
-      message.primitive_values.data[i].byte_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].char_value,
-      message.primitive_values.data[i].char_value);
-    EXPECT_FLOAT_EQ(expected_msg.primitive_values.data[i].float32_value,
-      message.primitive_values.data[i].float32_value);
-    EXPECT_DOUBLE_EQ(expected_msg.primitive_values.data[i].float64_value,
-      message.primitive_values.data[i].float64_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].int8_value,
-      message.primitive_values.data[i].int8_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].uint8_value,
-      message.primitive_values.data[i].uint8_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].int16_value,
-      message.primitive_values.data[i].int16_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].uint16_value,
-      message.primitive_values.data[i].uint16_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].int32_value,
-      message.primitive_values.data[i].int32_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].uint32_value,
-      message.primitive_values.data[i].uint32_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].int64_value,
-      message.primitive_values.data[i].int64_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].uint64_value,
-      message.primitive_values.data[i].uint64_value);
-    EXPECT_EQ(0, strcmp(message.primitive_values.data[i].string_value.data,
-      expected_msg.primitive_values.data[i].string_value.data));
-  }
-}
-
-DEFINE_FINI_MESSAGE(test_msgs__msg__DynamicArrayNested)
-TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_dynamicarraynested) {
-  const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
-    test_msgs, msg, DynamicArrayNested);
-  test_message_type<test_msgs__msg__DynamicArrayNested>(
-    "test_dynamicarraynested", ts, this->context_ptr);
-}
-
-
-template<>
 size_t get_message_num(test_msgs__msg__BoundedSequences * msg)
 {
   (void)msg;
@@ -1085,126 +962,84 @@ TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_bounded_sequence
 }
 
 template<>
-size_t get_message_num(test_msgs__msg__BoundedArrayNested * msg)
+size_t get_message_num(test_msgs__msg__MultiNested * msg)
 {
   (void)msg;
   return 1;
 }
 
-
 template<>
-void init_message(test_msgs__msg__BoundedArrayNested * msg)
+void init_message(test_msgs__msg__MultiNested * msg)
 {
-  test_msgs__msg__BoundedArrayNested__init(msg);
+  test_msgs__msg__MultiNested__init(msg);
 }
 
 template<>
-void get_message(test_msgs__msg__BoundedArrayNested * msg, size_t msg_num)
+void get_message(test_msgs__msg__MultiNested * msg, size_t msg_num)
 {
-  test_msgs__msg__Primitives submsg;
-  const size_t size = get_message_num(&submsg);
-  test_msgs__msg__BoundedArrayNested__init(msg);
-  test_msgs__msg__Primitives__Sequence__init(&msg->primitive_values, size);
-  switch (msg_num) {
-    case 0:
-      for (size_t i = 0; i < size; ++i) {
-        get_message(&msg->primitive_values.data[i], i);
-      }
-      break;
+  size_t i;
+  test_msgs__msg__MultiNested__init(msg);
+  test_msgs__msg__Array arrays;
+  test_msgs__msg__BoundedSequences bounded_sequences;
+  test_msgs__msg__UnboundedSequences unbounded_sequences;
+  size_t num_arrays = get_message_num(&arrays);
+  size_t num_bounded_sequences = get_message_num(&bounded_sequences);
+  size_t num_unbounded_sequences = get_message_num(&unbounded_sequences);
+  if (msg_num == 0u) {
+    // Size of all arrays and sequences in the message
+    const size_t size = 3u;
+    test_msgs__msg__Arrays__Sequence__init(&msg->bounded_sequence_of_arrays, size);
+    test_msgs__msg__BoundedSequences__Sequence__init(
+      &msg->bounded_sequence_of_bounded_sequences, size);
+    test_msgs__msg__UnboundedSequences__Sequence__init(
+      &msg->bounded_sequence_of_unbounded_sequences, size);
+    test_msgs__msg__Arrays__Sequence__init(&msg->unbounded_sequence_of_arrays, size);
+    test_msgs__msg__BoundedSequences__Sequence__init(
+      &msg->unbounded_sequence_of_bounded_sequences, size);
+    test_msgs__msg__UnboundedSequences__Sequence__init(
+      &msg->unbounded_sequence_of_unbounded_sequences, size);
+    for (i = 0u; i < size; ++i) {
+      get_message(&msg->array_of_arrays[i], i % num_arrays);
+      get_message(&msg->array_of_bounded_sequences[i], i % num_bounded_sequences);
+      get_message(&msg->array_of_unbounded_sequences[i], i % num_unbounded_sequences);
+      get_message(&msg->bounded_sequence_of_arrays[i], i % num_arrays);
+      get_message(&msg->bounded_sequence_of_bounded_sequences[i], i % num_bounded_sequences);
+      get_message(&msg->bounded_sequence_of_unbounded_sequences[i], i % num_unbounded_sequences);
+      get_message(&msg->unbounded_sequence_of_arrays[i], i % num_arrays);
+      get_message(&msg->unbounded_sequence_of_bounded_sequences[i], i % num_bounded_sequences);
+      get_message(&msg->unbounded_sequence_of_unbounded_sequences[i], i % num_unbounded_sequences);
+    }
   }
 }
 
 template<>
-void verify_message(test_msgs__msg__BoundedArrayNested & message, size_t msg_num)
+void verify_message(test_msgs__msg__MultiNested & message, size_t msg_num)
 {
-  test_msgs__msg__BoundedArrayNested expected_msg;
-  get_message(&expected_msg, msg_num);
-
-  for (size_t i = 0; i < expected_msg.primitive_values.size; ++i) {
-    EXPECT_EQ(expected_msg.primitive_values.data[i].bool_value,
-      message.primitive_values.data[i].bool_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].byte_value,
-      message.primitive_values.data[i].byte_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].char_value,
-      message.primitive_values.data[i].char_value);
-    EXPECT_FLOAT_EQ(expected_msg.primitive_values.data[i].float32_value,
-      message.primitive_values.data[i].float32_value);
-    EXPECT_DOUBLE_EQ(expected_msg.primitive_values.data[i].float64_value,
-      message.primitive_values.data[i].float64_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].int8_value,
-      message.primitive_values.data[i].int8_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].uint8_value,
-      message.primitive_values.data[i].uint8_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].int16_value,
-      message.primitive_values.data[i].int16_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].uint16_value,
-      message.primitive_values.data[i].uint16_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].int32_value,
-      message.primitive_values.data[i].int32_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].uint32_value,
-      message.primitive_values.data[i].uint32_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].int64_value,
-      message.primitive_values.data[i].int64_value);
-    EXPECT_EQ(expected_msg.primitive_values.data[i].uint64_value,
-      message.primitive_values.data[i].uint64_value);
-    EXPECT_EQ(0, strcmp(message.primitive_values.data[i].string_value.data,
-      expected_msg.primitive_values.data[i].string_value.data));
+  (void)msg_num;
+  test_msgs__msg__Array arrays;
+  test_msgs__msg__BoundedSequences bounded_sequences;
+  test_msgs__msg__UnboundedSequences unbounded_sequences;
+  size_t num_arrays = get_message_num(&arrays);
+  size_t num_bounded_sequences = get_message_num(&bounded_sequences);
+  size_t num_unbounded_sequences = get_message_num(&unbounded_sequences);
+  const size_t size = 3u;
+  for (size_t i = 0; i < size; ++i) {
+     verify_message(message.array_of_arrays[i], i % num_arrays);
+     verify_message(message.array_of_bounded_sequences[i], i % num_bounded_sequences);
+     verify_message(message.array_of_unbounded_sequences[i], i % num_unbounded_sequences);
+     verify_message(message.bounded_sequence_of_arrays[i], i % num_arrays);
+     verify_message(message.bounded_sequence_of_bounded_sequences[i], i % num_bounded_sequences);
+     verify_message(message.bounded_sequence_of_unbounded_sequences[i], i % num_unbounded_sequences);
+     verify_message(message.unbounded_sequence_of_arrays[i], i % num_arrays);
+     verify_message(message.unbounded_sequence_of_bounded_sequences[i], i % num_bounded_sequences);
+     verify_message(message.unbounded_sequence_of_unbounded_sequences[i], i % num_unbounded_sequences);
   }
 }
 
-DEFINE_FINI_MESSAGE(test_msgs__msg__BoundedArrayNested)
-TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_boundedarraynested) {
+DEFINE_FINI_MESSAGE(test_msgs__msg__MultiNested)
+TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_multi_nested) {
   const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
-    test_msgs, msg, BoundedArrayNested);
-  test_message_type<test_msgs__msg__BoundedArrayNested>(
-    "test_boundedarraynested", ts, this->context_ptr);
-}
-
-template<>
-size_t get_message_num(test_msgs__msg__DynamicArrayPrimitivesNested * msg)
-{
-  (void)msg;
-  return 1;
-}
-
-
-template<>
-void init_message(test_msgs__msg__DynamicArrayPrimitivesNested * msg)
-{
-  test_msgs__msg__DynamicArrayPrimitivesNested__init(msg);
-}
-
-template<>
-void get_message(test_msgs__msg__DynamicArrayPrimitivesNested * msg, size_t msg_num)
-{
-  test_msgs__msg__DynamicArrayPrimitives submsg;
-  const size_t size = get_message_num(&submsg);
-  test_msgs__msg__DynamicArrayPrimitivesNested__init(msg);
-  test_msgs__msg__DynamicArrayPrimitives__Sequence__init(
-    &msg->dynamic_array_primitive_values, size);
-  switch (msg_num) {
-    case 0:
-      for (size_t i = 0; i < size; ++i) {
-        get_message(&msg->dynamic_array_primitive_values.data[i], i);
-      }
-      break;
-  }
-}
-
-template<>
-void verify_message(test_msgs__msg__DynamicArrayPrimitivesNested & message, size_t msg_num)
-{
-  test_msgs__msg__DynamicArrayPrimitivesNested expected_msg;
-  get_message(&expected_msg, msg_num);
-  for (size_t i = 0; i < expected_msg.dynamic_array_primitive_values.size; ++i) {
-    verify_message(message.dynamic_array_primitive_values.data[i], i);
-  }
-}
-
-DEFINE_FINI_MESSAGE(test_msgs__msg__DynamicArrayPrimitivesNested)
-TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_dynamicarraynestedprimitives) {
-  const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
-    test_msgs, msg, DynamicArrayPrimitivesNested);
-  test_message_type<test_msgs__msg__DynamicArrayPrimitivesNested>(
-    "test_dynamicarraynestedprimitives", ts, this->context_ptr);
+    test_msgs, msg, MultiNested);
+  test_message_type<test_msgs__msg__MultiNested>(
+    "test_multi_nested", ts, this->context_ptr);
 }

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -30,9 +30,9 @@
 
 #include "test_msgs/msg/arrays.h"
 #include "test_msgs/msg/basic_types.h"
+#include "test_msgs/msg/bounded_sequences.h"
 
 #include "test_msgs/msg/bounded_array_nested.h"
-#include "test_msgs/msg/bounded_array_primitives.h"
 #include "test_msgs/msg/dynamic_array_nested.h"
 #include "test_msgs/msg/dynamic_array_primitives.h"
 #include "test_msgs/msg/dynamic_array_primitives_nested.h"
@@ -916,22 +916,22 @@ TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_dynamicarraynest
 
 
 template<>
-size_t get_message_num(test_msgs__msg__BoundedArrayPrimitives * msg)
+size_t get_message_num(test_msgs__msg__BoundedSequences * msg)
 {
   (void)msg;
   return 5;
 }
 
 template<>
-void init_message(test_msgs__msg__BoundedArrayPrimitives * msg)
+void init_message(test_msgs__msg__BoundedSequences * msg)
 {
-  test_msgs__msg__BoundedArrayPrimitives__init(msg);
+  test_msgs__msg__BoundedSequences__init(msg);
 }
 
 template<>
-void get_message(test_msgs__msg__BoundedArrayPrimitives * msg, size_t msg_num)
+void get_message(test_msgs__msg__BoundedSequences * msg, size_t msg_num)
 {
-  test_msgs__msg__BoundedArrayPrimitives__init(msg);
+  test_msgs__msg__BoundedSequences__init(msg);
   switch (msg_num) {
     case 0:
       rosidl_generator_c__bool__Sequence__init(&msg->bool_values, 3);
@@ -1014,9 +1014,9 @@ void get_message(test_msgs__msg__BoundedArrayPrimitives * msg, size_t msg_num)
 }
 
 template<>
-void verify_message(test_msgs__msg__BoundedArrayPrimitives & message, size_t msg_num)
+void verify_message(test_msgs__msg__BoundedSequences & message, size_t msg_num)
 {
-  test_msgs__msg__BoundedArrayPrimitives expected_msg;
+  test_msgs__msg__BoundedSequences expected_msg;
   get_message(&expected_msg, msg_num);
   for (size_t i = 0; i < expected_msg.bool_values.size; ++i) {
     EXPECT_EQ(expected_msg.bool_values.data[i],
@@ -1076,12 +1076,12 @@ void verify_message(test_msgs__msg__BoundedArrayPrimitives & message, size_t msg
   }
 }
 
-DEFINE_FINI_MESSAGE(test_msgs__msg__BoundedArrayPrimitives)
-TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_boundedarrayprimitives) {
+DEFINE_FINI_MESSAGE(test_msgs__msg__BoundedSequences)
+TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_bounded_sequences) {
   const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
-    test_msgs, msg, BoundedArrayPrimitives);
-  test_message_type<test_msgs__msg__BoundedArrayPrimitives>(
-    "test_boundedarrayprimitives", ts, this->context_ptr);
+    test_msgs, msg, BoundedSequences);
+  test_message_type<test_msgs__msg__BoundedSequences>(
+    "test_bounded_sequences", ts, this->context_ptr);
 }
 
 template<>

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -89,6 +89,12 @@ int main(int argc, char ** argv)
     publish<test_msgs::msg::Nested>(node, message, get_messages_nested());
   } else if (message == "Builtins") {
     publish<test_msgs::msg::Builtins>(node, message, get_messages_builtins());
+  } else if (message == "Constants") {
+    publish<test_msgs::msg::Constants>(node, message, get_messages_constants());
+  } else if (message == "Defaults") {
+    publish<test_msgs::msg::Defaults>(node, message, get_messages_defaults());
+  } else if (message == "Strings") {
+    publish<test_msgs::msg::Strings>(node, message, get_messages_strings());
   } else {
     fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());
     rclcpp::shutdown();

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -89,9 +89,9 @@ int main(int argc, char ** argv)
   } else if (message == "DynamicArrayStaticArrayPrimitivesNested") {
     publish<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
       node, message, get_messages_dynamic_array_static_array_primitives_nested());
-  } else if (message == "BoundedArrayPrimitives") {
-    publish<test_msgs::msg::BoundedArrayPrimitives>(
-      node, message, get_messages_bounded_array_primitives());
+  } else if (message == "BoundedSequences") {
+    publish<test_msgs::msg::BoundedSequences>(
+      node, message, get_messages_bounded_sequences());
   } else if (message == "BoundedArrayPrimitivesNested") {
     publish<test_msgs::msg::BoundedArrayPrimitivesNested>(
       node, message, get_messages_bounded_array_primitives_nested());

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -72,8 +72,8 @@ int main(int argc, char ** argv)
 
   if (message == "Empty") {
     publish<test_msgs::msg::Empty>(node, message, get_messages_empty());
-  } else if (message == "Primitives") {
-    publish<test_msgs::msg::Primitives>(node, message, get_messages_primitives());
+  } else if (message == "BasicTypes") {
+    publish<test_msgs::msg::BasicTypes>(node, message, get_messages_basic_types());
   } else if (message == "StaticArrayPrimitives") {
     publish<test_msgs::msg::StaticArrayPrimitives>(
       node, message, get_messages_static_array_primitives());

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -74,9 +74,9 @@ int main(int argc, char ** argv)
     publish<test_msgs::msg::Empty>(node, message, get_messages_empty());
   } else if (message == "BasicTypes") {
     publish<test_msgs::msg::BasicTypes>(node, message, get_messages_basic_types());
-  } else if (message == "StaticArrayPrimitives") {
-    publish<test_msgs::msg::StaticArrayPrimitives>(
-      node, message, get_messages_static_array_primitives());
+  } else if (message == "Arrays") {
+    publish<test_msgs::msg::Arrays>(
+      node, message, get_messages_arrays());
   } else if (message == "StaticArrayPrimitivesNested") {
     publish<test_msgs::msg::StaticArrayPrimitivesNested>(
       node, message, get_messages_static_array_primitives_nested());

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -83,29 +83,13 @@ int main(int argc, char ** argv)
   } else if (message == "UnboundedSequences") {
     publish<test_msgs::msg::UnboundedSequences>(
       node, message, get_messages_unbounded_sequences());
-  } else if (message == "DynamicArrayPrimitivesNested") {
-    publish<test_msgs::msg::DynamicArrayPrimitivesNested>(
-      node, message, get_messages_dynamic_array_primitives_nested());
-  } else if (message == "DynamicArrayStaticArrayPrimitivesNested") {
-    publish<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
-      node, message, get_messages_dynamic_array_static_array_primitives_nested());
   } else if (message == "BoundedSequences") {
     publish<test_msgs::msg::BoundedSequences>(
       node, message, get_messages_bounded_sequences());
-  } else if (message == "BoundedArrayPrimitivesNested") {
-    publish<test_msgs::msg::BoundedArrayPrimitivesNested>(
-      node, message, get_messages_bounded_array_primitives_nested());
+  } else if (message == "MultiNested") {
+    publish<test_msgs::msg::MultiNested>(node, message, get_messages_multi_nested());
   } else if (message == "Nested") {
     publish<test_msgs::msg::Nested>(node, message, get_messages_nested());
-  } else if (message == "DynamicArrayNested") {
-    publish<test_msgs::msg::DynamicArrayNested>(
-      node, message, get_messages_dynamic_array_nested());
-  } else if (message == "BoundedArrayNested") {
-    publish<test_msgs::msg::BoundedArrayNested>(
-      node, message, get_messages_bounded_array_nested());
-  } else if (message == "StaticArrayNested") {
-    publish<test_msgs::msg::StaticArrayNested>(
-      node, message, get_messages_static_array_nested());
   } else if (message == "Builtins") {
     publish<test_msgs::msg::Builtins>(node, message, get_messages_builtins());
   } else {

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -77,9 +77,6 @@ int main(int argc, char ** argv)
   } else if (message == "Arrays") {
     publish<test_msgs::msg::Arrays>(
       node, message, get_messages_arrays());
-  } else if (message == "StaticArrayPrimitivesNested") {
-    publish<test_msgs::msg::StaticArrayPrimitivesNested>(
-      node, message, get_messages_static_array_primitives_nested());
   } else if (message == "UnboundedSequences") {
     publish<test_msgs::msg::UnboundedSequences>(
       node, message, get_messages_unbounded_sequences());

--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -80,9 +80,9 @@ int main(int argc, char ** argv)
   } else if (message == "StaticArrayPrimitivesNested") {
     publish<test_msgs::msg::StaticArrayPrimitivesNested>(
       node, message, get_messages_static_array_primitives_nested());
-  } else if (message == "DynamicArrayPrimitives") {
-    publish<test_msgs::msg::DynamicArrayPrimitives>(
-      node, message, get_messages_dynamic_array_primitives());
+  } else if (message == "UnboundedSequences") {
+    publish<test_msgs::msg::UnboundedSequences>(
+      node, message, get_messages_unbounded_sequences());
   } else if (message == "DynamicArrayPrimitivesNested") {
     publish<test_msgs::msg::DynamicArrayPrimitivesNested>(
       node, message, get_messages_dynamic_array_primitives_nested());

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -119,7 +119,7 @@ int main(int argc, char ** argv)
 
   auto messages_empty = get_messages_empty();
   auto messages_basic_types = get_messages_basic_types();
-  auto messages_static_array_primitives = get_messages_static_array_primitives();
+  auto messages_arrays = get_messages_arrays();
   auto messages_static_array_primitives_nested = get_messages_static_array_primitives_nested();
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
   auto messages_dynamic_array_primitives_nested = get_messages_dynamic_array_primitives_nested();
@@ -145,11 +145,11 @@ int main(int argc, char ** argv)
     subscriber = subscribe<test_msgs::msg::BasicTypes>(
       node, message, messages_basic_types, received_messages);
     publish<test_msgs::msg::BasicTypes>(node, message, messages_basic_types);
-  } else if (message == "StaticArrayPrimitives") {
-    subscriber = subscribe<test_msgs::msg::StaticArrayPrimitives>(
-      node, message, messages_static_array_primitives, received_messages);
-    publish<test_msgs::msg::StaticArrayPrimitives>(node, message,
-      messages_static_array_primitives);
+  } else if (message == "Arrays") {
+    subscriber = subscribe<test_msgs::msg::Arrays>(
+      node, message, messages_arrays, received_messages);
+    publish<test_msgs::msg::Arrays>(node, message,
+      messages_arrays);
   } else if (message == "StaticArrayPrimitivesNested") {
     subscriber = subscribe<test_msgs::msg::StaticArrayPrimitivesNested>(
       node, message, messages_static_array_primitives_nested, received_messages);

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -118,7 +118,7 @@ int main(int argc, char ** argv)
   std::vector<bool> received_messages;  // collect flags about received messages
 
   auto messages_empty = get_messages_empty();
-  auto messages_primitives = get_messages_primitives();
+  auto messages_basic_types = get_messages_basic_types();
   auto messages_static_array_primitives = get_messages_static_array_primitives();
   auto messages_static_array_primitives_nested = get_messages_static_array_primitives_nested();
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
@@ -141,10 +141,10 @@ int main(int argc, char ** argv)
     subscriber = subscribe<test_msgs::msg::Empty>(
       node, message, messages_empty, received_messages);
     publish<test_msgs::msg::Empty>(node, message, messages_empty);
-  } else if (message == "Primitives") {
-    subscriber = subscribe<test_msgs::msg::Primitives>(
-      node, message, messages_primitives, received_messages);
-    publish<test_msgs::msg::Primitives>(node, message, messages_primitives);
+  } else if (message == "BasicTypes") {
+    subscriber = subscribe<test_msgs::msg::BasicTypes>(
+      node, message, messages_basic_types, received_messages);
+    publish<test_msgs::msg::BasicTypes>(node, message, messages_basic_types);
   } else if (message == "StaticArrayPrimitives") {
     subscriber = subscribe<test_msgs::msg::StaticArrayPrimitives>(
       node, message, messages_static_array_primitives, received_messages);

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -120,17 +120,10 @@ int main(int argc, char ** argv)
   auto messages_empty = get_messages_empty();
   auto messages_basic_types = get_messages_basic_types();
   auto messages_arrays = get_messages_arrays();
-  auto messages_static_array_primitives_nested = get_messages_static_array_primitives_nested();
-  auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
-  auto messages_dynamic_array_primitives_nested = get_messages_dynamic_array_primitives_nested();
-  auto messages_dynamic_array_static_array_primitives_nested =
-    get_messages_dynamic_array_static_array_primitives_nested();
-  auto messages_bounded_array_primitives = get_messages_bounded_array_primitives();
-  auto messages_bounded_array_primitives_nested = get_messages_bounded_array_primitives_nested();
+  auto message_bounded_sequences = get_messages_bounded_sequences();
+  auto message_unbounded_sequences = get_messages_unbounded_sequences();
+  auto messages_multi_nested = get_messages_multi_nested();
   auto messages_nested = get_messages_nested();
-  auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
-  auto messages_bounded_array_nested = get_messages_bounded_array_nested();
-  auto messages_static_array_nested = get_messages_static_array_nested();
   auto messages_builtins = get_messages_builtins();
 
   std::thread spin_thread([node]() {
@@ -150,55 +143,24 @@ int main(int argc, char ** argv)
       node, message, messages_arrays, received_messages);
     publish<test_msgs::msg::Arrays>(node, message,
       messages_arrays);
-  } else if (message == "StaticArrayPrimitivesNested") {
-    subscriber = subscribe<test_msgs::msg::StaticArrayPrimitivesNested>(
-      node, message, messages_static_array_primitives_nested, received_messages);
-    publish<test_msgs::msg::StaticArrayPrimitivesNested>(node, message,
-      messages_static_array_primitives_nested);
   } else if (message == "UnboundedSequences") {
     subscriber = subscribe<test_msgs::msg::UnboundedSequences>(
       node, message, messages_unbounded_sequences, received_messages);
     publish<test_msgs::msg::UnboundedSequences>(node, message,
       messages_unbounded_sequences);
-  } else if (message == "DynamicArrayPrimitivesNested") {
-    subscriber = subscribe<test_msgs::msg::DynamicArrayPrimitivesNested>(
-      node, message, messages_dynamic_array_primitives_nested, received_messages);
-    publish<test_msgs::msg::DynamicArrayPrimitivesNested>(node, message,
-      messages_dynamic_array_primitives_nested);
-  } else if (message == "DynamicArrayStaticArrayPrimitivesNested") {
-    subscriber = subscribe<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
-      node, message, messages_dynamic_array_static_array_primitives_nested, received_messages);
-    publish<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
-      node, message, get_messages_dynamic_array_static_array_primitives_nested());
   } else if (message == "BoundedSequences") {
     subscriber = subscribe<test_msgs::msg::BoundedSequences>(
       node, message, messages_bounded_sequences, received_messages);
     publish<test_msgs::msg::BoundedSequences>(node, message,
       messages_bounded_sequences);
-  } else if (message == "BoundedArrayPrimitivesNested") {
-    subscriber = subscribe<test_msgs::msg::BoundedArrayPrimitivesNested>(
-      node, message, messages_bounded_array_primitives_nested, received_messages);
-    publish<test_msgs::msg::BoundedArrayPrimitivesNested>(node, message,
-      messages_bounded_array_primitives_nested);
+  } else if (message == "MultiNested") {
+    subscriber = subscribe<test_msgs::msg::MultiNested>(
+      node, message, messages_multi_nested, received_messages);
+    publish<test_msgs::msg::MultiNested>(node, message, messages_multi_nested);
   } else if (message == "Nested") {
     subscriber = subscribe<test_msgs::msg::Nested>(
       node, message, messages_nested, received_messages);
     publish<test_msgs::msg::Nested>(node, message, messages_nested);
-  } else if (message == "DynamicArrayNested") {
-    subscriber = subscribe<test_msgs::msg::DynamicArrayNested>(
-      node, message, messages_dynamic_array_nested, received_messages);
-    publish<test_msgs::msg::DynamicArrayNested>(node, message,
-      messages_dynamic_array_nested);
-  } else if (message == "BoundedArrayNested") {
-    subscriber = subscribe<test_msgs::msg::BoundedArrayNested>(
-      node, message, messages_bounded_array_nested, received_messages);
-    publish<test_msgs::msg::BoundedArrayNested>(node, message,
-      messages_bounded_array_nested);
-  } else if (message == "StaticArrayNested") {
-    subscriber = subscribe<test_msgs::msg::StaticArrayNested>(
-      node, message, messages_static_array_nested, received_messages);
-    publish<test_msgs::msg::StaticArrayNested>(node, message,
-      messages_static_array_nested);
   } else if (message == "Builtins") {
     subscriber = subscribe<test_msgs::msg::Builtins>(
       node, message, messages_builtins, received_messages);

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -125,6 +125,9 @@ int main(int argc, char ** argv)
   auto messages_multi_nested = get_messages_multi_nested();
   auto messages_nested = get_messages_nested();
   auto messages_builtins = get_messages_builtins();
+  auto messages_constants = get_messages_constants();
+  auto messages_defaults = get_messages_defaults();
+  auto messages_strings = get_messages_strings();
 
   std::thread spin_thread([node]() {
       rclcpp::spin(node);
@@ -165,6 +168,18 @@ int main(int argc, char ** argv)
     subscriber = subscribe<test_msgs::msg::Builtins>(
       node, message, messages_builtins, received_messages);
     publish<test_msgs::msg::Builtins>(node, message, messages_builtins);
+  } else if (message == "Constants") {
+    subscriber = subscribe<test_msgs::msg::Constants>(
+      node, message, messages_constants, received_messages);
+    publish<test_msgs::msg::Constants>(node, message, messages_constants);
+  } else if (message == "Defaults") {
+    subscriber = subscribe<test_msgs::msg::Defaults>(
+      node, message, messages_defaults, received_messages);
+    publish<test_msgs::msg::Defaults>(node, message, messages_defaults);
+  } else if (message == "Strings") {
+    subscriber = subscribe<test_msgs::msg::Strings>(
+      node, message, messages_strings, received_messages);
+    publish<test_msgs::msg::Strings>(node, message, messages_strings);
   } else {
     fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());
     return 1;

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -120,8 +120,8 @@ int main(int argc, char ** argv)
   auto messages_empty = get_messages_empty();
   auto messages_basic_types = get_messages_basic_types();
   auto messages_arrays = get_messages_arrays();
-  auto message_bounded_sequences = get_messages_bounded_sequences();
-  auto message_unbounded_sequences = get_messages_unbounded_sequences();
+  auto messages_bounded_sequences = get_messages_bounded_sequences();
+  auto messages_unbounded_sequences = get_messages_unbounded_sequences();
   auto messages_multi_nested = get_messages_multi_nested();
   auto messages_nested = get_messages_nested();
   auto messages_builtins = get_messages_builtins();

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -155,11 +155,11 @@ int main(int argc, char ** argv)
       node, message, messages_static_array_primitives_nested, received_messages);
     publish<test_msgs::msg::StaticArrayPrimitivesNested>(node, message,
       messages_static_array_primitives_nested);
-  } else if (message == "DynamicArrayPrimitives") {
-    subscriber = subscribe<test_msgs::msg::DynamicArrayPrimitives>(
-      node, message, messages_dynamic_array_primitives, received_messages);
-    publish<test_msgs::msg::DynamicArrayPrimitives>(node, message,
-      messages_dynamic_array_primitives);
+  } else if (message == "UnboundedSequences") {
+    subscriber = subscribe<test_msgs::msg::UnboundedSequences>(
+      node, message, messages_unbounded_sequences, received_messages);
+    publish<test_msgs::msg::UnboundedSequences>(node, message,
+      messages_unbounded_sequences);
   } else if (message == "DynamicArrayPrimitivesNested") {
     subscriber = subscribe<test_msgs::msg::DynamicArrayPrimitivesNested>(
       node, message, messages_dynamic_array_primitives_nested, received_messages);

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -170,11 +170,11 @@ int main(int argc, char ** argv)
       node, message, messages_dynamic_array_static_array_primitives_nested, received_messages);
     publish<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
       node, message, get_messages_dynamic_array_static_array_primitives_nested());
-  } else if (message == "BoundedArrayPrimitives") {
-    subscriber = subscribe<test_msgs::msg::BoundedArrayPrimitives>(
-      node, message, messages_bounded_array_primitives, received_messages);
-    publish<test_msgs::msg::BoundedArrayPrimitives>(node, message,
-      messages_bounded_array_primitives);
+  } else if (message == "BoundedSequences") {
+    subscriber = subscribe<test_msgs::msg::BoundedSequences>(
+      node, message, messages_bounded_sequences, received_messages);
+    publish<test_msgs::msg::BoundedSequences>(node, message,
+      messages_bounded_sequences);
   } else if (message == "BoundedArrayPrimitivesNested") {
     subscriber = subscribe<test_msgs::msg::BoundedArrayPrimitivesNested>(
       node, message, messages_bounded_array_primitives_nested, received_messages);

--- a/test_communication/test/test_publisher_subscriber_serialized.cpp
+++ b/test_communication/test/test_publisher_subscriber_serialized.cpp
@@ -55,22 +55,22 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), serialized_callb
       printf("\n");
 
       auto message_cpp_typesupport =
-        rosidl_typesupport_cpp::get_message_type_support_handle<test_msgs::msg::Primitives>();
-      auto primitive_msg = std::make_shared<test_msgs::msg::Primitives>();
+        rosidl_typesupport_cpp::get_message_type_support_handle<test_msgs::msg::BasicTypes>();
+      auto basic_types_msg = std::make_shared<test_msgs::msg::BasicTypes>();
       auto ret =
-        rmw_deserialize(serialized_msg.get(), message_cpp_typesupport, primitive_msg.get());
+        rmw_deserialize(serialized_msg.get(), message_cpp_typesupport, basic_types_msg.get());
       ASSERT_EQ(RMW_RET_OK, ret);
-      EXPECT_EQ(counter, primitive_msg->uint8_value);
+      EXPECT_EQ(counter, basic_types_msg->uint8_value);
       counter++;
     };
 
   auto node = rclcpp::Node::make_shared("test_publisher_subscriber_serialized");
-  auto subscriber = node->create_subscription<test_msgs::msg::Primitives>(
+  auto subscriber = node->create_subscription<test_msgs::msg::BasicTypes>(
     "test_publisher_subscriber_serialized_topic", serialized_callback);
-  auto publisher = node->create_publisher<test_msgs::msg::Primitives>(
+  auto publisher = node->create_publisher<test_msgs::msg::BasicTypes>(
     "test_publisher_subscriber_serialized_topic");
 
-  auto msg = std::make_shared<test_msgs::msg::Primitives>();
+  auto msg = std::make_shared<test_msgs::msg::BasicTypes>();
 
   rclcpp::Rate loop_rate(10);
   for (auto i = 0u; i < 10; ++i) {

--- a/test_communication/test/test_replier.cpp
+++ b/test_communication/test/test_replier.cpp
@@ -76,15 +76,15 @@ int main(int argc, char ** argv)
     namespace_);
 
   auto services_empty = get_services_empty();
-  auto services_primitives = get_services_primitives();
+  auto services_basic_types = get_services_basic_types();
   rclcpp::ServiceBase::SharedPtr server;
 
   if (service == "Empty") {
     server = reply<test_msgs::srv::Empty>(
       node, service, services_empty);
-  } else if (service == "Primitives") {
-    server = reply<test_msgs::srv::Primitives>(
-      node, service, services_primitives);
+  } else if (service == "BasicTypes") {
+    server = reply<test_msgs::srv::BasicTypes>(
+      node, service, services_basic_types);
   } else {
     fprintf(stderr, "Unknown service argument '%s'\n", service.c_str());
     rclcpp::shutdown();

--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -116,9 +116,9 @@ int main(int argc, char ** argv)
   if (service == "Empty") {
     rc = request<test_msgs::srv::Empty>(
       node, service, get_services_empty());
-  } else if (service == "Primitives") {
-    rc = request<test_msgs::srv::Primitives>(
-      node, service, get_services_primitives());
+  } else if (service == "BasicTypes") {
+    rc = request<test_msgs::srv::BasicTypes>(
+      node, service, get_services_basic_types());
   } else {
     fprintf(stderr, "Unknown service argument '%s'\n", service.c_str());
     rclcpp::shutdown();

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -94,7 +94,7 @@ int main(int argc, char ** argv)
   auto messages_dynamic_array_primitives_nested = get_messages_dynamic_array_primitives_nested();
   auto messages_dynamic_array_static_array_primitives_nested =
     get_messages_dynamic_array_static_array_primitives_nested();
-  auto messages_bounded_array_primitives = get_messages_bounded_array_primitives();
+  auto messages_bounded_sequences = get_messages_bounded_sequences();
   auto messages_bounded_array_primitives_nested = get_messages_bounded_array_primitives_nested();
   auto messages_nested = get_messages_nested();
   auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
@@ -125,9 +125,9 @@ int main(int argc, char ** argv)
   } else if (message == "DynamicArrayStaticArrayPrimitivesNested") {
     subscriber = subscribe<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
       node, message, messages_dynamic_array_static_array_primitives_nested, received_messages);
-  } else if (message == "BoundedArrayPrimitives") {
-    subscriber = subscribe<test_msgs::msg::BoundedArrayPrimitives>(
-      node, message, messages_bounded_array_primitives, received_messages);
+  } else if (message == "BoundedSequences") {
+    subscriber = subscribe<test_msgs::msg::BoundedSequences>(
+      node, message, messages_bounded_sequences, received_messages);
   } else if (message == "BoundedArrayPrimitivesNested") {
     subscriber = subscribe<test_msgs::msg::BoundedArrayPrimitivesNested>(
       node, message, messages_bounded_array_primitives_nested, received_messages);

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -88,7 +88,7 @@ int main(int argc, char ** argv)
 
   auto messages_empty = get_messages_empty();
   auto messages_basic_types = get_messages_basic_types();
-  auto messages_static_array_primitives = get_messages_static_array_primitives();
+  auto messages_arrays = get_messages_arrays();
   auto messages_static_array_primitives_nested = get_messages_static_array_primitives_nested();
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
   auto messages_dynamic_array_primitives_nested = get_messages_dynamic_array_primitives_nested();
@@ -110,9 +110,9 @@ int main(int argc, char ** argv)
   } else if (message == "BasicTypes") {
     subscriber = subscribe<test_msgs::msg::BasicTypes>(
       node, message, messages_basic_types, received_messages);
-  } else if (message == "StaticArrayPrimitives") {
-    subscriber = subscribe<test_msgs::msg::StaticArrayPrimitives>(
-      node, message, messages_static_array_primitives, received_messages);
+  } else if (message == "Arrays") {
+    subscriber = subscribe<test_msgs::msg::Arrays>(
+      node, message, messages_arrays, received_messages);
   } else if (message == "StaticArrayPrimitivesNested") {
     subscriber = subscribe<test_msgs::msg::StaticArrayPrimitivesNested>(
       node, message, messages_static_array_primitives_nested, received_messages);

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -90,7 +90,7 @@ int main(int argc, char ** argv)
   auto messages_basic_types = get_messages_basic_types();
   auto messages_arrays = get_messages_arrays();
   auto messages_static_array_primitives_nested = get_messages_static_array_primitives_nested();
-  auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
+  auto messages_unbounded_sequences = get_messages_unbounded_sequences();
   auto messages_dynamic_array_primitives_nested = get_messages_dynamic_array_primitives_nested();
   auto messages_dynamic_array_static_array_primitives_nested =
     get_messages_dynamic_array_static_array_primitives_nested();
@@ -119,9 +119,9 @@ int main(int argc, char ** argv)
   } else if (message == "DynamicArrayPrimitivesNested") {
     subscriber = subscribe<test_msgs::msg::DynamicArrayPrimitivesNested>(
       node, message, messages_dynamic_array_primitives_nested, received_messages);
-  } else if (message == "DynamicArrayPrimitives") {
-    subscriber = subscribe<test_msgs::msg::DynamicArrayPrimitives>(
-      node, message, messages_dynamic_array_primitives, received_messages);
+  } else if (message == "UnboundedSequences") {
+    subscriber = subscribe<test_msgs::msg::UnboundedSequences>(
+      node, message, messages_unbounded_sequences, received_messages);
   } else if (message == "DynamicArrayStaticArrayPrimitivesNested") {
     subscriber = subscribe<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
       node, message, messages_dynamic_array_static_array_primitives_nested, received_messages);

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -89,17 +89,10 @@ int main(int argc, char ** argv)
   auto messages_empty = get_messages_empty();
   auto messages_basic_types = get_messages_basic_types();
   auto messages_arrays = get_messages_arrays();
-  auto messages_static_array_primitives_nested = get_messages_static_array_primitives_nested();
   auto messages_unbounded_sequences = get_messages_unbounded_sequences();
-  auto messages_dynamic_array_primitives_nested = get_messages_dynamic_array_primitives_nested();
-  auto messages_dynamic_array_static_array_primitives_nested =
-    get_messages_dynamic_array_static_array_primitives_nested();
   auto messages_bounded_sequences = get_messages_bounded_sequences();
-  auto messages_bounded_array_primitives_nested = get_messages_bounded_array_primitives_nested();
   auto messages_nested = get_messages_nested();
-  auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
-  auto messages_bounded_array_nested = get_messages_bounded_array_nested();
-  auto messages_static_array_nested = get_messages_static_array_nested();
+  auto messages_multi_nested = get_messages_multi_nested();
   auto messages_builtins = get_messages_builtins();
 
   rclcpp::SubscriptionBase::SharedPtr subscriber;
@@ -113,36 +106,18 @@ int main(int argc, char ** argv)
   } else if (message == "Arrays") {
     subscriber = subscribe<test_msgs::msg::Arrays>(
       node, message, messages_arrays, received_messages);
-  } else if (message == "StaticArrayPrimitivesNested") {
-    subscriber = subscribe<test_msgs::msg::StaticArrayPrimitivesNested>(
-      node, message, messages_static_array_primitives_nested, received_messages);
-  } else if (message == "DynamicArrayPrimitivesNested") {
-    subscriber = subscribe<test_msgs::msg::DynamicArrayPrimitivesNested>(
-      node, message, messages_dynamic_array_primitives_nested, received_messages);
   } else if (message == "UnboundedSequences") {
     subscriber = subscribe<test_msgs::msg::UnboundedSequences>(
       node, message, messages_unbounded_sequences, received_messages);
-  } else if (message == "DynamicArrayStaticArrayPrimitivesNested") {
-    subscriber = subscribe<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>(
-      node, message, messages_dynamic_array_static_array_primitives_nested, received_messages);
   } else if (message == "BoundedSequences") {
     subscriber = subscribe<test_msgs::msg::BoundedSequences>(
       node, message, messages_bounded_sequences, received_messages);
-  } else if (message == "BoundedArrayPrimitivesNested") {
-    subscriber = subscribe<test_msgs::msg::BoundedArrayPrimitivesNested>(
-      node, message, messages_bounded_array_primitives_nested, received_messages);
+  } else if (message == "MultiNested") {
+    subscriber = subscribe<test_msgs::msg::MultiNested>(
+      node, message, messages_multi_nested, received_messages);
   } else if (message == "Nested") {
     subscriber = subscribe<test_msgs::msg::Nested>(
       node, message, messages_nested, received_messages);
-  } else if (message == "DynamicArrayNested") {
-    subscriber = subscribe<test_msgs::msg::DynamicArrayNested>(
-      node, message, messages_dynamic_array_nested, received_messages);
-  } else if (message == "BoundedArrayNested") {
-    subscriber = subscribe<test_msgs::msg::BoundedArrayNested>(
-      node, message, messages_bounded_array_nested, received_messages);
-  } else if (message == "StaticArrayNested") {
-    subscriber = subscribe<test_msgs::msg::StaticArrayNested>(
-      node, message, messages_static_array_nested, received_messages);
   } else if (message == "Builtins") {
     subscriber = subscribe<test_msgs::msg::Builtins>(
       node, message, messages_builtins, received_messages);

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -94,6 +94,9 @@ int main(int argc, char ** argv)
   auto messages_nested = get_messages_nested();
   auto messages_multi_nested = get_messages_multi_nested();
   auto messages_builtins = get_messages_builtins();
+  auto messages_constants = get_messages_constants();
+  auto messages_defaults = get_messages_defaults();
+  auto messages_strings = get_messages_strings();
 
   rclcpp::SubscriptionBase::SharedPtr subscriber;
   std::vector<bool> received_messages;  // collect flags about received messages
@@ -121,6 +124,15 @@ int main(int argc, char ** argv)
   } else if (message == "Builtins") {
     subscriber = subscribe<test_msgs::msg::Builtins>(
       node, message, messages_builtins, received_messages);
+  } else if (message == "Constants") {
+    subscriber = subscribe<test_msgs::msg::Constants>(
+      node, message, messages_constants, received_messages);
+  } else if (message == "Defaults") {
+    subscriber = subscribe<test_msgs::msg::Defaults>(
+      node, message, messages_defaults, received_messages);
+  } else if (message == "Strings") {
+    subscriber = subscribe<test_msgs::msg::Strings>(
+      node, message, messages_strings, received_messages);
   } else {
     fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());
     rclcpp::shutdown();

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -87,7 +87,7 @@ int main(int argc, char ** argv)
     std::string("test_subscriber_") + message, namespace_);
 
   auto messages_empty = get_messages_empty();
-  auto messages_primitives = get_messages_primitives();
+  auto messages_basic_types = get_messages_basic_types();
   auto messages_static_array_primitives = get_messages_static_array_primitives();
   auto messages_static_array_primitives_nested = get_messages_static_array_primitives_nested();
   auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
@@ -107,9 +107,9 @@ int main(int argc, char ** argv)
   if (message == "Empty") {
     subscriber = subscribe<test_msgs::msg::Empty>(
       node, message, messages_empty, received_messages);
-  } else if (message == "Primitives") {
-    subscriber = subscribe<test_msgs::msg::Primitives>(
-      node, message, messages_primitives, received_messages);
+  } else if (message == "BasicTypes") {
+    subscriber = subscribe<test_msgs::msg::BasicTypes>(
+      node, message, messages_basic_types, received_messages);
   } else if (message == "StaticArrayPrimitives") {
     subscriber = subscribe<test_msgs::msg::StaticArrayPrimitives>(
       node, message, messages_static_array_primitives, received_messages);

--- a/test_security/test/test_secure_publisher.cpp
+++ b/test_security/test/test_secure_publisher.cpp
@@ -88,30 +88,33 @@ int main(int argc, char ** argv)
   if (message == "Empty") {
     ret = attempt_publish<test_msgs::msg::Empty>(
       node, topic_name, get_messages_empty());
-  } else if (message == "Primitives") {
-    ret = attempt_publish<test_msgs::msg::Primitives>(
-      node, topic_name, get_messages_primitives());
-  } else if (message == "StaticArrayPrimitives") {
-    ret = attempt_publish<test_msgs::msg::StaticArrayPrimitives>(
-      node, topic_name, get_messages_static_array_primitives());
-  } else if (message == "DynamicArrayPrimitives") {
-    ret = attempt_publish<test_msgs::msg::DynamicArrayPrimitives>(
-      node, topic_name, get_messages_dynamic_array_primitives());
-  } else if (message == "BoundedArrayPrimitives") {
-    ret = attempt_publish<test_msgs::msg::BoundedArrayPrimitives>(
-      node, topic_name, get_messages_bounded_array_primitives());
+  } else if (message == "BasicTypes") {
+    ret = attempt_publish<test_msgs::msg::BasicTypes>(
+      node, topic_name, get_messages_basic_types());
+  } else if (message == "Arrays") {
+    ret = attempt_publish<test_msgs::msg::Arrays>(
+      node, topic_name, get_messages_arrays());
+  } else if (message == "UnboundedSequences") {
+    ret = attempt_publish<test_msgs::msg::UnboundedSequences>(
+      node, topic_name, get_messages_unbounded_sequences());
+  } else if (message == "BoundedSequences") {
+    ret = attempt_publish<test_msgs::msg::BoundedSequences>(
+      node, topic_name, get_messages_bounded_sequences());
   } else if (message == "Nested") {
     ret = attempt_publish<test_msgs::msg::Nested>(
       node, topic_name, get_messages_nested());
-  } else if (message == "DynamicArrayNested") {
-    ret = attempt_publish<test_msgs::msg::DynamicArrayNested>(
-      node, topic_name, get_messages_dynamic_array_nested());
-  } else if (message == "BoundedArrayNested") {
-    ret = attempt_publish<test_msgs::msg::BoundedArrayNested>(
-      node, topic_name, get_messages_bounded_array_nested());
-  } else if (message == "StaticArrayNested") {
-    ret = attempt_publish<test_msgs::msg::StaticArrayNested>(
-      node, topic_name, get_messages_static_array_nested());
+  } else if (message == "MultiNested") {
+    ret = attempt_publish<test_msgs::msg::MultiNested>(
+      node, topic_name, get_messages_multi_nested());
+  } else if (message == "Strings") {
+    ret = attempt_publish<test_msgs::msg::Strings>(
+      node, topic_name, get_messages_strings());
+  } else if (message == "Constants") {
+    ret = attempt_publish<test_msgs::msg::Constants>(
+      node, topic_name, get_messages_constants());
+  } else if (message == "Defaults") {
+    ret = attempt_publish<test_msgs::msg::Defaults>(
+      node, topic_name, get_messages_defaults());
   } else if (message == "Builtins") {
     ret = attempt_publish<test_msgs::msg::Builtins>(
       node, topic_name, get_messages_builtins());

--- a/test_security/test/test_secure_subscriber.cpp
+++ b/test_security/test/test_secure_subscriber.cpp
@@ -141,42 +141,46 @@ int main(int argc, char ** argv)
   if (!should_timeout) {
     std::vector<bool> received_messages;  // collect flags about received messages
     auto messages_empty = get_messages_empty();
-    auto messages_primitives = get_messages_primitives();
-    auto messages_static_array_primitives = get_messages_static_array_primitives();
-    auto messages_dynamic_array_primitives = get_messages_dynamic_array_primitives();
-    auto messages_bounded_array_primitives = get_messages_bounded_array_primitives();
+    auto messages_basic_types = get_messages_basic_types();
+    auto messages_arrays = get_messages_arrays();
+    auto messages_unbounded_sequences = get_messages_unbounded_sequences();
+    auto messages_bounded_sequences = get_messages_bounded_sequences();
     auto messages_nested = get_messages_nested();
-    auto messages_dynamic_array_nested = get_messages_dynamic_array_nested();
-    auto messages_bounded_array_nested = get_messages_bounded_array_nested();
-    auto messages_static_array_nested = get_messages_static_array_nested();
+    auto messages_multi_nested = get_messages_multi_nested();
+    auto messages_strings = get_messages_strings();
+    auto messages_constants = get_messages_constants();
+    auto messages_defaults = get_messages_defaults();
     auto messages_builtins = get_messages_builtins();
     if (message == "Empty") {
       subscriber = attempt_subscribe<test_msgs::msg::Empty>(
         node, topic_name, messages_empty, received_messages);
-    } else if (message == "Primitives") {
-      subscriber = attempt_subscribe<test_msgs::msg::Primitives>(
-        node, topic_name, messages_primitives, received_messages);
-    } else if (message == "StaticArrayPrimitives") {
-      subscriber = attempt_subscribe<test_msgs::msg::StaticArrayPrimitives>(
-        node, topic_name, messages_static_array_primitives, received_messages);
-    } else if (message == "DynamicArrayPrimitives") {
-      subscriber = attempt_subscribe<test_msgs::msg::DynamicArrayPrimitives>(
-        node, topic_name, messages_dynamic_array_primitives, received_messages);
-    } else if (message == "BoundedArrayPrimitives") {
-      subscriber = attempt_subscribe<test_msgs::msg::BoundedArrayPrimitives>(
-        node, topic_name, messages_bounded_array_primitives, received_messages);
+    } else if (message == "BasicTypes") {
+      subscriber = attempt_subscribe<test_msgs::msg::BasicTypes>(
+        node, topic_name, messages_basic_types, received_messages);
+    } else if (message == "Arrays") {
+      subscriber = attempt_subscribe<test_msgs::msg::Arrays>(
+        node, topic_name, messages_arrays, received_messages);
+    } else if (message == "UnboundedSequences") {
+      subscriber = attempt_subscribe<test_msgs::msg::UnboundedSequences>(
+        node, topic_name, messages_unbounded_sequences, received_messages);
+    } else if (message == "BoundedSequences") {
+      subscriber = attempt_subscribe<test_msgs::msg::BoundedSequences>(
+        node, topic_name, messages_bounded_sequences, received_messages);
     } else if (message == "Nested") {
       subscriber = attempt_subscribe<test_msgs::msg::Nested>(
         node, topic_name, messages_nested, received_messages);
-    } else if (message == "DynamicArrayNested") {
-      subscriber = attempt_subscribe<test_msgs::msg::DynamicArrayNested>(
-        node, topic_name, messages_dynamic_array_nested, received_messages);
-    } else if (message == "BoundedArrayNested") {
-      subscriber = attempt_subscribe<test_msgs::msg::BoundedArrayNested>(
-        node, topic_name, messages_bounded_array_nested, received_messages);
-    } else if (message == "StaticArrayNested") {
-      subscriber = attempt_subscribe<test_msgs::msg::StaticArrayNested>(
-        node, topic_name, messages_static_array_nested, received_messages);
+    } else if (message == "MultiNested") {
+      subscriber = attempt_subscribe<test_msgs::msg::MultiNested>(
+        node, topic_name, messages_multi_nested, received_messages);
+    } else if (message == "Strings") {
+      subscriber = attempt_subscribe<test_msgs::msg::Strings>(
+        node, topic_name, messages_strings, received_messages);
+    } else if (message == "Constants") {
+      subscriber = attempt_subscribe<test_msgs::msg::Constants>(
+        node, topic_name, messages_constants, received_messages);
+    } else if (message == "Defaults") {
+      subscriber = attempt_subscribe<test_msgs::msg::Defaults>(
+        node, topic_name, messages_defaults, received_messages);
     } else if (message == "Builtins") {
       subscriber = attempt_subscribe<test_msgs::msg::Builtins>(
         node, topic_name, messages_builtins, received_messages);
@@ -195,29 +199,32 @@ int main(int argc, char ** argv)
     if (message == "Empty") {
       subscriber = attempt_subscribe<test_msgs::msg::Empty>(
         node, topic_name, sub_callback_called, executor);
-    } else if (message == "Primitives") {
-      subscriber = attempt_subscribe<test_msgs::msg::Primitives>(
+    } else if (message == "BasicTypes") {
+      subscriber = attempt_subscribe<test_msgs::msg::BasicTypes>(
         node, topic_name, sub_callback_called, executor);
-    } else if (message == "StaticArrayPrimitives") {
-      subscriber = attempt_subscribe<test_msgs::msg::StaticArrayPrimitives>(
+    } else if (message == "Arrays") {
+      subscriber = attempt_subscribe<test_msgs::msg::Arrays>(
         node, topic_name, sub_callback_called, executor);
-    } else if (message == "DynamicArrayPrimitives") {
-      subscriber = attempt_subscribe<test_msgs::msg::DynamicArrayPrimitives>(
+    } else if (message == "UnboundedSequences") {
+      subscriber = attempt_subscribe<test_msgs::msg::UnboundedSequences>(
         node, topic_name, sub_callback_called, executor);
-    } else if (message == "BoundedArrayPrimitives") {
-      subscriber = attempt_subscribe<test_msgs::msg::BoundedArrayPrimitives>(
+    } else if (message == "BoundedSequences") {
+      subscriber = attempt_subscribe<test_msgs::msg::BoundedSequences>(
         node, topic_name, sub_callback_called, executor);
     } else if (message == "Nested") {
       subscriber = attempt_subscribe<test_msgs::msg::Nested>(
         node, topic_name, sub_callback_called, executor);
-    } else if (message == "DynamicArrayNested") {
-      subscriber = attempt_subscribe<test_msgs::msg::DynamicArrayNested>(
+    } else if (message == "MultiNested") {
+      subscriber = attempt_subscribe<test_msgs::msg::MultiNested>(
         node, topic_name, sub_callback_called, executor);
-    } else if (message == "BoundedArrayNested") {
-      subscriber = attempt_subscribe<test_msgs::msg::BoundedArrayNested>(
+    } else if (message == "Strings") {
+      subscriber = attempt_subscribe<test_msgs::msg::Strings>(
         node, topic_name, sub_callback_called, executor);
-    } else if (message == "StaticArrayNested") {
-      subscriber = attempt_subscribe<test_msgs::msg::StaticArrayNested>(
+    } else if (message == "Constants") {
+      subscriber = attempt_subscribe<test_msgs::msg::Constants>(
+        node, topic_name, sub_callback_called, executor);
+    } else if (message == "Defaults") {
+      subscriber = attempt_subscribe<test_msgs::msg::Defaults>(
         node, topic_name, sub_callback_called, executor);
     } else if (message == "Builtins") {
       subscriber = attempt_subscribe<test_msgs::msg::Builtins>(


### PR DESCRIPTION
Interface definitions for testing have been consolidated into a common package, [test_interface_files](https://github.com/ros2/test_interface_files).
They have been refactored in an effort to reduce the number of interfaces and also renamed to follow IDL terminology.

This change switches over the tests to use the new interface definitions.

Connects to https://github.com/ros2/rcl_interfaces/issues/58