### PR TITLE
Don't set ignore_local_publications = true.

### DIFF
--- a/test_rclcpp/test/test_intra_process.cpp
+++ b/test_rclcpp/test/test_intra_process.cpp
@@ -62,10 +62,8 @@ TEST(CLASSNAME(test_intra_process_within_one_node, RMW_IMPLEMENTATION), nominal_
   rclcpp::executors::SingleThreadedExecutor executor;
 
   {
-    rclcpp::SubscriptionOptions options;
-    options.ignore_local_publications = true;
     auto subscriber = node->create_subscription<test_rclcpp::msg::UInt32>(
-      "test_intra_process", 10, callback, options);
+      "test_intra_process", 10, callback);
 
     // start condition
     ASSERT_EQ(0, counter);


### PR DESCRIPTION
According to [here](https://github.com/ros2/rclcpp/blob/master/rclcpp/include/rclcpp/intra_process_manager.hpp#L72), intra_process still needs local pub and sub to send special msg info.
Therefore, I think we shouldn't set ignore_local_publications to true.

Signed-off-by: evshary <evshary@gmail.com>