### PR TITLE
Guard against TOCTTOU with rclcpp::ok and rclcpp:spin_some

### DIFF
--- a/test_rclcpp/test/test_client_scope_consistency_server.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_server.cpp
@@ -39,9 +39,13 @@ int main(int argc, char ** argv)
     "client_scope", handle_add_two_ints, rmw_qos_profile);
 
   rclcpp::WallRate loop_rate(30);
-  while (rclcpp::ok()) {
-    rclcpp::spin_some(node);
-    loop_rate.sleep();
+  try {
+    while (rclcpp::ok()) {
+      rclcpp::spin_some(node);
+      loop_rate.sleep();
+    }
+  } catch (const rclcpp::exceptions::RCLError & ex) {
+    RCLCPP_ERROR(node->get_logger(), "failed with %s", ex.what());
   }
   rclcpp::shutdown();
   return 0;

--- a/test_rclcpp/test/test_client_scope_server.cpp
+++ b/test_rclcpp/test/test_client_scope_server.cpp
@@ -37,9 +37,13 @@ int main(int argc, char ** argv)
     "client_scope", handle_add_two_ints);
 
   rclcpp::WallRate loop_rate(30);
-  while (rclcpp::ok()) {
-    rclcpp::spin_some(node);
-    loop_rate.sleep();
+  try {
+    while (rclcpp::ok()) {
+      rclcpp::spin_some(node);
+      loop_rate.sleep();
+    }
+  } catch (const rclcpp::exceptions::RCLError & ex) {
+    RCLCPP_ERROR(node->get_logger(), "failed with %s", ex.what());
   }
   rclcpp::shutdown();
   return 0;


### PR DESCRIPTION
Fixes #458.

An exception can be thrown if an interrupt occurs between checking rclcpp::ok() and rclcpp::spin_some().

Related to https://github.com/ros2/rclcpp/issues/1066
