### PR TITLE
Set log format for test executables.

### DIFF
--- a/test_rclcpp/test/test_executable_output.py.in
+++ b/test_rclcpp/test/test_executable_output.py.in
@@ -9,16 +9,20 @@ import launch_testing
 import launch_testing.asserts
 import launch_testing_ros
 
+import os
 import unittest
 
 
 def generate_test_description(ready_fn):
+    env = os.environ.copy()
+    env['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '[{severity}] [{name}]: {message}'
     launch_description = LaunchDescription()
     proc_under_test = ExecuteProcess(
         cmd=['@TEST_EXECUTABLE@'],
         name='@TEST_EXECUTABLE_NAME@',
         sigterm_timeout='15',
-        output='screen'
+        output='screen',
+        env=env,
     )
     launch_description.add_action(proc_under_test)
     launch_description.add_action(


### PR DESCRIPTION
In order to prevent tests breaking when the default logging format
changes, let's set an explicit log format for these test executables.

The tests are currently breaking because https://github.com/ros2/rcutils/pull/190 changed the default log format.