### PR TITLE
Fix memory leaks in test_communication tests

### DIFF
--- a/test_communication/test/test_message_serialization.cpp
+++ b/test_communication/test/test_message_serialization.cpp
@@ -201,7 +201,6 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), cdr_integrity) {
     rosidl_typesupport_cpp::get_message_type_support_handle<test_msgs::msg::BoundedSequences>();
 
   test_msgs__msg__BoundedSequences msg_c;
-  test_msgs__msg__BoundedSequences__init(&msg_c);
   fill_c_message(&msg_c);
 
   test_msgs::msg::BoundedSequences msg_cpp;

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -175,6 +175,8 @@ public:
       EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
       ret = rcl_wait(&wait_set, -1);
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+      ret = rcl_wait_set_fini(&wait_set);
+      EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -225,6 +227,8 @@ public:
         ret = rcl_take(&subscription, &message, nullptr, nullptr);
         ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
         verify_message(message, msg_cnt);
+        ret = rcl_wait_set_fini(&wait_set);
+        EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
       }
     }
   }
@@ -535,6 +539,7 @@ void get_message(test_msgs__msg__Strings * msg, size_t msg_num)
   }
 }
 
+DEFINE_FINI_MESSAGE(test_msgs__msg__Strings)
 template<>
 void verify_message(test_msgs__msg__Strings & message, size_t msg_num)
 {
@@ -542,9 +547,13 @@ void verify_message(test_msgs__msg__Strings & message, size_t msg_num)
   get_message(&expected_msg, msg_num);
   EXPECT_EQ(0, strcmp(expected_msg.string_value.data, message.string_value.data));
   EXPECT_EQ(0, strcmp(expected_msg.bounded_string_value.data, message.bounded_string_value.data));
+
+  auto msg_exit = make_scope_exit(
+    [&expected_msg]() {
+      fini_message(&expected_msg);
+    });
 }
 
-DEFINE_FINI_MESSAGE(test_msgs__msg__Strings)
 TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_strings) {
   const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
     test_msgs, msg, Strings);
@@ -701,6 +710,7 @@ void get_message(test_msgs__msg__Arrays * msg, size_t msg_num)
   }
 }
 
+DEFINE_FINI_MESSAGE(test_msgs__msg__Arrays)
 template<>
 void verify_message(test_msgs__msg__Arrays & message, size_t msg_num)
 {
@@ -723,9 +733,13 @@ void verify_message(test_msgs__msg__Arrays & message, size_t msg_num)
     EXPECT_EQ(0, strcmp(expected_msg.string_values[i].data,
       message.string_values[i].data));
   }
+
+  auto msg_exit = make_scope_exit(
+    [&expected_msg]() {
+      fini_message(&expected_msg);
+    });
 }
 
-DEFINE_FINI_MESSAGE(test_msgs__msg__Arrays)
 TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_arrays) {
   const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
     test_msgs, msg, Arrays);
@@ -913,6 +927,7 @@ void get_message(test_msgs__msg__UnboundedSequences * msg, size_t msg_num)
   }
 }
 
+DEFINE_FINI_MESSAGE(test_msgs__msg__UnboundedSequences)
 template<>
 void verify_message(test_msgs__msg__UnboundedSequences & message, size_t msg_num)
 {
@@ -974,9 +989,13 @@ void verify_message(test_msgs__msg__UnboundedSequences & message, size_t msg_num
     EXPECT_EQ(0, strcmp(message.string_values.data[i].data,
       expected_msg.string_values.data[i].data));
   }
+
+  auto msg_exit = make_scope_exit(
+    [&expected_msg]() {
+      fini_message(&expected_msg);
+    });
 }
 
-DEFINE_FINI_MESSAGE(test_msgs__msg__UnboundedSequences)
 TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_unbounded_sequences) {
   const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
     test_msgs, msg, UnboundedSequences);
@@ -1082,6 +1101,7 @@ void get_message(test_msgs__msg__BoundedSequences * msg, size_t msg_num)
   }
 }
 
+DEFINE_FINI_MESSAGE(test_msgs__msg__BoundedSequences)
 template<>
 void verify_message(test_msgs__msg__BoundedSequences & message, size_t msg_num)
 {
@@ -1143,9 +1163,13 @@ void verify_message(test_msgs__msg__BoundedSequences & message, size_t msg_num)
     EXPECT_EQ(0, strcmp(message.string_values.data[i].data,
       expected_msg.string_values.data[i].data));
   }
+
+  auto msg_exit = make_scope_exit(
+    [&expected_msg]() {
+      fini_message(&expected_msg);
+    });
 }
 
-DEFINE_FINI_MESSAGE(test_msgs__msg__BoundedSequences)
 TEST_F(CLASSNAME(TestMessagesFixture, RMW_IMPLEMENTATION), test_bounded_sequences) {
   const rosidl_message_type_support_t * ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
     test_msgs, msg, BoundedSequences);


### PR DESCRIPTION
Fix memory leaks detected by AddressSanitizer in
test_message_serialization and test_messages_c tests.

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>

#### test_message_serialization.cpp
Before the fix:
```bash
Running main() from /home/ANT.AMAZON.COM/prajaktg/ros2_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from TestMessageSerialization
[ RUN      ] TestMessageSerialization.de_serialize_c
serialized data length: 52
serialized message c
00 01 00 00 01 ff 6b be 00 00 80 3f 00 00 00 00 00 00 00 40 03 04 05 00 06 00 be be 07 00 00 00 08 00 00 00 09 00 00 00 00 00 00 00 0a 00 00 00 00 00 00 00 
[       OK ] TestMessageSerialization.de_serialize_c (0 ms)
[ RUN      ] TestMessageSerialization.de_serialize_cpp
serialized message cpp
00 01 00 00 01 ff 6b be 00 00 80 3f 00 00 00 00 00 00 00 40 03 04 05 00 06 00 be be 07 00 00 00 08 00 00 00 09 00 00 00 00 00 00 00 0a 00 00 00 00 00 00 00 
[       OK ] TestMessageSerialization.de_serialize_cpp (0 ms)
[ RUN      ] TestMessageSerialization.cdr_integrity
serialized message c
00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 01 ff 6b be 00 00 80 3f be be be be 00 00 00 00 00 00 00 40 03 04 05 00 06 00 be be 07 00 00 00 08 00 00 00 09 00 00 00 00 00 00 00 0a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 03 00 00 00 00 01 00 be 03 00 00 00 00 01 ff be 03 00 00 00 00 01 7f be 03 00 00 00 00 00 90 3f 00 00 00 00 00 00 90 bf 03 00 00 00 be be be be 6f 12 83 c0 ca 21 09 40 00 00 00 00 00 00 00 00 6f 12 83 c0 ca 21 09 c0 03 00 00 00 00 7f 80 be 03 00 00 00 00 01 ff be 03 00 00 00 00 00 ff 7f 00 80 be be 03 00 00 00 00 00 01 00 ff ff be be 03 00 00 00 00 00 00 00 ff ff ff 7f 00 00 00 80 03 00 00 00 00 00 00 00 01 00 00 00 ff ff ff ff 03 00 00 00 be be be be 00 00 00 00 00 00 00 00 ff ff ff ff ff ff ff 7f 00 00 00 00 00 00 00 80 03 00 00 00 be be be be 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 ff ff ff ff ff ff ff ff 03 00 00 00 01 00 00 00 00 be be be 0a 00 00 00 6d 61 78 20 76 61 6c 75 65 00 be be 0a 00 00 00 6d 69 6e 20 76 61 6c 75 65 00 be be e2 df 3b 34 be be be be be be be be 
serialized message cpp
00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 01 ff 6b be 00 00 80 3f be be be be 00 00 00 00 00 00 00 40 03 04 05 00 06 00 be be 07 00 00 00 08 00 00 00 09 00 00 00 00 00 00 00 0a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 03 00 00 00 00 01 00 be 03 00 00 00 00 01 ff be 03 00 00 00 00 01 7f be 03 00 00 00 00 00 90 3f 00 00 00 00 00 00 90 bf 03 00 00 00 be be be be 6f 12 83 c0 ca 21 09 40 00 00 00 00 00 00 00 00 6f 12 83 c0 ca 21 09 c0 03 00 00 00 00 7f 80 be 03 00 00 00 00 01 ff be 03 00 00 00 00 00 ff 7f 00 80 be be 03 00 00 00 00 00 01 00 ff ff be be 03 00 00 00 00 00 00 00 ff ff ff 7f 00 00 00 80 03 00 00 00 00 00 00 00 01 00 00 00 ff ff ff ff 03 00 00 00 be be be be 00 00 00 00 00 00 00 00 ff ff ff ff ff ff ff 7f 00 00 00 00 00 00 00 80 03 00 00 00 be be be be 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 ff ff ff ff ff ff ff ff 03 00 00 00 01 00 00 00 00 be be be 0a 00 00 00 6d 61 78 20 76 61 6c 75 65 00 be be 0a 00 00 00 6d 69 6e 20 76 61 6c 75 65 00 be be 00 00 00 00 be be be be be be be be 
[       OK ] TestMessageSerialization.cdr_integrity (1 ms)
[----------] 3 tests from TestMessageSerialization (1 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (1 ms total)
[  PASSED  ] 3 tests.

=================================================================
==4344==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    ...snip...

SUMMARY: AddressSanitizer: 228 byte(s) leaked in 17 allocation(s).
```

After the fix:
```bash
Running main() from /home/ANT.AMAZON.COM/prajaktg/ros2_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from TestMessageSerialization
[ RUN      ] TestMessageSerialization.de_serialize_c
serialized data length: 52
serialized message c
00 01 00 00 01 ff 6b be 00 00 80 3f 00 00 00 00 00 00 00 40 03 04 05 00 06 00 be be 07 00 00 00 08 00 00 00 09 00 00 00 00 00 00 00 0a 00 00 00 00 00 00 00 
[       OK ] TestMessageSerialization.de_serialize_c (0 ms)
[ RUN      ] TestMessageSerialization.de_serialize_cpp
serialized message cpp
00 01 00 00 01 ff 6b be 00 00 80 3f 00 00 00 00 00 00 00 40 03 04 05 00 06 00 be be 07 00 00 00 08 00 00 00 09 00 00 00 00 00 00 00 0a 00 00 00 00 00 00 00 
[       OK ] TestMessageSerialization.de_serialize_cpp (1 ms)
[ RUN      ] TestMessageSerialization.cdr_integrity
serialized message c
00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 01 ff 6b be 00 00 80 3f be be be be 00 00 00 00 00 00 00 40 03 04 05 00 06 00 be be 07 00 00 00 08 00 00 00 09 00 00 00 00 00 00 00 0a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 03 00 00 00 00 01 00 be 03 00 00 00 00 01 ff be 03 00 00 00 00 01 7f be 03 00 00 00 00 00 90 3f 00 00 00 00 00 00 90 bf 03 00 00 00 be be be be 6f 12 83 c0 ca 21 09 40 00 00 00 00 00 00 00 00 6f 12 83 c0 ca 21 09 c0 03 00 00 00 00 7f 80 be 03 00 00 00 00 01 ff be 03 00 00 00 00 00 ff 7f 00 80 be be 03 00 00 00 00 00 01 00 ff ff be be 03 00 00 00 00 00 00 00 ff ff ff 7f 00 00 00 80 03 00 00 00 00 00 00 00 01 00 00 00 ff ff ff ff 03 00 00 00 be be be be 00 00 00 00 00 00 00 00 ff ff ff ff ff ff ff 7f 00 00 00 00 00 00 00 80 03 00 00 00 be be be be 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 ff ff ff ff ff ff ff ff 03 00 00 00 01 00 00 00 00 be be be 0a 00 00 00 6d 61 78 20 76 61 6c 75 65 00 be be 0a 00 00 00 6d 69 6e 20 76 61 6c 75 65 00 be be 02 04 96 63 be be be be be be be be 
serialized message cpp
00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 01 ff 6b be 00 00 80 3f be be be be 00 00 00 00 00 00 00 40 03 04 05 00 06 00 be be 07 00 00 00 08 00 00 00 09 00 00 00 00 00 00 00 0a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 03 00 00 00 00 01 00 be 03 00 00 00 00 01 ff be 03 00 00 00 00 01 7f be 03 00 00 00 00 00 90 3f 00 00 00 00 00 00 90 bf 03 00 00 00 be be be be 6f 12 83 c0 ca 21 09 40 00 00 00 00 00 00 00 00 6f 12 83 c0 ca 21 09 c0 03 00 00 00 00 7f 80 be 03 00 00 00 00 01 ff be 03 00 00 00 00 00 ff 7f 00 80 be be 03 00 00 00 00 00 01 00 ff ff be be 03 00 00 00 00 00 00 00 ff ff ff 7f 00 00 00 80 03 00 00 00 00 00 00 00 01 00 00 00 ff ff ff ff 03 00 00 00 be be be be 00 00 00 00 00 00 00 00 ff ff ff ff ff ff ff 7f 00 00 00 00 00 00 00 80 03 00 00 00 be be be be 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 ff ff ff ff ff ff ff ff 03 00 00 00 01 00 00 00 00 be be be 0a 00 00 00 6d 61 78 20 76 61 6c 75 65 00 be be 0a 00 00 00 6d 69 6e 20 76 61 6c 75 65 00 be be 00 00 00 00 be be be be be be be be 
[       OK ] TestMessageSerialization.cdr_integrity (0 ms)
[----------] 3 tests from TestMessageSerialization (1 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (1 ms total)
[  PASSED  ] 3 tests.
```

####  test_messages_c.cpp
This does not include fix for memory leaks from test_multi_nested.

Before the fixes:
```bash
Running main() from /home/ANT.AMAZON.COM/prajaktg/ros2_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TestMessagesFixture
[ RUN      ] TestMessagesFixture.test_basic_types
[       OK ] TestMessagesFixture.test_basic_types (121 ms)
[----------] 1 test from TestMessagesFixture (121 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (121 ms total)
[  PASSED  ] 1 test.

=================================================================
==3135==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 184 byte(s) in 1 object(s) allocated from:
    ...snip...

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    ...snip...

Indirect leak of 88 byte(s) in 1 object(s) allocated from:
    ...snip...

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    ...snip...

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    ...snip...

SUMMARY: AddressSanitizer: 312 byte(s) leaked in 5 allocation(s).
```

```bash
Running main() from /home/ANT.AMAZON.COM/prajaktg/ros2_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 10 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 10 tests from TestMessagesFixture
[ RUN      ] TestMessagesFixture.test_basic_types
[       OK ] TestMessagesFixture.test_basic_types (122 ms)
[ RUN      ] TestMessagesFixture.test_constants
[       OK ] TestMessagesFixture.test_constants (120 ms)
[ RUN      ] TestMessagesFixture.test_defaults
[       OK ] TestMessagesFixture.test_defaults (111 ms)
[ RUN      ] TestMessagesFixture.test_empty
[       OK ] TestMessagesFixture.test_empty (114 ms)
[ RUN      ] TestMessagesFixture.test_strings
[       OK ] TestMessagesFixture.test_strings (115 ms)
[ RUN      ] TestMessagesFixture.test_nested
[       OK ] TestMessagesFixture.test_nested (115 ms)
[ RUN      ] TestMessagesFixture.test_builtins
[       OK ] TestMessagesFixture.test_builtins (122 ms)
[ RUN      ] TestMessagesFixture.test_arrays
[       OK ] TestMessagesFixture.test_arrays (114 ms)
[ RUN      ] TestMessagesFixture.test_unbounded_sequences
[       OK ] TestMessagesFixture.test_unbounded_sequences (132 ms)
[ RUN      ] TestMessagesFixture.test_bounded_sequences
[       OK ] TestMessagesFixture.test_bounded_sequences (111 ms)
[----------] 10 tests from TestMessagesFixture (1176 ms total)

[----------] Global test environment tear-down
[==========] 10 tests from 1 test case ran. (1176 ms total)
[  PASSED  ] 10 tests.

=================================================================
==12390==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 144 byte(s) in 2 object(s) allocated from:
    ...snip...

Indirect leak of 10 byte(s) in 1 object(s) allocated from:
    ...snip...

SUMMARY: AddressSanitizer: 693 byte(s) leaked in 51 allocation(s).
```

After the fixes:
```bash
Running main() from /home/ANT.AMAZON.COM/prajaktg/ros2_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
Note: Google Test filter = -TestMessagesFixture.test_multi_nested
[==========] Running 10 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 10 tests from TestMessagesFixture
[ RUN      ] TestMessagesFixture.test_basic_types
[       OK ] TestMessagesFixture.test_basic_types (125 ms)
[ RUN      ] TestMessagesFixture.test_constants
[       OK ] TestMessagesFixture.test_constants (127 ms)
[ RUN      ] TestMessagesFixture.test_defaults
[       OK ] TestMessagesFixture.test_defaults (129 ms)
[ RUN      ] TestMessagesFixture.test_empty
[       OK ] TestMessagesFixture.test_empty (129 ms)
[ RUN      ] TestMessagesFixture.test_strings
[       OK ] TestMessagesFixture.test_strings (131 ms)
[ RUN      ] TestMessagesFixture.test_nested
[       OK ] TestMessagesFixture.test_nested (130 ms)
[ RUN      ] TestMessagesFixture.test_builtins
[       OK ] TestMessagesFixture.test_builtins (126 ms)
[ RUN      ] TestMessagesFixture.test_arrays
[       OK ] TestMessagesFixture.test_arrays (127 ms)
[ RUN      ] TestMessagesFixture.test_unbounded_sequences
[       OK ] TestMessagesFixture.test_unbounded_sequences (153 ms)
[ RUN      ] TestMessagesFixture.test_bounded_sequences
[       OK ] TestMessagesFixture.test_bounded_sequences (125 ms)
[----------] 10 tests from TestMessagesFixture (1302 ms total)

[----------] Global test environment tear-down
[==========] 10 tests from 1 test case ran. (1302 ms total)
[  PASSED  ] 10 tests.
```