### PR TITLE
Change which node name cross-vendor tests are enabled.

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -210,22 +210,32 @@ if(BUILD_TESTING)
       set(rmw_implementation2_is_cyclonedds TRUE)
     endif()
 
-    # Skipped tests between fastrtps and others, as the node names are communicated with a different mechanism.
-    # TODO(ivanpauno): Reenable this tests after the other implementations also use one Participant per Context.
-    if(
-      (rmw_implementation1_is_fastrtps AND rmw_implementation2_is_cyclonedds) OR
-      (rmw_implementation1_is_cyclonedds AND rmw_implementation2_is_fastrtps) OR
-      (rmw_implementation1_is_cyclonedds AND rmw_implementation2_is_cyclonedds) OR
-      (rmw_implementation1_is_connext AND rmw_implementation2_is_connext) OR
-      (rmw_implementation1_is_fastrtps AND rmw_implementation2_is_fastrtps)
-    )
-      custom_launch_test_two_executables(test_node_name
-        node_with_name node_name_list
-        ARGS1 "${rmw_implementation1}" ARGS2 "node_with_name_${rmw_implementation1}"
-        RMW1 ${rmw_implementation1} RMW2 ${rmw_implementation2}
-        TIMEOUT 15
-        ${SKIP_TEST})
+
+    # Whitelist cross-vendor tests
+    if (NOT (rmw_implementation1 STREQUAL rmw_implementation2))
+      # TODO(sloretz) enable connext/cyclone/fastrtps when all three use 1 participant per context
+      if(
+        (rmw_implementation1_is_fastrtps AND rmw_implementation2_is_cyclonedds) OR
+        (rmw_implementation1_is_cyclonedds AND rmw_implementation2_is_fastrtps) OR
+        (rmw_implementation1_is_fastrtps AND rmw_implementation2_is_fastrtps)
+      )
+        # Whitelisted cross-vendor tests
+        set(_crt_SKIP_TEST ${SKIP_TEST})
+      else()
+        # Default skip cross-vendor tests
+        set(_crt_SKIP_TEST "SKIP_TEST")
+      endif()
+    else()
+      # Same vendor tests always allowed
+      set(_crt_SKIP_TEST ${SKIP_TEST})
     endif()
+
+    custom_launch_test_two_executables(test_node_name
+      node_with_name node_name_list
+      ARGS1 "${rmw_implementation1}" ARGS2 "node_with_name_${rmw_implementation1}"
+      RMW1 ${rmw_implementation1} RMW2 ${rmw_implementation2}
+      TIMEOUT 15
+      ${_crt_SKIP_TEST})
   endmacro()
 
   macro(targets)

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -192,10 +192,31 @@ if(BUILD_TESTING)
       set(rmw_implementation2_is_fastrtps TRUE)
     endif()
 
+    set(rmw_implementation1_is_connext FALSE)
+    set(rmw_implementation2_is_connext FALSE)
+    if(rmw_implementation1 MATCHES "(.*)connext(.*)")
+      set(rmw_implementation1_is_connext TRUE)
+    endif()
+    if(rmw_implementation2 MATCHES "(.*)connext(.*)")
+      set(rmw_implementation2_is_connext TRUE)
+    endif()
+
+    set(rmw_implementation1_is_cyclonedds FALSE)
+    set(rmw_implementation2_is_cyclonedds FALSE)
+    if(rmw_implementation1 MATCHES "(.*)cyclonedds(.*)")
+      set(rmw_implementation1_is_cyclonedds TRUE)
+    endif()
+    if(rmw_implementation2 MATCHES "(.*)cyclonedds(.*)")
+      set(rmw_implementation2_is_cyclonedds TRUE)
+    endif()
+
     # Skipped tests between fastrtps and others, as the node names are communicated with a different mechanism.
     # TODO(ivanpauno): Reenable this tests after the other implementations also use one Participant per Context.
     if(
-      (NOT rmw_implementation1_is_fastrtps AND NOT rmw_implementation2_is_fastrtps) OR
+      (rmw_implementation1_is_fastrtps AND rmw_implementation2_is_cyclonedds) OR
+      (rmw_implementation1_is_cyclonedds AND rmw_implementation2_is_fastrtps) OR
+      (rmw_implementation1_is_cyclonedds AND rmw_implementation2_is_cyclonedds) OR
+      (rmw_implementation1_is_connext AND rmw_implementation2_is_connext) OR
       (rmw_implementation1_is_fastrtps AND rmw_implementation2_is_fastrtps)
     )
       custom_launch_test_two_executables(test_node_name

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -212,7 +212,7 @@ if(BUILD_TESTING)
 
 
     # Whitelist cross-vendor tests
-    if (NOT (rmw_implementation1 STREQUAL rmw_implementation2))
+    if(NOT (rmw_implementation1 STREQUAL rmw_implementation2))
       # TODO(sloretz) enable connext/cyclone/fastrtps when all three use 1 participant per context
       if(
         (rmw_implementation1_is_fastrtps AND rmw_implementation2_is_cyclonedds) OR


### PR DESCRIPTION
Currently `test_nodes_name` is enabled for fastrtps/fastrtps and  cyclonedds/connext. Cyclonedds uses one participant per context (ros2/rmw_cyclonedds#145) while Connext uses 1 participant per node (ros2/rmw_connext#381), so cyclone/connext is not expected to work and is currently failing in the nightlies.

* https://ci.ros2.org/job/nightly_linux_release/1527/testReport/(root)/projectroot/test_node_name__rmw_connext_cpp__rmw_cyclonedds_cpp/
* https://ci.ros2.org/job/nightly_linux_release/1527/testReport/(root)/projectroot/test_node_name__rmw_cyclonedds_cpp__rmw_connext_cpp/


This PR changes to what should work. FastRTPS uses 1 participant per context (https://github.com/ros2/rmw_fastrtps#312), so it should work with itself and Cyclonedds. Connext should only work with itself.

However, it turns out all cross-vendor tests are failing to communicate node names to each other 

```
The following tests FAILED:
	 47 - test_node_name__rmw_cyclonedds_cpp__rmw_fastrtps_cpp (Failed)
	 48 - test_node_name__rmw_cyclonedds_cpp__rmw_fastrtps_dynamic_cpp (Failed)
	 71 - test_node_name__rmw_fastrtps_cpp__rmw_cyclonedds_cpp (Failed)
	 96 - test_node_name__rmw_fastrtps_dynamic_cpp__rmw_cyclonedds_cpp (Failed)
```

@ivanpauno ideas on why fastrtps/cyclonedds are failing to communicate node names?