### PR TITLE
Make `test_executor.spin_some_max_duration` more reliable

### DIFF
--- a/test_rclcpp/test/test_executor.cpp
+++ b/test_rclcpp/test/test_executor.cpp
@@ -77,7 +77,7 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), spin_some_max_duration) {
   executor.spin_some(max_duration);
   const auto end = std::chrono::steady_clock::now();
   ASSERT_LT(max_duration, end - start);
-  ASSERT_GT(max_duration + 200ms, end - start);
+  ASSERT_GT(max_duration + 500ms, end - start);
 }
 
 TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), multithreaded_spin_call) {

--- a/test_rclcpp/test/test_executor.cpp
+++ b/test_rclcpp/test/test_executor.cpp
@@ -64,8 +64,8 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), spin_some_max_duration) {
       std::this_thread::sleep_for(100ms);
     };
   std::vector<std::shared_ptr<rclcpp::WallTimer<decltype(lambda)>>> timers;
-  // creating 20 timers which will try to do 1 ms of work each
-  // only about 10ms worth of them should actually be performed
+  // creating 20 timers which will try to do 100 ms of work each
+  // only about 1s worth of them should actually be performed
   for (int i = 0; i < 20; i++) {
     auto timer = node->create_wall_timer(0s, lambda);
     timers.push_back(timer);

--- a/test_rclcpp/test/test_executor.cpp
+++ b/test_rclcpp/test/test_executor.cpp
@@ -77,7 +77,7 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), spin_some_max_duration) {
   executor.spin_some(max_duration);
   const auto end = std::chrono::steady_clock::now();
   ASSERT_LT(max_duration, end - start);
-  ASSERT_GT(max_duration + 100ms, end - start);
+  ASSERT_GT(max_duration + 200ms, end - start);
 }
 
 TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), multithreaded_spin_call) {

--- a/test_rclcpp/test/test_executor.cpp
+++ b/test_rclcpp/test/test_executor.cpp
@@ -61,7 +61,7 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), spin_some_max_duration) {
   rclcpp::executors::SingleThreadedExecutor executor;
   auto node = rclcpp::Node::make_shared("spin_some_max_duration");
   auto lambda = []() {
-      std::this_thread::sleep_for(1ms);
+      std::this_thread::sleep_for(100ms);
     };
   std::vector<std::shared_ptr<rclcpp::WallTimer<decltype(lambda)>>> timers;
   // creating 20 timers which will try to do 1 ms of work each
@@ -72,12 +72,12 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), spin_some_max_duration) {
   }
   executor.add_node(node);
 
-  const auto max_duration = 10ms;
+  const auto max_duration = 1s;
   const auto start = std::chrono::steady_clock::now();
   executor.spin_some(max_duration);
   const auto end = std::chrono::steady_clock::now();
   ASSERT_LT(max_duration, end - start);
-  ASSERT_GT(max_duration + 5ms, end - start);
+  ASSERT_GT(max_duration + 100ms, end - start);
 }
 
 TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), multithreaded_spin_call) {


### PR DESCRIPTION
Fixes https://ci.ros2.org/view/nightly/job/nightly_win_rel/1537/testReport/junit/test_rclcpp/test_executor__rmw_cyclonedds_cpp/spin_some_max_duration/.

Considering that the Windows scheduler time slice is [20ms](https://docs.microsoft.com/en-us/windows/win32/procthread/multitasking), the test is being too optimistic (same applies for macOS and Linux, though it was only failing on Windows).

I increased all durations, to ensure that the OS time slice doesn't represent a big fraction of it.