### PR TITLE
Skip rclcpp__rclpy__rmw_connext_cpp__rmw_fastrtps_cpp tests

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -171,7 +171,11 @@ if(BUILD_TESTING)
       set(SKIP_TEST "SKIP_TEST")
     endif()
 
+    set(rmw_implementation1_is_connext FALSE)
     set(rmw_implementation2_is_connext FALSE)
+    if(rmw_implementation1 MATCHES "(.*)connext(.*)")
+      set(rmw_implementation1_is_connext TRUE)
+    endif()
     if(rmw_implementation2 MATCHES "(.*)connext(.*)")
       set(rmw_implementation2_is_connext TRUE)
     endif()
@@ -183,6 +187,14 @@ if(BUILD_TESTING)
     endif()
     if(rmw_implementation2 MATCHES "(.*)opensplice(.*)")
       set(rmw_implementation2_is_opensplice TRUE)
+    endif()
+
+    # TODO(cottsay) Recent builds of FastRTPS don't communicate correctly with connext
+    if(
+      rmw_implementation1_is_connext AND rmw_implementation2_is_fastrtps AND
+      client_library1 STREQUAL "rclcpp" AND client_library2 STREQUAL "rclpy"
+    )
+      set(SKIP_TEST "SKIP_TEST")
     endif()
 
     set(PUBLISHER_RMW ${rmw_implementation1})


### PR DESCRIPTION
These tests fail consistently due to an assertion in Fast-RTPS which was recently introduced.

Tracked by ros2/build_cop#230
Regressed by eProsima/Fast-RTPS#646
Reported upstream as eProsima/Fast-RTPS#671

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7979)](https://ci.ros2.org/job/ci_linux/7979/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7980)](https://ci.ros2.org/job/ci_linux/7980/)