### PR TITLE
Update the expected exception thrown when getting an invalid parameter type

### DIFF
--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -206,7 +206,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_TRUE(parameters_client->has_parameter("foo"));
   EXPECT_THROW(
     baz = parameters_client->get_parameter<double>("foo"),
-    rclcpp::ParameterTypeException);
+    rclcpp::exceptions::InvalidParameterTypeException);
   EXPECT_NO_THROW(foo = parameters_client->get_parameter<int>("foo"));
   EXPECT_EQ(foo, 2);
   EXPECT_NO_THROW(foo = parameters_client->get_parameter("foo", 42));
@@ -215,7 +215,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_TRUE(parameters_client->has_parameter("bar"));
   EXPECT_THROW(
     foo = parameters_client->get_parameter<int>("bar"),
-    rclcpp::ParameterTypeException);
+    rclcpp::exceptions::InvalidParameterTypeException);
   EXPECT_NO_THROW(bar = parameters_client->get_parameter<std::string>("bar"));
   EXPECT_EQ(bar, "hello");
   EXPECT_NO_THROW(bar = parameters_client->get_parameter<std::string>("bar", "goodbye"));
@@ -224,7 +224,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_TRUE(parameters_client->has_parameter("barstr"));
   EXPECT_THROW(
     foobar = parameters_client->get_parameter<bool>("barstr"),
-    rclcpp::ParameterTypeException);
+    rclcpp::exceptions::InvalidParameterTypeException);
   EXPECT_NO_THROW(barstr = parameters_client->get_parameter<std::string>("barstr"));
   EXPECT_EQ(barstr, "hello_str");
   EXPECT_NO_THROW(barstr = parameters_client->get_parameter("barstr", std::string("heya")));
@@ -233,7 +233,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_TRUE(parameters_client->has_parameter("baz"));
   EXPECT_THROW(
     foobar = parameters_client->get_parameter<bool>("baz"),
-    rclcpp::ParameterTypeException);
+    rclcpp::exceptions::InvalidParameterTypeException);
   EXPECT_NO_THROW(baz = parameters_client->get_parameter<double>("baz"));
   EXPECT_DOUBLE_EQ(baz, 1.45);
   EXPECT_NO_THROW(baz = parameters_client->get_parameter("baz", -4.2));
@@ -242,7 +242,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_TRUE(parameters_client->has_parameter("foobar"));
   EXPECT_THROW(
     baz = parameters_client->get_parameter<double>("foobar"),
-    rclcpp::ParameterTypeException);
+    rclcpp::exceptions::InvalidParameterTypeException);
   EXPECT_NO_THROW(foobar = parameters_client->get_parameter<bool>("foobar"));
   EXPECT_EQ(foobar, true);
   EXPECT_NO_THROW(foobar = parameters_client->get_parameter("foobar", false));
@@ -251,7 +251,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_TRUE(parameters_client->has_parameter("barfoo"));
   EXPECT_THROW(
     bar = parameters_client->get_parameter<std::string>("barfoo"),
-    rclcpp::ParameterTypeException);
+    rclcpp::exceptions::InvalidParameterTypeException);
   EXPECT_NO_THROW(barfoo = parameters_client->get_parameter<std::vector<uint8_t>>("barfoo"));
   EXPECT_EQ(barfoo[0], 0);
   EXPECT_EQ(barfoo[1], 1);
@@ -335,7 +335,9 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_primiti
   EXPECT_EQ(2, foo);
 
   // Throw on type error
-  EXPECT_THROW(got_param = node->get_parameter("foo", foostr), rclcpp::ParameterTypeException);
+  EXPECT_THROW(
+    got_param = node->get_parameter("foo", foostr),
+    rclcpp::exceptions::InvalidParameterTypeException);
 
   // No throw on non-existent param, param shouldn't change
   foo = 1000;


### PR DESCRIPTION
The type of the exception was changed in https://github.com/ros2/rclcpp/pull/1027