### PR TITLE
Revert "Skip rclcpp__rclpy__rmw_connext_cpp__rmw_fastrtps_cpp tests (#382)

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -171,11 +171,7 @@ if(BUILD_TESTING)
       set(SKIP_TEST "SKIP_TEST")
     endif()
 
-    set(rmw_implementation1_is_connext FALSE)
     set(rmw_implementation2_is_connext FALSE)
-    if(rmw_implementation1 MATCHES "(.*)connext(.*)")
-      set(rmw_implementation1_is_connext TRUE)
-    endif()
     if(rmw_implementation2 MATCHES "(.*)connext(.*)")
       set(rmw_implementation2_is_connext TRUE)
     endif()
@@ -187,14 +183,6 @@ if(BUILD_TESTING)
     endif()
     if(rmw_implementation2 MATCHES "(.*)opensplice(.*)")
       set(rmw_implementation2_is_opensplice TRUE)
-    endif()
-
-    # TODO(cottsay) Recent builds of FastRTPS don't communicate correctly with connext
-    if(
-      rmw_implementation1_is_connext AND rmw_implementation2_is_fastrtps AND
-      client_library1 STREQUAL "rclcpp" AND client_library2 STREQUAL "rclpy"
-    )
-      set(SKIP_TEST "SKIP_TEST")
     endif()
 
     set(PUBLISHER_RMW ${rmw_implementation1})


### PR DESCRIPTION
This reverts #382.

The issue was resolved by eProsima.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8023)](http://ci.ros2.org/job/ci_linux/8023/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4034)](http://ci.ros2.org/job/ci_linux-aarch64/4034/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6534)](http://ci.ros2.org/job/ci_osx/6534/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7877)](http://ci.ros2.org/job/ci_windows/7877/)