### PR TITLE
Call rclcpp::init and rclcpp::shutdown in each test for test_rclcpp

### DIFF
--- a/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
+++ b/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
@@ -32,13 +32,17 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-class CLASSNAME (test_avoid_ros_namespace_conventions_qos, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_avoid_ros_namespace_conventions_qos, RMW_IMPLEMENTATION)
+  : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
+++ b/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
@@ -32,12 +32,22 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
+class CLASSNAME (test_avoid_ros_namespace_conventions_qos, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
 // Test communciation works with the avoid_ros_namespace_conventions QoS enabled.
-TEST(
+TEST_F(
   CLASSNAME(test_avoid_ros_namespace_conventions_qos, RMW_IMPLEMENTATION),
   pub_sub_works
 ) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
   // topic name
   std::string topic_name = "test_avoid_ros_namespace_conventions_qos";
   // code to create the callback and subscription

--- a/test_rclcpp/test/test_client_scope_client.cpp
+++ b/test_rclcpp/test/test_client_scope_client.cpp
@@ -30,8 +30,18 @@
 
 using namespace std::chrono_literals;
 
-TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_regression_test) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (service_client, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_regression_test) {
   auto node = rclcpp::Node::make_shared("client_scope_regression_test");
 
   // Extra scope so the first client will be deleted afterwards

--- a/test_rclcpp/test/test_client_scope_client.cpp
+++ b/test_rclcpp/test/test_client_scope_client.cpp
@@ -30,13 +30,16 @@
 
 using namespace std::chrono_literals;
 
-class CLASSNAME (service_client, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (service_client, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_client_scope_consistency_client.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_client.cpp
@@ -32,10 +32,20 @@
 
 using namespace std::chrono_literals;
 
+class CLASSNAME (service_client, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
 // This test is concerned with the consistency of the two clients' behavior, not necessarily whether
 // or not they are successful.
-TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_consistency_regression_test) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_consistency_regression_test) {
   auto node = rclcpp::Node::make_shared("client_scope_consistency_regression_test");
 
   // Replicate the settings that caused https://github.com/ros2/system_tests/issues/153

--- a/test_rclcpp/test/test_client_scope_consistency_client.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_client.cpp
@@ -32,13 +32,16 @@
 
 using namespace std::chrono_literals;
 
-class CLASSNAME (service_client, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (service_client, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_client_wait_for_service_shutdown.cpp
+++ b/test_rclcpp/test/test_client_wait_for_service_shutdown.cpp
@@ -29,9 +29,19 @@
 
 using namespace std::chrono_literals;
 
+class CLASSNAME (service_client, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
 // rclcpp::shutdown() should wake up wait_for_service, even without spin.
-TEST(CLASSNAME(service_client, RMW_IMPLEMENTATION), wait_for_service_shutdown) {
-  rclcpp::init(0, nullptr);
+TEST_F(CLASSNAME(service_client, RMW_IMPLEMENTATION), wait_for_service_shutdown) {
   auto node = rclcpp::Node::make_shared("wait_for_service_shutdown");
 
   auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("wait_for_service_shutdown");

--- a/test_rclcpp/test/test_client_wait_for_service_shutdown.cpp
+++ b/test_rclcpp/test/test_client_wait_for_service_shutdown.cpp
@@ -29,13 +29,16 @@
 
 using namespace std::chrono_literals;
 
-class CLASSNAME (service_client, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (service_client, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_executor.cpp
+++ b/test_rclcpp/test/test_executor.cpp
@@ -40,13 +40,16 @@
 
 using namespace std::chrono_literals;
 
-class CLASSNAME (test_executor, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_executor, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_executor.cpp
+++ b/test_rclcpp/test/test_executor.cpp
@@ -40,8 +40,18 @@
 
 using namespace std::chrono_literals;
 
-TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), recursive_spin_call) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (test_executor, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(test_executor, RMW_IMPLEMENTATION), recursive_spin_call) {
   rclcpp::executors::SingleThreadedExecutor executor;
   auto node = rclcpp::Node::make_shared("recursive_spin_call");
   auto timer = node->create_wall_timer(
@@ -56,8 +66,7 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), recursive_spin_call) {
   executor.spin();
 }
 
-TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), spin_some_max_duration) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_executor, RMW_IMPLEMENTATION), spin_some_max_duration) {
   rclcpp::executors::SingleThreadedExecutor executor;
   auto node = rclcpp::Node::make_shared("spin_some_max_duration");
   auto lambda = []() {
@@ -80,8 +89,7 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), spin_some_max_duration) {
   ASSERT_GT(max_duration + 500ms, end - start);
 }
 
-TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), multithreaded_spin_call) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_executor, RMW_IMPLEMENTATION), multithreaded_spin_call) {
   rclcpp::executors::SingleThreadedExecutor executor;
   auto node = rclcpp::Node::make_shared("multithreaded_spin_call");
   std::mutex m;
@@ -113,8 +121,7 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), multithreaded_spin_call) {
 }
 
 // Try spinning 2 single-threaded executors in two separate threads.
-TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), multiple_executors) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_executor, RMW_IMPLEMENTATION), multiple_executors) {
   std::atomic_uint counter1;
   counter1 = 0;
   std::atomic_uint counter2;
@@ -174,8 +181,7 @@ TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), multiple_executors) {
 
 // Check that the executor is notified when a node adds a new timer, publisher, subscription,
 // service or client.
-TEST(CLASSNAME(test_executor, RMW_IMPLEMENTATION), notify) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_executor, RMW_IMPLEMENTATION), notify) {
   rclcpp::executors::SingleThreadedExecutor executor;
   auto executor_spin_lambda = [&executor]() {
       executor.spin();

--- a/test_rclcpp/test/test_intra_process.cpp
+++ b/test_rclcpp/test/test_intra_process.cpp
@@ -33,9 +33,18 @@
 static const std::chrono::milliseconds sleep_per_loop(10);
 static const int max_loops = 200;
 
-TEST(CLASSNAME(test_intra_process_within_one_node, RMW_IMPLEMENTATION), nominal_usage) {
-  rclcpp::init(0, nullptr);
+class CLASSNAME (test_intra_process_within_one_node, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
 
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(test_intra_process_within_one_node, RMW_IMPLEMENTATION), nominal_usage) {
   // use intra process = true
   auto node = rclcpp::Node::make_shared(
     "test_intra_process",
@@ -164,5 +173,4 @@ TEST(CLASSNAME(test_intra_process_within_one_node, RMW_IMPLEMENTATION), nominal_
   printf("spin_node_some() - no callbacks expected\n");
   executor.spin_node_some(node);
   ASSERT_EQ(5, counter);
-  rclcpp::shutdown();
 }

--- a/test_rclcpp/test/test_intra_process.cpp
+++ b/test_rclcpp/test/test_intra_process.cpp
@@ -33,13 +33,16 @@
 static const std::chrono::milliseconds sleep_per_loop(10);
 static const int max_loops = 200;
 
-class CLASSNAME (test_intra_process_within_one_node, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_intra_process_within_one_node, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -33,8 +33,18 @@ using namespace std::chrono_literals;
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), to_string) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (test_local_parameters, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), to_string) {
   rclcpp::Parameter pv("foo", "bar");
   rclcpp::Parameter pv2("foo2", "bar2");
   std::string json_dict = std::to_string(pv);
@@ -65,8 +75,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), to_string) {
     std::to_string(pv).c_str());
 }
 
-TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous) {
   auto node = rclcpp::Node::make_shared("test_parameters_local_synchronous");
   declare_test_parameters(node);
   auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
@@ -77,8 +86,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous) {
   test_get_parameters_sync(parameters_client);
 }
 
-TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous_repeated) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous_repeated) {
   auto node = rclcpp::Node::make_shared("test_parameters_local_synchronous_repeated");
   declare_test_parameters(node);
   auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
@@ -92,8 +100,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_synchronous_rep
   }
 }
 
-TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_asynchronous) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_asynchronous) {
   auto node = rclcpp::Node::make_shared(std::string("test_parameters_local_asynchronous"));
   declare_test_parameters(node);
   auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(node);
@@ -153,8 +160,7 @@ public:
 
 // Regression test for calling parameter client async services, but having the specified callback
 // go out of scope before it gets called: see https://github.com/ros2/rclcpp/pull/414
-TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_async_with_callback) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_async_with_callback) {
   auto node = std::make_shared<ParametersAsyncNode>();
   if (!node->parameters_client_->wait_for_service(20s)) {
     ASSERT_TRUE(false) << "service not available after waiting";
@@ -166,8 +172,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), local_async_with_call
   executor.spin();
 }
 
-TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   auto node = rclcpp::Node::make_shared("test_parameters_local_helpers");
   node->declare_parameter("foo");
   node->declare_parameter("bar");
@@ -290,8 +295,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), helpers) {
   EXPECT_EQ(barfoo[2], 5);
 }
 
-TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_primitive_type) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_primitive_type) {
   auto node = rclcpp::Node::make_shared("test_parameters_local_helpers");
   node->declare_parameter("foo");
   node->declare_parameter("bar");
@@ -364,8 +368,7 @@ TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_primiti
   EXPECT_EQ(barfoo[2], 5);
 }
 
-TEST(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_variant_type) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_local_parameters, RMW_IMPLEMENTATION), get_from_node_variant_type) {
   using rclcpp::Parameter;
 
   auto node = rclcpp::Node::make_shared("test_parameters_local_helpers");

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -33,13 +33,16 @@ using namespace std::chrono_literals;
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-class CLASSNAME (test_local_parameters, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_local_parameters, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_multiple_service_calls.cpp
+++ b/test_rclcpp/test/test_multiple_service_calls.cpp
@@ -43,13 +43,16 @@ void handle_add_two_ints(
   response->sum = request->a + request->b;
 }
 
-class CLASSNAME (test_two_service_calls, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_two_service_calls, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };
@@ -143,13 +146,16 @@ TEST_F(CLASSNAME(test_two_service_calls, RMW_IMPLEMENTATION), recursive_service_
   EXPECT_TRUE(second_result_received);
 }
 
-class CLASSNAME (test_multiple_service_calls, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_multiple_service_calls, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_multiple_service_calls.cpp
+++ b/test_rclcpp/test/test_multiple_service_calls.cpp
@@ -43,8 +43,18 @@ void handle_add_two_ints(
   response->sum = request->a + request->b;
 }
 
-TEST(CLASSNAME(test_two_service_calls, RMW_IMPLEMENTATION), two_service_calls) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (test_two_service_calls, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(test_two_service_calls, RMW_IMPLEMENTATION), two_service_calls) {
   auto node = rclcpp::Node::make_shared("test_two_service_calls");
 
   auto service = node->create_service<test_rclcpp::srv::AddTwoInts>(
@@ -86,8 +96,7 @@ TEST(CLASSNAME(test_two_service_calls, RMW_IMPLEMENTATION), two_service_calls) {
 
 // Regression test for async client not being able to queue another request in a response callback.
 // See https://github.com/ros2/rclcpp/pull/415
-TEST(CLASSNAME(test_two_service_calls, RMW_IMPLEMENTATION), recursive_service_call) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_two_service_calls, RMW_IMPLEMENTATION), recursive_service_call) {
   auto node = rclcpp::Node::make_shared("test_recursive_service_call");
 
   auto service = node->create_service<test_rclcpp::srv::AddTwoInts>(
@@ -134,8 +143,18 @@ TEST(CLASSNAME(test_two_service_calls, RMW_IMPLEMENTATION), recursive_service_ca
   EXPECT_TRUE(second_result_received);
 }
 
-TEST(CLASSNAME(test_multiple_service_calls, RMW_IMPLEMENTATION), multiple_clients) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (test_multiple_service_calls, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(test_multiple_service_calls, RMW_IMPLEMENTATION), multiple_clients) {
   const uint32_t n = 5;
 
   auto node = rclcpp::Node::make_shared("test_multiple_clients");

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -163,6 +163,9 @@ TEST_F(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_intra_p
   multi_consumer_pub_sub_test(true);
 }
 
+// TODO(brawner) On high core-count machines, this test fails with rmw_cyclonedds_cpp because
+// cyclonedds hard codes the maximum allowed threads.
+// For potential resolution, see https://github.com/ros2/rmw_cyclonedds/issues/268
 TEST_F(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_clients) {
   // multiple clients, single server
   auto node = rclcpp::Node::make_shared("multi_consumer_clients");

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -39,13 +39,16 @@
 
 using namespace std::chrono_literals;
 
-class CLASSNAME (test_multithreaded, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_multithreaded, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  void SetUp()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  void TearDown()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -39,6 +39,17 @@
 
 using namespace std::chrono_literals;
 
+class CLASSNAME (test_multithreaded, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
 static inline void multi_consumer_pub_sub_test(bool intra_process)
 {
   std::string node_topic_name = "multi_consumer";
@@ -139,20 +150,17 @@ static inline void multi_consumer_pub_sub_test(bool intra_process)
   EXPECT_EQ(expected_count, counter.load());
 }
 
-TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_single_producer) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_single_producer) {
   // multiple subscriptions, single publisher
   multi_consumer_pub_sub_test(false);
 }
 
-TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_intra_process) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_intra_process) {
   // multiple subscriptions, single publisher, intra-process
   multi_consumer_pub_sub_test(true);
 }
 
-TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_clients) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_clients) {
   // multiple clients, single server
   auto node = rclcpp::Node::make_shared("multi_consumer_clients");
   rclcpp::executors::MultiThreadedExecutor executor;
@@ -330,12 +338,10 @@ static inline void multi_access_publisher(bool intra_process)
   ASSERT_EQ(subscription_counter, timer_counter.load());
 }
 
-TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_access_publisher) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_access_publisher) {
   multi_access_publisher(false);
 }
 
-TEST(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_access_publisher_intra_process) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_access_publisher_intra_process) {
   multi_access_publisher(true);
 }

--- a/test_rclcpp/test/test_publisher.cpp
+++ b/test_rclcpp/test/test_publisher.cpp
@@ -32,9 +32,19 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
+class CLASSNAME (test_publisher, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
 // Short test for the const reference publish signature.
-TEST(CLASSNAME(test_publisher, RMW_IMPLEMENTATION), publish_with_const_reference) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_publisher, RMW_IMPLEMENTATION), publish_with_const_reference) {
   // topic name
   std::string topic_name = "test_publish_with_const_reference";
   // code to create the callback and subscription

--- a/test_rclcpp/test/test_publisher.cpp
+++ b/test_rclcpp/test/test_publisher.cpp
@@ -32,13 +32,16 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-class CLASSNAME (test_publisher, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_publisher, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_remote_parameters.cpp
+++ b/test_rclcpp/test/test_remote_parameters.cpp
@@ -31,13 +31,16 @@
 
 using namespace std::chrono_literals;
 
-class CLASSNAME (parameters, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (parameters, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };
@@ -94,13 +97,16 @@ TEST_F(CLASSNAME(parameters, RMW_IMPLEMENTATION), test_set_remote_parameters_ato
   test_get_parameters_sync(parameters_client);
 }
 
-class CLASSNAME (parameters_must_declare, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (parameters_must_declare, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_remote_parameters.cpp
+++ b/test_rclcpp/test/test_remote_parameters.cpp
@@ -31,8 +31,18 @@
 
 using namespace std::chrono_literals;
 
-TEST(CLASSNAME(parameters, rmw_implementation), test_remote_parameters_async) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (parameters, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(parameters, RMW_IMPLEMENTATION), test_remote_parameters_async) {
   std::string test_server_name = "test_parameters_server_allow_undeclared";
   // TODO(tfoote) make test_server name parameterizable
   // if (argc >= 2) {
@@ -52,8 +62,7 @@ TEST(CLASSNAME(parameters, rmw_implementation), test_remote_parameters_async) {
   test_get_parameters_async(node, parameters_client);
 }
 
-TEST(CLASSNAME(parameters, rmw_implementation), test_remote_parameters_sync) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(parameters, RMW_IMPLEMENTATION), test_remote_parameters_sync) {
   std::string test_server_name = "test_parameters_server_allow_undeclared";
 
   auto node = rclcpp::Node::make_shared(std::string("test_remote_parameters_sync"));
@@ -69,8 +78,7 @@ TEST(CLASSNAME(parameters, rmw_implementation), test_remote_parameters_sync) {
   test_get_parameters_sync(parameters_client);
 }
 
-TEST(CLASSNAME(parameters, rmw_implementation), test_set_remote_parameters_atomically_sync) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(parameters, RMW_IMPLEMENTATION), test_set_remote_parameters_atomically_sync) {
   std::string test_server_name = "test_parameters_server_allow_undeclared";
 
   auto node = rclcpp::Node::make_shared(std::string("test_set_remote_parameters_atomically_sync"));
@@ -86,8 +94,18 @@ TEST(CLASSNAME(parameters, rmw_implementation), test_set_remote_parameters_atomi
   test_get_parameters_sync(parameters_client);
 }
 
-TEST(CLASSNAME(parameters_must_declare, rmw_implementation), test_remote_parameters_async) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (parameters_must_declare, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(parameters_must_declare, RMW_IMPLEMENTATION), test_remote_parameters_async) {
   std::string test_server_name = "test_parameters_server_must_declare";
 
   auto node = rclcpp::Node::make_shared(std::string("test_remote_parameters_async"));
@@ -102,8 +120,7 @@ TEST(CLASSNAME(parameters_must_declare, rmw_implementation), test_remote_paramet
   test_set_parameters_async(node, parameters_client, 0);
 }
 
-TEST(CLASSNAME(parameters_must_declare, rmw_implementation), test_remote_parameters_sync) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(parameters_must_declare, RMW_IMPLEMENTATION), test_remote_parameters_sync) {
   std::string test_server_name = "test_parameters_server_must_declare";
 
   auto node = rclcpp::Node::make_shared(std::string("test_remote_parameters_sync"));
@@ -118,11 +135,10 @@ TEST(CLASSNAME(parameters_must_declare, rmw_implementation), test_remote_paramet
   test_set_parameters_sync(parameters_client, 0);
 }
 
-TEST(
-  CLASSNAME(parameters_must_declare, rmw_implementation),
+TEST_F(
+  CLASSNAME(parameters_must_declare, RMW_IMPLEMENTATION),
   test_set_remote_parameters_atomically_sync)
 {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
   std::string test_server_name = "test_parameters_server_must_declare";
 
   auto node = rclcpp::Node::make_shared(std::string("test_set_remote_parameters_atomically_sync"));

--- a/test_rclcpp/test/test_repeated_publisher_subscriber.cpp
+++ b/test_rclcpp/test/test_repeated_publisher_subscriber.cpp
@@ -29,18 +29,25 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-class CLASSNAME (test_repeated_publisher_subscriber, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_repeated_publisher_subscriber, RMW_IMPLEMENTATION)
+  : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };
 
-TEST_F(CLASSNAME(test_repeated_publisher_subscriber, RMW_IMPLEMENTATION), subscription_and_spinning) {
+TEST_F(
+  CLASSNAME(test_repeated_publisher_subscriber, RMW_IMPLEMENTATION),
+  subscription_and_spinning)
+{
   auto node = rclcpp::Node::make_shared("test_repeated_publisher_subscriber");
 
   auto callback =

--- a/test_rclcpp/test/test_repeated_publisher_subscriber.cpp
+++ b/test_rclcpp/test/test_repeated_publisher_subscriber.cpp
@@ -29,9 +29,18 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-TEST(CLASSNAME(test_repeated_publisher_subscriber, RMW_IMPLEMENTATION), subscription_and_spinning) {
-  rclcpp::init(0, nullptr);
+class CLASSNAME (test_repeated_publisher_subscriber, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
 
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(test_repeated_publisher_subscriber, RMW_IMPLEMENTATION), subscription_and_spinning) {
   auto node = rclcpp::Node::make_shared("test_repeated_publisher_subscriber");
 
   auto callback =

--- a/test_rclcpp/test/test_services_client.cpp
+++ b/test_rclcpp/test/test_services_client.cpp
@@ -31,8 +31,18 @@
 
 using namespace std::chrono_literals;
 
-TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_noreqid) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (test_services_client, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_noreqid) {
   auto node = rclcpp::Node::make_shared("test_services_client_no_reqid");
 
   auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("add_two_ints_noreqid");
@@ -52,8 +62,7 @@ TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_noreqid) {
   EXPECT_EQ(3, result.get()->sum);
 }
 
-TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_reqid) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_reqid) {
   auto node = rclcpp::Node::make_shared("test_services_client_add_reqid");
 
   auto client = node->create_client<test_rclcpp::srv::AddTwoInts>("add_two_ints_reqid");
@@ -73,8 +82,7 @@ TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_add_reqid) {
   EXPECT_EQ(9, result.get()->sum);
 }
 
-TEST(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_return_request) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_services_client, RMW_IMPLEMENTATION), test_return_request) {
   auto node = rclcpp::Node::make_shared("test_services_client_return_request");
 
   auto client = node->create_client<test_rclcpp::srv::AddTwoInts>(

--- a/test_rclcpp/test/test_services_client.cpp
+++ b/test_rclcpp/test/test_services_client.cpp
@@ -31,13 +31,16 @@
 
 using namespace std::chrono_literals;
 
-class CLASSNAME (test_services_client, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_services_client, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_services_in_constructor.cpp
+++ b/test_rclcpp/test/test_services_in_constructor.cpp
@@ -53,8 +53,18 @@ private:
   rclcpp::ServiceBase::SharedPtr service_;
 };
 
-TEST(CLASSNAME(test_services_in_constructor, RMW_IMPLEMENTATION), service_in_constructor) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (test_services_in_constructor, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(test_services_in_constructor, RMW_IMPLEMENTATION), service_in_constructor) {
   auto n = std::make_shared<MyNodeWithService>();
 }
 
@@ -71,7 +81,6 @@ private:
   rclcpp::ClientBase::SharedPtr client_;
 };
 
-TEST(CLASSNAME(test_services_in_constructor, RMW_IMPLEMENTATION), client_in_constructor) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_services_in_constructor, RMW_IMPLEMENTATION), client_in_constructor) {
   auto n = std::make_shared<MyNodeWithClient>();
 }

--- a/test_rclcpp/test/test_services_in_constructor.cpp
+++ b/test_rclcpp/test/test_services_in_constructor.cpp
@@ -53,13 +53,16 @@ private:
   rclcpp::ServiceBase::SharedPtr service_;
 };
 
-class CLASSNAME (test_services_in_constructor, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_services_in_constructor, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_spin.cpp
+++ b/test_rclcpp/test/test_spin.cpp
@@ -33,11 +33,23 @@
 
 using namespace std::chrono_literals;
 
+class CLASSNAME (test_spin, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  void SetUp() {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDownTestCase() {
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+};
+
 /*
    Ensures that the timeout behavior of spin_until_future_complete is correct.
  */
-TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), test_spin_until_future_complete_timeout) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_spin, RMW_IMPLEMENTATION), test_spin_until_future_complete_timeout) {
   using rclcpp::FutureReturnCode;
   rclcpp::executors::SingleThreadedExecutor executor;
 
@@ -124,8 +136,7 @@ TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), test_spin_until_future_complete_t
   }
 }
 
-TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete) {
   auto node = rclcpp::Node::make_shared("test_spin");
 
   // Construct a fake future to wait on
@@ -147,8 +158,7 @@ TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete) {
   EXPECT_EQ(future.get(), true);
 }
 
-TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete_timeout) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete_timeout) {
   auto node = rclcpp::Node::make_shared("test_spin");
 
   // Construct a fake future to wait on
@@ -173,8 +183,7 @@ TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete_timeou
   EXPECT_EQ(future.get(), true);
 }
 
-TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete_interrupted) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete_interrupted) {
   auto node = rclcpp::Node::make_shared("test_spin");
 
   // Construct a fake future to wait on
@@ -198,8 +207,7 @@ TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), spin_until_future_complete_interr
     rclcpp::FutureReturnCode::INTERRUPTED);
 }
 
-TEST(CLASSNAME(test_spin, RMW_IMPLEMENTATION), cancel) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_spin, RMW_IMPLEMENTATION), cancel) {
   auto node = rclcpp::Node::make_shared("cancel");
   rclcpp::executors::SingleThreadedExecutor executor;
   auto pub = node->create_publisher<test_rclcpp::msg::UInt32>("cancel", 10);

--- a/test_rclcpp/test/test_spin.cpp
+++ b/test_rclcpp/test/test_spin.cpp
@@ -33,13 +33,16 @@
 
 using namespace std::chrono_literals;
 
-class CLASSNAME (test_spin, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_spin, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  void SetUp() {
+  void SetUp()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  void TearDownTestCase() {
+  void TearDown()
+  {
     if (rclcpp::ok()) {
       rclcpp::shutdown();
     }

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -55,13 +55,16 @@ void wait_for_future(
     " milliseconds\n";
 }
 
-class CLASSNAME (test_subscription, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_subscription, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -55,8 +55,18 @@ void wait_for_future(
     " milliseconds\n";
 }
 
-TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (test_subscription, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning) {
   auto node = rclcpp::Node::make_shared("test_subscription");
 
   std::string topic = "test_subscription";
@@ -170,8 +180,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_and_spinning
 }
 
 // Shortened version of the test for the ConstSharedPtr callback signature
-TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_const) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_const) {
   std::string topic_name = "test_subscription_subscription_shared_ptr_const";
   // create the callback and subscription
   int counter = 0;
@@ -218,11 +227,10 @@ public:
 };
 
 // Shortened version of the test for the ConstSharedPtr callback signature in a method
-TEST(
+TEST_F(
   CLASSNAME(test_subscription, RMW_IMPLEMENTATION),
   subscription_shared_ptr_const_method_std_function
 ) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
   std::string topic_name = "test_subscription_shared_ptr_const_method_std_function";
   // create the callback and subscription
   CallbackHolder cb_holder;
@@ -251,11 +259,10 @@ TEST(
 }
 
 // Shortened version of the test for the ConstSharedPtr callback signature in a method
-TEST(
+TEST_F(
   CLASSNAME(test_subscription, RMW_IMPLEMENTATION),
   subscription_shared_ptr_const_method_direct
 ) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
   std::string topic_name = "test_subscription_shared_ptr_const_method_direct";
   // create the callback and subscription
   CallbackHolder cb_holder;
@@ -284,8 +291,7 @@ TEST(
 }
 
 // Shortened version of the test for the ConstSharedPtr with info callback signature
-TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_const_with_info) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_const_with_info) {
   std::string topic_name = "test_subscription_shared_ptr_const_method_direct";
   // create the callback and subscription
   int counter = 0;
@@ -320,8 +326,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), subscription_shared_ptr_c
 }
 
 // Shortened version of the test for subscribing after spinning has started.
-TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), spin_before_subscription) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), spin_before_subscription) {
   std::string topic_name = "test_spin_before_subscription";
   // create the callback and subscription
   int counter = 0;
@@ -363,8 +368,7 @@ TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), spin_before_subscription)
 }
 
 // Test of the queue size create_subscription signature.
-TEST(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), create_subscription_with_queue_size) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_subscription, RMW_IMPLEMENTATION), create_subscription_with_queue_size) {
   auto node = rclcpp::Node::make_shared("test_subscription");
 
   auto callback = [](test_rclcpp::msg::UInt32::ConstSharedPtr) -> void {};

--- a/test_rclcpp/test/test_timeout_subscriber.cpp
+++ b/test_rclcpp/test/test_timeout_subscriber.cpp
@@ -33,9 +33,18 @@ void callback(const test_rclcpp::msg::UInt32::SharedPtr /*msg*/)
   throw std::runtime_error("The subscriber received a message but there should be no publisher!");
 }
 
-TEST(CLASSNAME(test_timeout_subscriber, RMW_IMPLEMENTATION), timeout_subscriber) {
-  rclcpp::init(0, nullptr);
+class CLASSNAME (test_timeout_subscriber, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
 
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(test_timeout_subscriber, RMW_IMPLEMENTATION), timeout_subscriber) {
   auto start = std::chrono::steady_clock::now();
 
   auto node = rclcpp::Node::make_shared("test_timeout_subscriber");
@@ -73,7 +82,6 @@ TEST(CLASSNAME(test_timeout_subscriber, RMW_IMPLEMENTATION), timeout_subscriber)
       std::chrono::duration_cast<std::chrono::nanoseconds>(blocking_timeout + tolerance).count());
   }
 
-  rclcpp::shutdown();
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);
   printf("subscribed for %f seconds\n", diff.count());

--- a/test_rclcpp/test/test_timeout_subscriber.cpp
+++ b/test_rclcpp/test/test_timeout_subscriber.cpp
@@ -33,13 +33,16 @@ void callback(const test_rclcpp::msg::UInt32::SharedPtr /*msg*/)
   throw std::runtime_error("The subscriber received a message but there should be no publisher!");
 }
 
-class CLASSNAME (test_timeout_subscriber, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_timeout_subscriber, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };

--- a/test_rclcpp/test/test_timer.cpp
+++ b/test_rclcpp/test/test_timer.cpp
@@ -26,16 +26,17 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-class CLASSNAME (test_time, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_time, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  void SetUp() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  void TearDown() {
-    if (rclcpp::ok()) {
-      rclcpp::shutdown();
-    }
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
   }
 };
 
@@ -132,7 +133,7 @@ TEST_F(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_during_wait) {
   printf("sleeping for 4 periods\n");
   std::this_thread::sleep_for(4 * period);
   printf("shutdown()\n");
-  rclcpp::shutdown();
+  executor.cancel();
   thread.join();
 
   // check number of callbacks

--- a/test_rclcpp/test/test_timer.cpp
+++ b/test_rclcpp/test/test_timer.cpp
@@ -26,8 +26,20 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_fire_regularly) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (test_time, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  void SetUp() {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() {
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+};
+
+TEST_F(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_fire_regularly) {
   auto node = rclcpp::Node::make_shared("test_timer_fire_regularly");
 
   int counter = 0;
@@ -81,8 +93,7 @@ TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_fire_regularly) {
   printf("running for %.3f seconds\n", diff.count());
 }
 
-TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_during_wait) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_during_wait) {
   auto node = rclcpp::Node::make_shared("test_timer_during_wait");
 
   int counter = 0;
@@ -134,8 +145,7 @@ TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), timer_during_wait) {
 }
 
 
-TEST(CLASSNAME(test_time, RMW_IMPLEMENTATION), finite_timer) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+TEST_F(CLASSNAME(test_time, RMW_IMPLEMENTATION), finite_timer) {
   auto node = rclcpp::Node::make_shared("finite_timer");
 
   int counter = 0;

--- a/test_rclcpp/test/test_waitable.cpp
+++ b/test_rclcpp/test/test_waitable.cpp
@@ -96,8 +96,18 @@ public:
   std::promise<bool> execute_promise_;
 };  // class WaitableWithTimer
 
-TEST(CLASSNAME(test_waitable, RMW_IMPLEMENTATION), waitable_with_timer) {
-  if (!rclcpp::ok()) {rclcpp::init(0, nullptr);}
+class CLASSNAME (test_waitable, RMW_IMPLEMENTATION) : public ::testing::Test {
+public:
+  static void SetUpTestCase() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase() {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(CLASSNAME(test_waitable, RMW_IMPLEMENTATION), waitable_with_timer) {
   auto node = rclcpp::Node::make_shared("waitable_with_timer");
   auto waitable = WaitableWithTimer::make_shared(node->get_clock());
   auto group = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);

--- a/test_rclcpp/test/test_waitable.cpp
+++ b/test_rclcpp/test/test_waitable.cpp
@@ -96,13 +96,16 @@ public:
   std::promise<bool> execute_promise_;
 };  // class WaitableWithTimer
 
-class CLASSNAME (test_waitable, RMW_IMPLEMENTATION) : public ::testing::Test {
+class CLASSNAME (test_waitable, RMW_IMPLEMENTATION) : public ::testing::Test
+{
 public:
-  static void SetUpTestCase() {
+  static void SetUpTestCase()
+  {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestCase()
+  {
     rclcpp::shutdown();
   }
 };


### PR DESCRIPTION
We're seeing many hangs on windows CI jobs in these tests, and I think the issue can be resolved by ensuring that `rclcpp::shutdown` gets called for each invocation of `rclcpp::init`. In the process of addressing this, I noticed that the test_remote_parameters wasn't setting up the test cases correctly for each rmw_implementation.

There may be some uncrustify issues to cleanup.

Testing `--packages-select test_rclcpp`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13192)](http://ci.ros2.org/job/ci_linux/13192/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8123)](http://ci.ros2.org/job/ci_linux-aarch64/8123/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10908)](http://ci.ros2.org/job/ci_osx/10908/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13206)](http://ci.ros2.org/job/ci_windows/13206/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>