### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/test_communication/test/test_action_client.cpp
+++ b/test_communication/test/test_action_client.cpp
@@ -55,7 +55,8 @@ send_goals(
   size_t test_index = 0;
   bool invalid_feedback = false;
   auto start = std::chrono::steady_clock::now();
-  RCLCPP_SCOPE_EXIT({
+  RCLCPP_SCOPE_EXIT(
+  {
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<float> diff = (end - start);
     RCLCPP_INFO(logger, "sent goals for %f seconds\n", diff.count());
@@ -191,7 +192,8 @@ generate_nested_message_goal_tests()
     test.result_is_valid =
       [initial_value, expected_result_value](auto result) -> bool {
         if (result->nested_field.int32_value != expected_result_value) {
-          fprintf(stderr, "expected result %d but got %d for initial value %d\n",
+          fprintf(
+            stderr, "expected result %d but got %d for initial value %d\n",
             expected_result_value, result->nested_field.int32_value, initial_value);
           return false;
         }
@@ -200,7 +202,8 @@ generate_nested_message_goal_tests()
     test.feedback_is_valid =
       [initial_value, expected_feedback_value](auto feedback) -> bool {
         if (feedback->nested_different_pkg.sec != expected_feedback_value) {
-          fprintf(stderr, "expected feedback %d but got %d for initial value %d\n",
+          fprintf(
+            stderr, "expected feedback %d but got %d for initial value %d\n",
             expected_feedback_value, feedback->nested_different_pkg.sec, initial_value);
           return false;
         }

--- a/test_communication/test/test_messages_c.cpp
+++ b/test_communication/test/test_messages_c.cpp
@@ -95,7 +95,8 @@ public:
       rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
       ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+      {
         EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
       });
       this->context_ptr = new rcl_context_t;
@@ -731,8 +732,7 @@ void verify_message(test_msgs__msg__Arrays & message, size_t msg_num)
     EXPECT_EQ(expected_msg.uint32_values[i], message.uint32_values[i]);
     EXPECT_EQ(expected_msg.int64_values[i], message.int64_values[i]);
     EXPECT_EQ(expected_msg.uint64_values[i], message.uint64_values[i]);
-    EXPECT_EQ(0, strcmp(expected_msg.string_values[i].data,
-      message.string_values[i].data));
+    EXPECT_EQ(0, strcmp(expected_msg.string_values[i].data, message.string_values[i].data));
   }
 
   auto msg_exit = make_scope_exit(
@@ -935,60 +935,55 @@ void verify_message(test_msgs__msg__UnboundedSequences & message, size_t msg_num
   test_msgs__msg__UnboundedSequences expected_msg;
   get_message(&expected_msg, msg_num);
   for (size_t i = 0; i < expected_msg.bool_values.size; ++i) {
-    EXPECT_EQ(expected_msg.bool_values.data[i],
-      message.bool_values.data[i]);
+    EXPECT_EQ(expected_msg.bool_values.data[i], message.bool_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.byte_values.size; ++i) {
-    EXPECT_EQ(expected_msg.byte_values.data[i],
-      message.byte_values.data[i]);
+    EXPECT_EQ(expected_msg.byte_values.data[i], message.byte_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.char_values.size; ++i) {
-    EXPECT_EQ(expected_msg.char_values.data[i],
-      message.char_values.data[i]);
+    EXPECT_EQ(expected_msg.char_values.data[i], message.char_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.float32_values.size; ++i) {
-    EXPECT_FLOAT_EQ(expected_msg.float32_values.data[i],
-      message.float32_values.data[i]);
+    EXPECT_FLOAT_EQ(
+      expected_msg.float32_values.data[i], message.float32_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.float64_values.size; ++i) {
-    EXPECT_DOUBLE_EQ(expected_msg.float64_values.data[i],
-      message.float64_values.data[i]);
+    EXPECT_DOUBLE_EQ(
+      expected_msg.float64_values.data[i], message.float64_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.int8_values.size; ++i) {
-    EXPECT_EQ(expected_msg.int8_values.data[i],
-      message.int8_values.data[i]);
+    EXPECT_EQ(expected_msg.int8_values.data[i], message.int8_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.uint8_values.size; ++i) {
-    EXPECT_EQ(expected_msg.uint8_values.data[i],
-      message.uint8_values.data[i]);
+    EXPECT_EQ(expected_msg.uint8_values.data[i], message.uint8_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.int16_values.size; ++i) {
-    EXPECT_EQ(expected_msg.int16_values.data[i],
-      message.int16_values.data[i]);
+    EXPECT_EQ(expected_msg.int16_values.data[i], message.int16_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.uint16_values.size; ++i) {
-    EXPECT_EQ(expected_msg.uint16_values.data[i],
-      message.uint16_values.data[i]);
+    EXPECT_EQ(
+      expected_msg.uint16_values.data[i], message.uint16_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.int32_values.size; ++i) {
-    EXPECT_EQ(expected_msg.int32_values.data[i],
-      message.int32_values.data[i]);
+    EXPECT_EQ(expected_msg.int32_values.data[i], message.int32_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.uint32_values.size; ++i) {
-    EXPECT_EQ(expected_msg.uint32_values.data[i],
-      message.uint32_values.data[i]);
+    EXPECT_EQ(
+      expected_msg.uint32_values.data[i], message.uint32_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.int64_values.size; ++i) {
-    EXPECT_EQ(expected_msg.int64_values.data[i],
-      message.int64_values.data[i]);
+    EXPECT_EQ(expected_msg.int64_values.data[i], message.int64_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.uint64_values.size; ++i) {
-    EXPECT_EQ(expected_msg.uint64_values.data[i],
-      message.uint64_values.data[i]);
+    EXPECT_EQ(
+      expected_msg.uint64_values.data[i], message.uint64_values.data[i]);
   }
   for (size_t i = 0; i < expected_msg.string_values.size; ++i) {
-    EXPECT_EQ(0, strcmp(message.string_values.data[i].data,
-      expected_msg.string_values.data[i].data));
+    EXPECT_EQ(
+      0,
+      strcmp(
+        message.string_values.data[i].data,
+        expected_msg.string_values.data[i].data));
   }
 
   auto msg_exit = make_scope_exit(

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -142,18 +142,17 @@ int main(int argc, char ** argv)
   } else if (message == "Arrays") {
     subscriber = subscribe<test_msgs::msg::Arrays>(
       node, message, messages_arrays, received_messages);
-    publish<test_msgs::msg::Arrays>(node, message,
-      messages_arrays);
+    publish<test_msgs::msg::Arrays>(node, message, messages_arrays);
   } else if (message == "UnboundedSequences") {
     subscriber = subscribe<test_msgs::msg::UnboundedSequences>(
       node, message, messages_unbounded_sequences, received_messages);
-    publish<test_msgs::msg::UnboundedSequences>(node, message,
-      messages_unbounded_sequences);
+    publish<test_msgs::msg::UnboundedSequences>(
+      node, message, messages_unbounded_sequences);
   } else if (message == "BoundedSequences") {
     subscriber = subscribe<test_msgs::msg::BoundedSequences>(
       node, message, messages_bounded_sequences, received_messages);
-    publish<test_msgs::msg::BoundedSequences>(node, message,
-      messages_bounded_sequences);
+    publish<test_msgs::msg::BoundedSequences>(
+      node, message, messages_bounded_sequences);
   } else if (message == "MultiNested") {
     subscriber = subscribe<test_msgs::msg::MultiNested>(
       node, message, messages_multi_nested, received_messages);

--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -69,7 +69,8 @@ int request(
         printf("received reply #%zu of %zu\n", service_index + 1, services.size());
         ++service_index;
       } else {
-        fprintf(stderr, "received reply for request #%zu does not match the expected reply\n",
+        fprintf(
+          stderr, "received reply for request #%zu does not match the expected reply\n",
           service_index + 1);
         rc = 2;
         break;

--- a/test_quality_of_service/test/qos_test_publisher.cpp
+++ b/test_quality_of_service/test/qos_test_publisher.cpp
@@ -37,8 +37,8 @@ void QosTestPublisher::publish_message()
   message_buffer << this->name_ << ": testing " << std::to_string(this->increment_count());
   message.data = message_buffer.str();
 
-  RCLCPP_INFO(this->get_logger(), "%s: publishing '%s'",
-    this->name_.c_str(),
+  RCLCPP_INFO(
+    this->get_logger(), "%s: publishing '%s'", this->name_.c_str(),
     message.data.c_str());
   this->publisher_->publish(message);
 }

--- a/test_quality_of_service/test/qos_test_subscriber.cpp
+++ b/test_quality_of_service/test/qos_test_subscriber.cpp
@@ -36,8 +36,8 @@ QosTestSubscriber::QosTestSubscriber(
 
 void QosTestSubscriber::listen_to_message(const std_msgs::msg::String::SharedPtr received_message)
 {
-  RCLCPP_INFO(this->get_logger(), "%s: subscriber heard [%s]",
-    this->name_.c_str(),
+  RCLCPP_INFO(
+    this->get_logger(), "%s: subscriber heard [%s]", this->name_.c_str(),
     received_message->data.c_str());
   this->increment_count();
 }

--- a/test_rclcpp/include/test_rclcpp/utils.hpp
+++ b/test_rclcpp/include/test_rclcpp/utils.hpp
@@ -59,9 +59,9 @@ void wait_for_subscriber(
   }
   int64_t time_slept_count =
     std::chrono::duration_cast<std::chrono::microseconds>(time_slept).count();
-  printf("Waited %" PRId64 " microseconds for the subscriber to %s topic '%s'\n",
-    time_slept_count,
-    to_be_available ? "connect to" : "disconnect from",
+  printf(
+    "Waited %" PRId64 " microseconds for the subscriber to %s topic '%s'\n",
+    time_slept_count, to_be_available ? "connect to" : "disconnect from",
     topic_name.c_str());
 }
 

--- a/test_rclcpp/test/parameter_fixtures.hpp
+++ b/test_rclcpp/test/parameter_fixtures.hpp
@@ -125,8 +125,8 @@ void test_get_parameters_sync(
 {
   printf("Listing parameters with recursive depth\n");
   // Test recursive depth (=0)
-  auto parameters_and_prefixes = parameters_client->list_parameters({"foo", "bar"},
-      rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);
+  auto parameters_and_prefixes = parameters_client->list_parameters(
+    {"foo", "bar"}, rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);
   for (auto & name : parameters_and_prefixes.names) {
     EXPECT_TRUE(name == "foo" || name == "bar" || name == "foo.first" || name == "foo.second");
   }
@@ -190,14 +190,15 @@ void test_get_parameters_sync(
 
   printf("Listing parameters with recursive depth\n");
   // List all of the parameters, using an empty prefix list and depth=0
-  parameters_and_prefixes = parameters_client->list_parameters({},
-      rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);
+  parameters_and_prefixes = parameters_client->list_parameters(
+    {}, rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);
   std::vector<std::string> all_names = {
     "foo", "bar", "barstr", "baz", "foo.first", "foo.second", "foobar", "use_sim_time"
   };
   EXPECT_EQ(parameters_and_prefixes.names.size(), all_names.size());
   for (auto & name : all_names) {
-    EXPECT_NE(std::find(
+    EXPECT_NE(
+      std::find(
         parameters_and_prefixes.names.cbegin(),
         parameters_and_prefixes.names.cend(),
         name),
@@ -208,7 +209,8 @@ void test_get_parameters_sync(
   parameters_and_prefixes = parameters_client->list_parameters({}, 100);
   EXPECT_EQ(parameters_and_prefixes.names.size(), all_names.size());
   for (auto & name : all_names) {
-    EXPECT_NE(std::find(
+    EXPECT_NE(
+      std::find(
         parameters_and_prefixes.names.cbegin(),
         parameters_and_prefixes.names.cend(),
         name),
@@ -222,7 +224,8 @@ void test_get_parameters_sync(
   };
   EXPECT_EQ(parameters_and_prefixes.names.size(), depth_one_names.size());
   for (auto & name : depth_one_names) {
-    EXPECT_NE(std::find(
+    EXPECT_NE(
+      std::find(
         parameters_and_prefixes.names.cbegin(),
         parameters_and_prefixes.names.cend(),
         name),
@@ -236,8 +239,8 @@ void test_get_parameters_async(
 {
   printf("Listing parameters with recursive depth\n");
   // Test recursive depth (=0)
-  auto result = parameters_client->list_parameters({"foo", "bar"},
-      rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);
+  auto result = parameters_client->list_parameters(
+    {"foo", "bar"}, rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);
   rclcpp::spin_until_future_complete(node, result);
   auto parameters_and_prefixes = result.get();
   for (auto & name : parameters_and_prefixes.names) {
@@ -311,8 +314,8 @@ void test_get_parameters_async(
 
   printf("Listing parameters with recursive depth\n");
   // List all of the parameters, using an empty prefix list
-  auto result5 = parameters_client->list_parameters({},
-      rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);
+  auto result5 = parameters_client->list_parameters(
+    {}, rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE);
   rclcpp::spin_until_future_complete(node, result5);
   parameters_and_prefixes = result5.get();
   std::vector<std::string> all_names = {
@@ -320,7 +323,8 @@ void test_get_parameters_async(
   };
   EXPECT_EQ(parameters_and_prefixes.names.size(), all_names.size());
   for (auto & name : all_names) {
-    EXPECT_NE(std::find(
+    EXPECT_NE(
+      std::find(
         parameters_and_prefixes.names.cbegin(),
         parameters_and_prefixes.names.cend(),
         name),

--- a/test_rclcpp/test/test_client_scope_client.cpp
+++ b/test_rclcpp/test/test_client_scope_client.cpp
@@ -49,8 +49,9 @@ TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_regression_test
     printf("sending first request\n");
     std::cout.flush();
     auto result1 = client1->async_send_request(request1);
-    if (rclcpp::spin_until_future_complete(node,
-      result1) != rclcpp::executor::FutureReturnCode::SUCCESS)
+    if (
+      rclcpp::spin_until_future_complete(node, result1) !=
+      rclcpp::executor::FutureReturnCode::SUCCESS)
     {
       FAIL();
     }

--- a/test_rclcpp/test/test_intra_process.cpp
+++ b/test_rclcpp/test/test_intra_process.cpp
@@ -144,7 +144,8 @@ TEST(CLASSNAME(test_intra_process_within_one_node, RMW_IMPLEMENTATION), nominal_
       int i = 0;
       executor.spin_node_once(node, std::chrono::milliseconds(0));
       while ((counter == 3 || counter == 4) && i < max_loops) {
-        printf("spin_node_some() - callback (%s) expected - try %d/%d\n",
+        printf(
+          "spin_node_some() - callback (%s) expected - try %d/%d\n",
           counter == 3 ? "4 and 5" : "5", ++i, max_loops);
         std::this_thread::sleep_for(sleep_per_loop);
         executor.spin_node_once(node, std::chrono::milliseconds(0));

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -126,23 +126,25 @@ public:
     using rclcpp::Parameter;
     using SetParametersResult =
       std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>>;
-    auto set_parameters_results = parameters_client_->set_parameters({
+    auto parameters = {
       Parameter("foo", 2),
       Parameter("bar", "hello"),
       Parameter("barstr", std::string("hello_str")),
       Parameter("baz", 1.45),
       Parameter("foobar", true),
       Parameter("barfoo", std::vector<uint8_t>{3, 4, 5}),
-    },
-        [&executor](SetParametersResult future)
-        {
-          printf("Got set_parameters result\n");
-          // Check to see if they were set.
-          for (auto & result : future.get()) {
-            ASSERT_TRUE(result.successful);
-          }
-          executor.cancel();
+    };
+    auto set_parameters_results = parameters_client_->set_parameters(
+      parameters,
+      [&executor](SetParametersResult future)
+      {
+        printf("Got set_parameters result\n");
+        // Check to see if they were set.
+        for (auto & result : future.get()) {
+          ASSERT_TRUE(result.successful);
         }
+        executor.cancel();
+      }
     );
   }
 
@@ -178,7 +180,8 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   if (!parameters_client->wait_for_service(20s)) {
     ASSERT_TRUE(false) << "service not available after waiting";
   }
-  auto set_parameters_results = parameters_client->set_parameters({
+  auto set_parameters_results = parameters_client->set_parameters(
+  {
     rclcpp::Parameter("foo", 2),
     rclcpp::Parameter("bar", "hello"),
     rclcpp::Parameter("barstr", std::string("hello_str")),
@@ -201,7 +204,8 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
 
   // Test variables that are set, verifying that types are obeyed, and defaults not used.
   EXPECT_TRUE(parameters_client->has_parameter("foo"));
-  EXPECT_THROW(baz = parameters_client->get_parameter<double>("foo"),
+  EXPECT_THROW(
+    baz = parameters_client->get_parameter<double>("foo"),
     rclcpp::ParameterTypeException);
   EXPECT_NO_THROW(foo = parameters_client->get_parameter<int>("foo"));
   EXPECT_EQ(foo, 2);
@@ -209,7 +213,8 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_EQ(foo, 2);
 
   EXPECT_TRUE(parameters_client->has_parameter("bar"));
-  EXPECT_THROW(foo = parameters_client->get_parameter<int>("bar"),
+  EXPECT_THROW(
+    foo = parameters_client->get_parameter<int>("bar"),
     rclcpp::ParameterTypeException);
   EXPECT_NO_THROW(bar = parameters_client->get_parameter<std::string>("bar"));
   EXPECT_EQ(bar, "hello");
@@ -217,7 +222,8 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_EQ(bar, "hello");
 
   EXPECT_TRUE(parameters_client->has_parameter("barstr"));
-  EXPECT_THROW(foobar = parameters_client->get_parameter<bool>("barstr"),
+  EXPECT_THROW(
+    foobar = parameters_client->get_parameter<bool>("barstr"),
     rclcpp::ParameterTypeException);
   EXPECT_NO_THROW(barstr = parameters_client->get_parameter<std::string>("barstr"));
   EXPECT_EQ(barstr, "hello_str");
@@ -225,7 +231,8 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_EQ(barstr, "hello_str");
 
   EXPECT_TRUE(parameters_client->has_parameter("baz"));
-  EXPECT_THROW(foobar = parameters_client->get_parameter<bool>("baz"),
+  EXPECT_THROW(
+    foobar = parameters_client->get_parameter<bool>("baz"),
     rclcpp::ParameterTypeException);
   EXPECT_NO_THROW(baz = parameters_client->get_parameter<double>("baz"));
   EXPECT_DOUBLE_EQ(baz, 1.45);
@@ -233,7 +240,8 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_DOUBLE_EQ(baz, 1.45);
 
   EXPECT_TRUE(parameters_client->has_parameter("foobar"));
-  EXPECT_THROW(baz = parameters_client->get_parameter<double>("foobar"),
+  EXPECT_THROW(
+    baz = parameters_client->get_parameter<double>("foobar"),
     rclcpp::ParameterTypeException);
   EXPECT_NO_THROW(foobar = parameters_client->get_parameter<bool>("foobar"));
   EXPECT_EQ(foobar, true);
@@ -241,14 +249,15 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_EQ(foobar, true);
 
   EXPECT_TRUE(parameters_client->has_parameter("barfoo"));
-  EXPECT_THROW(bar = parameters_client->get_parameter<std::string>("barfoo"),
+  EXPECT_THROW(
+    bar = parameters_client->get_parameter<std::string>("barfoo"),
     rclcpp::ParameterTypeException);
   EXPECT_NO_THROW(barfoo = parameters_client->get_parameter<std::vector<uint8_t>>("barfoo"));
   EXPECT_EQ(barfoo[0], 0);
   EXPECT_EQ(barfoo[1], 1);
   EXPECT_EQ(barfoo[2], 2);
-  EXPECT_NO_THROW(barfoo =
-    parameters_client->get_parameter("barfoo", std::vector<uint8_t>{3, 4, 5}));
+  EXPECT_NO_THROW(
+    barfoo = parameters_client->get_parameter("barfoo", std::vector<uint8_t>{3, 4, 5}));
   EXPECT_EQ(barfoo[0], 0);
   EXPECT_EQ(barfoo[1], 1);
   EXPECT_EQ(barfoo[2], 2);
@@ -260,8 +269,8 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_THROW(parameters_client->get_parameter<std::string>("not_there"), std::runtime_error);
   EXPECT_THROW(parameters_client->get_parameter<double>("not_there"), std::runtime_error);
   EXPECT_THROW(parameters_client->get_parameter<bool>("not_there"), std::runtime_error);
-  EXPECT_THROW(parameters_client->get_parameter<std::vector<uint8_t>>(
-      "not_there"), std::runtime_error);
+  EXPECT_THROW(
+    parameters_client->get_parameter<std::vector<uint8_t>>("not_there"), std::runtime_error);
 
   // Test a variable that's not set, checking that we correctly get the specified default.
   EXPECT_NO_THROW(foo = parameters_client->get_parameter("not_there", 42));
@@ -274,8 +283,8 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_DOUBLE_EQ(baz, -4.2);
   EXPECT_NO_THROW(foobar = parameters_client->get_parameter("not_there", false));
   EXPECT_EQ(foobar, false);
-  EXPECT_NO_THROW(barfoo =
-    parameters_client->get_parameter("not_there", std::vector<uint8_t>{3, 4, 5}));
+  EXPECT_NO_THROW(
+    barfoo = parameters_client->get_parameter("not_there", std::vector<uint8_t>{3, 4, 5}));
   EXPECT_EQ(barfoo[0], 3);
   EXPECT_EQ(barfoo[1], 4);
   EXPECT_EQ(barfoo[2], 5);
@@ -295,7 +304,8 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_primiti
   if (!parameters_client->wait_for_service(20s)) {
     ASSERT_TRUE(false) << "service not available after waiting";
   }
-  auto set_parameters_results = parameters_client->set_parameters({
+  auto set_parameters_results = parameters_client->set_parameters(
+  {
     rclcpp::Parameter("foo", 2),
     rclcpp::Parameter("bar", "hello"),
     rclcpp::Parameter("barstr", std::string("hello_str")),
@@ -368,7 +378,8 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_variant
   if (!parameters_client->wait_for_service(20s)) {
     ASSERT_TRUE(false) << "service not available after waiting";
   }
-  auto set_parameters_results = parameters_client->set_parameters({
+  auto set_parameters_results = parameters_client->set_parameters(
+  {
     Parameter("foo", 2),
     Parameter("bar", "hello"),
     Parameter("barstr", std::string("hello_str")),

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -48,8 +48,8 @@ static inline void multi_consumer_pub_sub_test(bool intra_process)
 
   rclcpp::executors::MultiThreadedExecutor executor;
 
-  auto node = rclcpp::Node::make_shared(node_topic_name,
-      rclcpp::NodeOptions().use_intra_process_comms(intra_process));
+  auto node = rclcpp::Node::make_shared(
+    node_topic_name, rclcpp::NodeOptions().use_intra_process_comms(intra_process));
   auto callback_group = node->create_callback_group(
     rclcpp::callback_group::CallbackGroupType::Reentrant);
   const size_t num_messages = std::min<size_t>(executor.get_number_of_threads(), 16);

--- a/test_rclcpp/test/test_remote_parameters.cpp
+++ b/test_rclcpp/test/test_remote_parameters.cpp
@@ -41,8 +41,8 @@ TEST(CLASSNAME(parameters, rmw_implementation), test_remote_parameters_async) {
 
   auto node = rclcpp::Node::make_shared(std::string("test_remote_parameters_async"));
 
-  auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(node,
-      test_server_name);
+  auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(
+    node, test_server_name);
   if (!parameters_client->wait_for_service(20s)) {
     ASSERT_TRUE(false) << "service not available after waiting";
   }
@@ -58,8 +58,8 @@ TEST(CLASSNAME(parameters, rmw_implementation), test_remote_parameters_sync) {
 
   auto node = rclcpp::Node::make_shared(std::string("test_remote_parameters_sync"));
 
-  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node,
-      test_server_name);
+  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(
+    node, test_server_name);
   if (!parameters_client->wait_for_service(20s)) {
     ASSERT_TRUE(false) << "service not available after waiting";
   }
@@ -75,8 +75,8 @@ TEST(CLASSNAME(parameters, rmw_implementation), test_set_remote_parameters_atomi
 
   auto node = rclcpp::Node::make_shared(std::string("test_set_remote_parameters_atomically_sync"));
 
-  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node,
-      test_server_name);
+  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(
+    node, test_server_name);
   if (!parameters_client->wait_for_service(20s)) {
     ASSERT_TRUE(false) << "service not available after waiting";
   }

--- a/test_rclcpp/test/test_spin.cpp
+++ b/test_rclcpp/test/test_spin.cpp
@@ -141,7 +141,8 @@ TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete) {
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
-  ASSERT_EQ(executor.spin_until_future_complete(future),
+  ASSERT_EQ(
+    executor.spin_until_future_complete(future),
     rclcpp::executor::FutureReturnCode::SUCCESS);
   EXPECT_EQ(future.get(), true);
 }
@@ -160,11 +161,13 @@ TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete_timeou
     };
   auto timer = node->create_wall_timer(std::chrono::milliseconds(50), callback);
 
-  ASSERT_EQ(rclcpp::spin_until_future_complete(node, future, std::chrono::milliseconds(25)),
+  ASSERT_EQ(
+    rclcpp::spin_until_future_complete(node, future, std::chrono::milliseconds(25)),
     rclcpp::executor::FutureReturnCode::TIMEOUT);
 
   // If we wait a little longer, we should complete the future
-  ASSERT_EQ(rclcpp::spin_until_future_complete(node, future, std::chrono::milliseconds(50)),
+  ASSERT_EQ(
+    rclcpp::spin_until_future_complete(node, future, std::chrono::milliseconds(50)),
     rclcpp::executor::FutureReturnCode::SUCCESS);
 
   EXPECT_EQ(future.get(), true);
@@ -190,7 +193,8 @@ TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete_interr
     };
   auto shutdown_timer = node->create_wall_timer(std::chrono::milliseconds(25), shutdown_callback);
 
-  ASSERT_EQ(rclcpp::spin_until_future_complete(node, future, std::chrono::milliseconds(50)),
+  ASSERT_EQ(
+    rclcpp::spin_until_future_complete(node, future, std::chrono::milliseconds(50)),
     rclcpp::executor::FutureReturnCode::INTERRUPTED);
 }
 

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -218,7 +218,8 @@ public:
 };
 
 // Shortened version of the test for the ConstSharedPtr callback signature in a method
-TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION),
+TEST(
+  CLASSNAME(test_subscription, RMW_IMPLEMENTATION),
   subscription_shared_ptr_const_method_std_function
 ) {
   if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
@@ -250,7 +251,8 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION),
 }
 
 // Shortened version of the test for the ConstSharedPtr callback signature in a method
-TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION),
+TEST(
+  CLASSNAME(test_subscription, RMW_IMPLEMENTATION),
   subscription_shared_ptr_const_method_direct
 ) {
   if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.