### PR TITLE
Remove ament_pytest dependency from test_rclcpp.

### DIFF
--- a/test_rclcpp/package.xml
+++ b/test_rclcpp/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>launch</test_depend>


### PR DESCRIPTION
It is not used in test_rclcpp anywhere.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>