### PR TITLE
Add corresponding rclcpp::shutdown to tests in test_communication

### DIFF
--- a/test_communication/test/test_action_client.cpp
+++ b/test_communication/test/test_action_client.cpp
@@ -218,6 +218,10 @@ generate_nested_message_goal_tests()
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
+  RCLCPP_SCOPE_EXIT(
+  {
+    rclcpp::shutdown();
+  });
   if (argc != 3) {
     fprintf(stderr, "Wrong number of arguments, pass an action type and a namespace\n");
     return 1;

--- a/test_communication/test/test_action_server.cpp
+++ b/test_communication/test/test_action_server.cpp
@@ -244,6 +244,10 @@ int main(int argc, char ** argv)
     return 1;
   }
   rclcpp::init(argc, argv);
+  RCLCPP_SCOPE_EXIT(
+  {
+    rclcpp::shutdown();
+  });
 
   auto start = std::chrono::steady_clock::now();
 

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -101,6 +101,10 @@ rclcpp::SubscriptionBase::SharedPtr subscribe(
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
+  RCLCPP_SCOPE_EXIT(
+  {
+    rclcpp::shutdown();
+  });
   if (argc != 2) {
     fprintf(stderr, "Wrong number of arguments, pass one message type\n");
     return 1;


### PR DESCRIPTION
Several test configurations have been hanging, and I believe that's resolved by adding a corresponding shutdown to rclcpp::init.

Example failures:
https://ci.ros2.org/view/nightly/job/nightly_win_rel/1767/testReport/test_communication/

Testing `--packages-select test_communication`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13193)](http://ci.ros2.org/job/ci_linux/13193/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8124)](http://ci.ros2.org/job/ci_linux-aarch64/8124/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10909)](http://ci.ros2.org/job/ci_osx/10909/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13207)](http://ci.ros2.org/job/ci_windows/13207/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>