### PR TITLE
Remove the test_cli dependency on launch.

### DIFF
--- a/test_cli/package.xml
+++ b/test_cli/package.xml
@@ -17,7 +17,6 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>launch</test_depend>
   <test_depend>rcl_interfaces</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rclpy</test_depend>


### PR DESCRIPTION
It never uses it, so we don't need it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@sloretz It looks like you added this initially, but as far as I can tell this is never used in test_cli.  But let me know if I missed something.