### PR TITLE
[POC] Force MSVC to use UTF-8 to read C++ source files

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -115,6 +115,11 @@ if(BUILD_TESTING)
     add_executable(${target} ${ARGN})
     rosidl_target_interfaces(${target}
       ${PROJECT_NAME} "rosidl_typesupport_cpp")
+    if(WIN32)
+      target_compile_options(${target}
+        PRIVATE /source-charset:utf-8 /execution-charset:utf-8
+      )
+    endif()
     ament_target_dependencies(${target}
       "rclcpp"
       "rclcpp_action"


### PR DESCRIPTION
This pull request fixes #359 but it's actually a proof of concept in the sense that, even though tests pass (and as a side effect, the stack corruption went away though it's unrelated, see https://github.com/ros2/system_tests/issues/360#issuecomment-490945372), these compile options probably have to enforced everywhere.

For those interested in the rationale behind this, during compilation `msvc` will attempt to read source files as `utf-8` but if it fails to find a BOM mark, it'll switch to whatever is the current default code page. For the VM that I've been using, that is `cp1252`. [These compile options](https://docs.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=vs-2019) exist to force it to always read files as if they were encoded in `utf-8`. So, in our case, a `utf-8` encoded kanji character was being decoded as `cp1252` during compilation and then encoded as `utf-16-le` in the final executable. Thus the difference with Python, which always does the right thing.