### PR TITLE
Set cppcheck timeout to 400 seconds

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -388,3 +388,8 @@ endif()  # BUILD_TESTING
 
 # TODO should not install anything
 ament_package()
+
+if(TEST cppcheck)
+  # cppcheck test is created in hook in ament_package()
+  set_tests_properties(cppcheck PROPERTIES TIMEOUT 400)
+endif()


### PR DESCRIPTION
The `test_rclcpp` cppcheck test timed out after 300 seconds in the latest Windows release nightly. Previous jobs took 273, 220, and 217 seconds. This increases it to 400.

There doesn't seem to be plumbing for setting a timeout with ament_cppcheck, so this sets the timeout on the test target directly.

https://ci.ros2.org/view/nightly/job/nightly_win_rel/1761