### PR TITLE
remove invalid cert folder to force regeneration of certificates

### DIFF
--- a/test_security/CMakeLists.txt
+++ b/test_security/CMakeLists.txt
@@ -332,6 +332,7 @@ if(BUILD_TESTING)
     find_program(PROGRAM ros2)
 
     set(node_names_list "/publisher;/subscriber;/publisher_missing_key;/publisher_invalid_cert")
+    file(REMOVE_RECURSE "${KEYSTORE_DIRECTORY}/enclaves/publisher_invalid_cert")
     set(generate_artifacts_command ${PROGRAM} security generate_artifacts -k ${KEYSTORE_DIRECTORY_NATIVE_PATH} -e ${node_names_list})
     execute_process(
       COMMAND ${generate_artifacts_command}


### PR DESCRIPTION
Fixes https://github.com/ros2/system_tests/issues/432

This package artificially creates an invalid certificate for testing purposes. If compiling twice in a row, the invalid certificate is used to sign material and fails. This PR deletes the existing invalid certificate (and all the material related to this enclave), this ensures the regeneration of all material related to that enclave on rebuild.
 
Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>