### PR TITLE
Replace ready_fn with ReadyToTest action

### DIFF
--- a/test_cli_remapping/test/test_cli_remapping.py
+++ b/test_cli_remapping/test/test_cli_remapping.py
@@ -21,8 +21,8 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 import launch_testing
+import launch_testing.actions
 
 import rclpy
 
@@ -65,7 +65,7 @@ TEST_CASES = {
 
 
 @launch_testing.parametrize('executable', CLIENT_LIBRARY_EXECUTABLES)
-def generate_test_description(executable, ready_fn):
+def generate_test_description(executable):
     command = [executable]
     # Execute python files using same python used to start this test
     env = dict(os.environ)
@@ -88,7 +88,7 @@ def generate_test_description(executable, ready_fn):
         test_context[replacement_name] = replacement_value.format(**locals())
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
 
     return launch_description, test_context

--- a/test_communication/test/test_action_client_server.py.in
+++ b/test_communication/test/test_action_client_server.py.in
@@ -6,9 +6,9 @@ import time
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 
 import unittest
 
@@ -17,7 +17,7 @@ ACTION_TYPES = '@TEST_ACTION_TYPES@'.split(';')
 
 
 @launch_testing.parametrize('action_type', ACTION_TYPES)
-def generate_test_description(action_type, ready_fn):
+def generate_test_description(action_type):
     namespace = '/test_time_%s' % time.strftime('%H_%M_%S', time.gmtime())
 
     launch_description = LaunchDescription()
@@ -55,7 +55,7 @@ def generate_test_description(action_type, ready_fn):
     launch_description.add_action(action_client_process)
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/test_communication/test/test_publisher_subscriber.py.in
+++ b/test_communication/test/test_publisher_subscriber.py.in
@@ -6,9 +6,9 @@ import time
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 
 import unittest
 
@@ -17,7 +17,7 @@ MESSAGE_TYPES = '@TEST_MESSAGE_TYPES@'.split(';')
 
 
 @launch_testing.parametrize('message_type', MESSAGE_TYPES)
-def generate_test_description(message_type, ready_fn):
+def generate_test_description(message_type):
     namespace = '/test_time_%s' % time.strftime('%H_%M_%S', time.gmtime())
 
     launch_description = LaunchDescription()
@@ -54,7 +54,7 @@ def generate_test_description(message_type, ready_fn):
     )
     launch_description.add_action(subscriber_process)
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/test_communication/test/test_requester_replier.py.in
+++ b/test_communication/test/test_requester_replier.py.in
@@ -6,9 +6,9 @@ import time
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 
 import unittest
 
@@ -17,7 +17,7 @@ SERVICE_TYPES = '@TEST_SERVICE_TYPES@'.split(';')
 
 
 @launch_testing.parametrize('service_type', SERVICE_TYPES)
-def generate_test_description(service_type, ready_fn):
+def generate_test_description(service_type):
     namespace = '/test_time_%s' % time.strftime('%H_%M_%S', time.gmtime())
 
     launch_description = LaunchDescription()
@@ -55,7 +55,7 @@ def generate_test_description(service_type, ready_fn):
     launch_description.add_action(requester_process)
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/test_rclcpp/test/test_executable_output.py.in
+++ b/test_rclcpp/test/test_executable_output.py.in
@@ -3,9 +3,9 @@
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
@@ -13,7 +13,7 @@ import os
 import unittest
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     env = os.environ.copy()
     env['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '[{severity}] [{name}]: {message}'
     launch_description = LaunchDescription()
@@ -26,7 +26,7 @@ def generate_test_description(ready_fn):
     )
     launch_description.add_action(proc_under_test)
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/test_rclcpp/test/test_n_nodes.py.in
+++ b/test_rclcpp/test/test_n_nodes.py.in
@@ -4,16 +4,16 @@ import os
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 import unittest
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
 
     env = None
@@ -37,7 +37,7 @@ def generate_test_description(ready_fn):
     )
     launch_description.add_action(checking_process)
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/test_rclcpp/test/test_two_executables.py.in
+++ b/test_rclcpp/test/test_two_executables.py.in
@@ -4,16 +4,16 @@ import os
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 
 import unittest
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
 
     cmd = ['@TEST_EXECUTABLE1@']
@@ -48,16 +48,16 @@ def generate_test_description(ready_fn):
     launch_description.add_action(executable_2)
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 
 
 class TestTwoExecutables(unittest.TestCase):
 
-    def @TEST_NAME@(self, executable_2):
+    def @TEST_NAME@(self, executable_2, proc_info):
         """Test that the second executable terminates after a finite amount of time."""
-        self.proc_info.assertWaitForShutdown(process=executable_2, timeout=60)
+        proc_info.assertWaitForShutdown(process=executable_2, timeout=60)
 
 
 @launch_testing.post_shutdown_test()

--- a/test_security/test/test_secure_publisher_subscriber.py.in
+++ b/test_security/test/test_secure_publisher_subscriber.py.in
@@ -6,14 +6,14 @@ import os
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 
 import unittest
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     # TODO Timestamping tests via the node's namespace is no longer appropriate,
     # given the FQN is used to lookup security artifacts from secure root directory.
     # namespace = '/test_time_%s' % time.strftime('%H_%M_%S', time.gmtime())
@@ -66,7 +66,7 @@ def generate_test_description(ready_fn):
     launch_description.add_action(subscriber_process)
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 


### PR DESCRIPTION
The ready_fn will be deprecated in the future in favor of the ReadyToTest() action in launch_testing. See ros2/launch#346 (comment) for background information


**Note** I had some trouble getting these tests to build and run locally, so I'll pay extra-close attention to the CI jobs on this one

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>