### PR TITLE
get_parameters_service_ should return empty if allow_undeclared_ is false

### DIFF
--- a/test_rclcpp/test/parameter_fixtures.hpp
+++ b/test_rclcpp/test/parameter_fixtures.hpp
@@ -126,7 +126,8 @@ void test_set_parameters_async(
 }
 
 void test_get_parameters_sync(
-  std::shared_ptr<rclcpp::SyncParametersClient> parameters_client)
+  std::shared_ptr<rclcpp::SyncParametersClient> parameters_client,
+  bool allowed_undeclared = false)
 {
   printf("Listing parameters with recursive depth\n");
   // Test recursive depth (=0)
@@ -191,11 +192,15 @@ void test_get_parameters_sync(
   {
     std::vector<rclcpp::Parameter> retrieved_params =
       parameters_client->get_parameters({"not_foo", "not_baz"}, std::chrono::seconds(1));
-    ASSERT_EQ(2u, retrieved_params.size());
-    EXPECT_STREQ("not_foo", retrieved_params[0].get_name().c_str());
-    EXPECT_STREQ("not_baz", retrieved_params[1].get_name().c_str());
-    EXPECT_EQ(rclcpp::ParameterType::PARAMETER_NOT_SET, retrieved_params[0].get_type());
-    EXPECT_EQ(rclcpp::ParameterType::PARAMETER_NOT_SET, retrieved_params[1].get_type());
+    if (allowed_undeclared == false) {
+      ASSERT_EQ(0u, retrieved_params.size());
+    } else { // allowed_undeclared == true
+      ASSERT_EQ(2u, retrieved_params.size());
+      EXPECT_STREQ("not_foo", retrieved_params[0].get_name().c_str());
+      EXPECT_STREQ("not_baz", retrieved_params[1].get_name().c_str());
+      EXPECT_EQ(rclcpp::ParameterType::PARAMETER_NOT_SET, retrieved_params[0].get_type());
+      EXPECT_EQ(rclcpp::ParameterType::PARAMETER_NOT_SET, retrieved_params[1].get_type());
+    }
   }
 
   printf("Listing parameters with recursive depth\n");
@@ -259,7 +264,8 @@ void test_get_parameters_sync(
 
 void test_get_parameters_async(
   std::shared_ptr<rclcpp::Node> node,
-  std::shared_ptr<rclcpp::AsyncParametersClient> parameters_client)
+  std::shared_ptr<rclcpp::AsyncParametersClient> parameters_client,
+  bool allowed_undeclared = false)
 {
   printf("Listing parameters with recursive depth\n");
   // Test recursive depth (=0)
@@ -329,11 +335,15 @@ void test_get_parameters_async(
     auto result3 = parameters_client->get_parameters({"not_foo", "not_baz"});
     rclcpp::spin_until_future_complete(node, result3);
     std::vector<rclcpp::Parameter> retrieved_params = result3.get();
-    ASSERT_EQ(2u, retrieved_params.size());
-    EXPECT_STREQ("not_foo", retrieved_params[0].get_name().c_str());
-    EXPECT_STREQ("not_baz", retrieved_params[1].get_name().c_str());
-    EXPECT_EQ(rclcpp::ParameterType::PARAMETER_NOT_SET, retrieved_params[0].get_type());
-    EXPECT_EQ(rclcpp::ParameterType::PARAMETER_NOT_SET, retrieved_params[1].get_type());
+    if (allowed_undeclared == false) {
+      ASSERT_EQ(0u, retrieved_params.size());
+    } else { // allowed_undeclared == true
+      ASSERT_EQ(2u, retrieved_params.size());
+      EXPECT_STREQ("not_foo", retrieved_params[0].get_name().c_str());
+      EXPECT_STREQ("not_baz", retrieved_params[1].get_name().c_str());
+      EXPECT_EQ(rclcpp::ParameterType::PARAMETER_NOT_SET, retrieved_params[0].get_type());
+      EXPECT_EQ(rclcpp::ParameterType::PARAMETER_NOT_SET, retrieved_params[1].get_type());
+    }
   }
 
   printf("Listing parameters with recursive depth\n");

--- a/test_rclcpp/test/parameter_fixtures.hpp
+++ b/test_rclcpp/test/parameter_fixtures.hpp
@@ -194,7 +194,7 @@ void test_get_parameters_sync(
       parameters_client->get_parameters({"not_foo", "not_baz"}, std::chrono::seconds(1));
     if (allowed_undeclared == false) {
       ASSERT_EQ(0u, retrieved_params.size());
-    } else { // allowed_undeclared == true
+    } else {
       ASSERT_EQ(2u, retrieved_params.size());
       EXPECT_STREQ("not_foo", retrieved_params[0].get_name().c_str());
       EXPECT_STREQ("not_baz", retrieved_params[1].get_name().c_str());
@@ -337,7 +337,7 @@ void test_get_parameters_async(
     std::vector<rclcpp::Parameter> retrieved_params = result3.get();
     if (allowed_undeclared == false) {
       ASSERT_EQ(0u, retrieved_params.size());
-    } else { // allowed_undeclared == true
+    } else {
       ASSERT_EQ(2u, retrieved_params.size());
       EXPECT_STREQ("not_foo", retrieved_params[0].get_name().c_str());
       EXPECT_STREQ("not_baz", retrieved_params[1].get_name().c_str());

--- a/test_rclcpp/test/test_remote_parameters.cpp
+++ b/test_rclcpp/test/test_remote_parameters.cpp
@@ -62,7 +62,7 @@ TEST_F(CLASSNAME(parameters, RMW_IMPLEMENTATION), test_remote_parameters_async) 
 
   test_set_parameters_async(node, parameters_client);
 
-  test_get_parameters_async(node, parameters_client);
+  test_get_parameters_async(node, parameters_client, true);
 }
 
 TEST_F(CLASSNAME(parameters, RMW_IMPLEMENTATION), test_remote_parameters_sync) {
@@ -78,7 +78,7 @@ TEST_F(CLASSNAME(parameters, RMW_IMPLEMENTATION), test_remote_parameters_sync) {
 
   test_set_parameters_sync(parameters_client);
 
-  test_get_parameters_sync(parameters_client);
+  test_get_parameters_sync(parameters_client, true);
 }
 
 TEST_F(CLASSNAME(parameters, RMW_IMPLEMENTATION), test_set_remote_parameters_atomically_sync) {
@@ -94,7 +94,7 @@ TEST_F(CLASSNAME(parameters, RMW_IMPLEMENTATION), test_set_remote_parameters_ato
 
   test_set_parameters_atomically_sync(parameters_client);
 
-  test_get_parameters_sync(parameters_client);
+  test_get_parameters_sync(parameters_client, true);
 }
 
 class CLASSNAME (parameters_must_declare, RMW_IMPLEMENTATION) : public ::testing::Test


### PR DESCRIPTION
depends on https://github.com/ros2/rclcpp/pull/1514

Signed-off-by: Tomoya.Fujita <Tomoya.Fujita@sony.com>