### PR TITLE
show numbers of nanseconds in EXPECT with durations

### DIFF
--- a/test_rclcpp/test/test_timeout_subscriber.cpp
+++ b/test_rclcpp/test/test_timeout_subscriber.cpp
@@ -67,7 +67,7 @@ TEST(CLASSNAME(test_timeout_subscriber, RMW_IMPLEMENTATION), timeout_subscriber)
     auto blocking_diff = blocking_end - blocking_start;
     EXPECT_LT(
       std::chrono::duration_cast<std::chrono::nanoseconds>(blocking_diff).count(),
-      std::chrono::duration_cast<std::chrono::nanoseconds>(blocking_timeout + tolerance).count();
+      std::chrono::duration_cast<std::chrono::nanoseconds>(blocking_timeout + tolerance).count());
   }
 
   rclcpp::shutdown();

--- a/test_rclcpp/test/test_timeout_subscriber.cpp
+++ b/test_rclcpp/test/test_timeout_subscriber.cpp
@@ -55,7 +55,9 @@ TEST(CLASSNAME(test_timeout_subscriber, RMW_IMPLEMENTATION), timeout_subscriber)
     executor.spin_node_once(node, std::chrono::milliseconds::zero());
     auto nonblocking_end = std::chrono::steady_clock::now();
     auto nonblocking_diff = nonblocking_end - nonblocking_start;
-    EXPECT_LT(nonblocking_diff, tolerance);
+    EXPECT_LT(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(nonblocking_diff).count(),
+      std::chrono::duration_cast<std::chrono::nanoseconds>(tolerance).count());
 
     // ensure that the blocking spin does return after the specified timeout
     auto blocking_timeout = std::chrono::milliseconds(100);
@@ -63,7 +65,9 @@ TEST(CLASSNAME(test_timeout_subscriber, RMW_IMPLEMENTATION), timeout_subscriber)
     executor.spin_node_once(node, blocking_timeout);
     auto blocking_end = std::chrono::steady_clock::now();
     auto blocking_diff = blocking_end - blocking_start;
-    EXPECT_LT(blocking_diff, blocking_timeout + tolerance);
+    EXPECT_LT(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(blocking_diff).count(),
+      std::chrono::duration_cast<std::chrono::nanoseconds>(blocking_timeout + tolerance).count();
   }
 
   rclcpp::shutdown();


### PR DESCRIPTION
When the test fails this actually show the nanoseconds of each duration rather than an `8-byte object`.

Allows to triage this long time failing test: https://ci.ros2.org/view/nightly/job/nightly_win_rel/1598/testReport/(root)/projectroot/gtest_timeout_subscriber__rmw_connext_cpp/

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11338)](http://ci.ros2.org/job/ci_linux/11338/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6575)](http://ci.ros2.org/job/ci_linux-aarch64/6575/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9301)](http://ci.ros2.org/job/ci_osx/9301/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11235)](http://ci.ros2.org/job/ci_windows/11235/)