### PR TITLE
Modifying test for failing on getting an empty node name

### DIFF
--- a/test_rclcpp/test/node_name_list.cpp
+++ b/test_rclcpp/test/node_name_list.cpp
@@ -45,6 +45,13 @@ int main(int argc, char ** argv)
     auto names = node->get_node_graph_interface()->get_node_names();
     for (auto it : names) {
       printf("- %s\n", it.c_str());
+
+      if (it.empty()) {
+        printf("  found an empty named node, which is unexpected\n");
+        rc = 1;
+        break;
+      }
+
       if (argc >= 2 && it.compare(name_to_find) == 0) {
         printf("  found expected node name\n");
         rc = 0;
@@ -59,6 +66,7 @@ int main(int argc, char ** argv)
 
   exec.remove_node(node);
   rclcpp::shutdown();
+
   if (rc) {
     fprintf(stderr, "not found expected node name\n");
   }

--- a/test_rclcpp/test/node_name_list.cpp
+++ b/test_rclcpp/test/node_name_list.cpp
@@ -48,7 +48,7 @@ int main(int argc, char ** argv)
 
       if (it.empty()) {
         printf("  found an empty named node, which is unexpected\n");
-        rc = 1;
+        rc = 2;
         break;
       }
 
@@ -67,8 +67,10 @@ int main(int argc, char ** argv)
   exec.remove_node(node);
   rclcpp::shutdown();
 
-  if (rc) {
+  if (rc == 1) {
     fprintf(stderr, "not found expected node name\n");
+  } else if (rc == 2) {
+    fprintf(stderr, "found a node with an empty name\n");
   }
   return rc;
 }


### PR DESCRIPTION
Related to ros2/rmw_connext#362 and ros2/ros2#489.

PR modifies existing node_name_list test that it would fail on getting an empty node name.

Connects to ros2/ros2#489