### PR TITLE
Revert "disable flakey test" (#431)

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -293,12 +293,6 @@ if(BUILD_TESTING)
       RMW_IMPLEMENTATION=${rmw_implementation}
       TIMEOUT 60)
 
-    if(rmw_implementation STREQUAL "rmw_cyclonedds_cpp")
-      # TODO(tfoote) Disable this tests on CI as it's being flakey
-      # This should be removed when https://github.com/ros2/rmw_cyclonedds/issues/183 is resolved.
-      ament_add_test_label(test_parameter_server_cpp${target_suffix} xfail)
-    endif()
-
     # Service tests single implementation
     custom_launch_test_two_executables(test_services_cpp
       test_services_server_cpp test_services_client_cpp


### PR DESCRIPTION
This reverts commit 4bedf8dcf7f78b69dd1721a999c40f443e9f4896. I've been unable to reproduce the original issue locally.

Trying repeated CI up to `test_rclcpp`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14114)](http://ci.ros2.org/job/ci_linux/14114/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8922)](http://ci.ros2.org/job/ci_linux-aarch64/8922/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11803)](http://ci.ros2.org/job/ci_osx/11803/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14210)](http://ci.ros2.org/job/ci_windows/14210/)
