### PR TITLE
Setting AMENT_CMAKE_CPPCHECK_ADDITIONAL_INCLUDE_DIRS with rclcpp

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -13,6 +13,9 @@ endif()
 find_package(ament_cmake REQUIRED)
 
 if(BUILD_TESTING)
+  find_package(rclcpp REQUIRED)
+  set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rclcpp_INCLUDE_DIRS})
+
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 


### PR DESCRIPTION
I'm not sure why this is not showing up yet on ci.ros2.org, but cppcheck fails to find some macros in test_rclcpp. This sets the appropriate ament_cmake variable to find their definitions.

Example failure:
http://build.ros2.org/view/Fci/job/Fci__nightly-debug_ubuntu_focal_amd64/lastCompletedBuild/testReport/

https://ci.ros2.org/view/nightly/job/nightly_windows-container_release/4/testReport/(root)/projectroot/cppcheck_2/

Builds with this PR
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9439)](http://ci.ros2.org/job/ci_linux/9439/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5127)](http://ci.ros2.org/job/ci_linux-aarch64/5127/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7719)](http://ci.ros2.org/job/ci_osx/7719/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9366)](http://ci.ros2.org/job/ci_windows/9366/)
* Windows-container [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows-container&build=211)](http://ci.ros2.org/job/ci_windows-container/211/)