### PR TITLE
Update deprecated gtest macros

### DIFF
--- a/test_security/test/test_invalid_secure_node_creation_c.cpp
+++ b/test_security/test/test_invalid_secure_node_creation_c.cpp
@@ -170,7 +170,7 @@ std::vector<TestConfig> test_configs {
   },
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   TestInitializationFails,
   TestSecureNodes,
   ::testing::ValuesIn(test_configs),


### PR DESCRIPTION
This PR updates `INSTANTIATE_TEST_CASE_P` to `-INSTANTIATE_TEST_SUITE_P`.
