### PR TITLE
Ensure that the ros2 daemon is stopped before running system tests

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -191,15 +191,6 @@ if(BUILD_TESTING)
       set(rmw_implementation2_is_cyclonedds TRUE)
     endif()
 
-    set(rmw_implementation1_is_opensplice FALSE)
-    set(rmw_implementation2_is_opensplice FALSE)
-    if(rmw_implementation1 MATCHES "(.*)opensplice(.*)")
-      set(rmw_implementation1_is_opensplice TRUE)
-    endif()
-    if(rmw_implementation2 MATCHES "(.*)opensplice(.*)")
-      set(rmw_implementation2_is_opensplice TRUE)
-    endif()
-
     set(PUBLISHER_RMW ${rmw_implementation1})
     set(SUBSCRIBER_RMW ${rmw_implementation2})
     set(TEST_MESSAGE_TYPES "")
@@ -212,15 +203,6 @@ if(BUILD_TESTING)
         rmw_implementation1_is_fastrtps AND
         rmw_implementation2_is_connext AND
         APPLE
-      )
-        continue()
-      endif()
-      # TODO(dirk-thomas) OpenSplice doesn't support WString and the rmw impl.
-      # maps it to string which has a different wire representation
-      if(
-        "${message_type}" STREQUAL "WStrings" AND
-        (rmw_implementation1_is_opensplice OR rmw_implementation2_is_opensplice) AND
-        NOT "${rmw_implementation1_is_opensplice}" STREQUAL "${rmw_implementation2_is_opensplice}"
       )
         continue()
       endif()
@@ -468,7 +450,7 @@ if(BUILD_TESTING)
 
   macro(serialize)
     set(SKIP_TEST "")
-    if(${rmw_implementation} STREQUAL "rmw_connext_dynamic_cpp" OR ${rmw_implementation} STREQUAL "rmw_opensplice_cpp")
+    if(${rmw_implementation} STREQUAL "rmw_connext_dynamic_cpp")
       message(STATUS "skipping serialize tests for ${rmw_implementation}")
       set(SKIP_TEST "SKIP_TEST")
     endif()
@@ -500,7 +482,7 @@ if(BUILD_TESTING)
 
   macro(pub_sub_serialized)
     set(SKIP_TEST "")
-    if(${rmw_implementation} STREQUAL "rmw_connext_dynamic_cpp" OR ${rmw_implementation} STREQUAL "rmw_opensplice_cpp")
+    if(${rmw_implementation} STREQUAL "rmw_connext_dynamic_cpp")
       message(STATUS "skipping serialize tests for ${rmw_implementation}")
       set(SKIP_TEST "SKIP_TEST")
     endif()

--- a/test_communication/package.xml
+++ b/test_communication/package.xml
@@ -35,6 +35,7 @@
   <test_depend>rclpy</test_depend>
   <test_depend>rmw_implementation</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
+  <test_depend>ros2cli</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/test_communication/test/test_action_client_server.py.in
+++ b/test_communication/test/test_action_client_server.py.in
@@ -23,41 +23,44 @@ def generate_test_description(action_type):
     launch_description = LaunchDescription()
 
     action_client_cmd = ['@TEST_ACTION_CLIENT_EXECUTABLE@', action_type, namespace]
-    action_server_cmd = ['@TEST_ACTION_SERVER_EXECUTABLE@', action_type, namespace]
-
-    action_server_env = dict(os.environ)
     action_client_env = dict(os.environ)
-
-    if '@TEST_ACTION_SERVER_RCL@' == 'rclpy':
-        action_server_cmd.insert(0, sys.executable)
-        action_server_env['PYTHONUNBUFFERED'] = '1'
     if '@TEST_ACTION_CLIENT_RCL@' == 'rclpy':
         action_client_cmd.insert(0, sys.executable)
         action_client_env['PYTHONUNBUFFERED'] = '1'
-
-    action_server_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@ACTION_SERVER_RMW@'
-    action_server_env['RMW_IMPLEMENTATION'] = '@ACTION_SERVER_RMW@'
-
-    launch_description.add_action(ExecuteProcess(
-        cmd=action_server_cmd,
-        name='test_action_server',
-        env=action_server_env,
-    ))
-
     action_client_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@ACTION_CLIENT_RMW@'
     action_client_env['RMW_IMPLEMENTATION'] = '@ACTION_CLIENT_RMW@'
-
     action_client_process = ExecuteProcess(
         cmd=action_client_cmd,
         name='test_action_client',
         env=action_client_env,
     )
-    launch_description.add_action(action_client_process)
 
-    launch_description.add_action(
-        launch_testing.actions.ReadyToTest()
+    action_server_cmd = ['@TEST_ACTION_SERVER_EXECUTABLE@', action_type, namespace]
+    action_server_env = dict(os.environ)
+    if '@TEST_ACTION_SERVER_RCL@' == 'rclpy':
+        action_server_cmd.insert(0, sys.executable)
+        action_server_env['PYTHONUNBUFFERED'] = '1'
+    action_server_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@ACTION_SERVER_RMW@'
+    action_server_env['RMW_IMPLEMENTATION'] = '@ACTION_SERVER_RMW@'
+
+    action_server_process = ExecuteProcess(
+        cmd=action_server_cmd,
+        name='test_action_server',
+        env=action_server_env,
     )
-    return launch_description, locals()
+
+    return LaunchDescription([
+        # Always stop daemon to isolate tests.
+        ExecuteProcess(
+            cmd=['ros2', 'daemon', 'stop'],
+            name='daemon-stop',
+            on_exit=[
+                action_server_process,
+                action_client_process,
+                launch_testing.actions.ReadyToTest()
+            ]
+        )
+    ]), locals()
 
 
 class TestActionClientServer(unittest.TestCase):

--- a/test_communication/test/test_publisher_subscriber.py.in
+++ b/test_communication/test/test_publisher_subscriber.py.in
@@ -23,40 +23,43 @@ def generate_test_description(message_type):
     launch_description = LaunchDescription()
 
     publisher_cmd = ['@TEST_PUBLISHER_EXECUTABLE@', message_type, namespace]
-    subscriber_cmd = ['@TEST_SUBSCRIBER_EXECUTABLE@', message_type, namespace]
-
     publisher_env = dict(os.environ)
-    subscriber_env = dict(os.environ)
-
     if '@TEST_PUBLISHER_RCL@' == 'rclpy':
         publisher_cmd.insert(0, sys.executable)
         publisher_env['PYTHONUNBUFFERED'] = '1'
-    if '@TEST_SUBSCRIBER_RCL@' == 'rclpy':
-        subscriber_cmd.insert(0, sys.executable)
-        subscriber_env['PYTHONUNBUFFERED'] = '1'
-
     publisher_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@PUBLISHER_RMW@'
     publisher_env['RMW_IMPLEMENTATION'] = '@PUBLISHER_RMW@'
-
-    launch_description.add_action(ExecuteProcess(
+    publisher_process = ExecuteProcess(
         cmd=publisher_cmd,
         name='test_publisher',
         env=publisher_env,
-    ))
+    )
 
+    subscriber_cmd = ['@TEST_SUBSCRIBER_EXECUTABLE@', message_type, namespace]
+    subscriber_env = dict(os.environ)
+    if '@TEST_SUBSCRIBER_RCL@' == 'rclpy':
+        subscriber_cmd.insert(0, sys.executable)
+        subscriber_env['PYTHONUNBUFFERED'] = '1'
     subscriber_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@SUBSCRIBER_RMW@'
     subscriber_env['RMW_IMPLEMENTATION'] = '@SUBSCRIBER_RMW@'
-
     subscriber_process = ExecuteProcess(
         cmd=subscriber_cmd,
         name='test_subscriber',
         env=subscriber_env,
     )
-    launch_description.add_action(subscriber_process)
-    launch_description.add_action(
-        launch_testing.actions.ReadyToTest()
-    )
-    return launch_description, locals()
+
+    return LaunchDescription([
+        # Always stop daemon to isolate tests.
+        ExecuteProcess(
+            cmd=['ros2', 'daemon', 'stop'],
+            name='daemon-stop',
+            on_exit=[
+                publisher_process,
+                subscriber_process,
+                launch_testing.actions.ReadyToTest()
+            ]
+        )
+    ]), locals()
 
 
 class TestPublisherSubscriber(unittest.TestCase):

--- a/test_communication/test/test_requester_replier.py.in
+++ b/test_communication/test/test_requester_replier.py.in
@@ -20,44 +20,44 @@ SERVICE_TYPES = '@TEST_SERVICE_TYPES@'.split(';')
 def generate_test_description(service_type):
     namespace = '/test_time_%s' % time.strftime('%H_%M_%S', time.gmtime())
 
-    launch_description = LaunchDescription()
-
-    requester_cmd = ['@TEST_REQUESTER_EXECUTABLE@', service_type, namespace]
     replier_cmd = ['@TEST_REPLIER_EXECUTABLE@', service_type, namespace]
-
     replier_env = dict(os.environ)
-    requester_env = dict(os.environ)
-
     if '@TEST_REPLIER_RCL@' == 'rclpy':
         replier_cmd.insert(0, sys.executable)
         replier_env['PYTHONUNBUFFERED'] = '1'
-    if '@TEST_REQUESTER_RCL@' == 'rclpy':
-        requester_cmd.insert(0, sys.executable)
-        requester_env['PYTHONUNBUFFERED'] = '1'
-
     replier_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@REPLIER_RMW@'
     replier_env['RMW_IMPLEMENTATION'] = '@REPLIER_RMW@'
-
-    launch_description.add_action(ExecuteProcess(
+    replier_process = ExecuteProcess(
         cmd=replier_cmd,
         name='test_replier',
         env=replier_env,
-    ))
+    )
 
+    requester_cmd = ['@TEST_REQUESTER_EXECUTABLE@', service_type, namespace]
+    requester_env = dict(os.environ)
+    if '@TEST_REQUESTER_RCL@' == 'rclpy':
+        requester_cmd.insert(0, sys.executable)
+        requester_env['PYTHONUNBUFFERED'] = '1'
     requester_env['RCL_ASSERT_RMW_ID_MATCHES'] = '@REQUESTER_RMW@'
     requester_env['RMW_IMPLEMENTATION'] = '@REQUESTER_RMW@'
-
     requester_process = ExecuteProcess(
         cmd=requester_cmd,
         name='test_requester',
         env=requester_env,
     )
-    launch_description.add_action(requester_process)
 
-    launch_description.add_action(
-        launch_testing.actions.ReadyToTest()
-    )
-    return launch_description, locals()
+    return LaunchDescription([
+        # Always stop daemon to isolate tests.
+        ExecuteProcess(
+            cmd=['ros2', 'daemon', 'stop'],
+            name='daemon-stop',
+            on_exit=[
+                replier_process,
+                requester_process,
+                launch_testing.actions.ReadyToTest()
+            ]
+        )
+    ]), locals()
 
 
 class TestRequesterReplier(unittest.TestCase):


### PR DESCRIPTION
While debugging some failures over in https://github.com/ros2/rmw/pull/293, we came across a situation that seemed to make no sense.  The change from Fast-RTPS -> CycloneDDS as the default was causing *Connext* builds to fail.  After poking at it for a while, we think that an earlier running instance of the ros2 daemon is causing some incompatibilities for tests later on.

This PR changes it so that the test_communication tests always kill off the ros2 daemon before running tests, similar to how the ros2cli tests work.

Before: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13366)](http://ci.ros2.org/job/ci_linux/13366/)
After: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13376)](http://ci.ros2.org/job/ci_linux/13376/)

Full CI with this change in place:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13376)](http://ci.ros2.org/job/ci_linux/13376/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8299)](http://ci.ros2.org/job/ci_linux-aarch64/8299/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11103)](http://ci.ros2.org/job/ci_osx/11103/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13426)](http://ci.ros2.org/job/ci_windows/13426/)