### PR TITLE
Fix test_cli_remapping flaky test

### DIFF
--- a/test_cli_remapping/test/test_cli_remapping.py
+++ b/test_cli_remapping/test/test_cli_remapping.py
@@ -85,7 +85,7 @@ def generate_test_description(executable):
                 name='name_maker_' + replacement_name, env=env
             )
         )
-        test_context[replacement_name] = replacement_value.format(**locals())
+        test_context[replacement_name] = replacement_value.format(random_string=random_string)
 
     launch_description.add_action(
         launch_testing.actions.ReadyToTest()

--- a/test_cli_remapping/test/test_cli_remapping.py
+++ b/test_cli_remapping/test/test_cli_remapping.py
@@ -50,12 +50,12 @@ TEST_CASES = {
         '__node:=node_{random_string}'
     ),
     'topic_and_service_replacement': (
-        '/remapped/s{random_string}',
-        '/fully/qualified/name:=/remapped/s{random_string}'
+        '/remapped/ts{random_string}',
+        '/fully/qualified/name:=/remapped/ts{random_string}'
     ),
     'topic_replacement': (
-        '/remapped/s{random_string}',
-        'rostopic://~/private/name:=/remapped/s{random_string}'
+        '/remapped/t{random_string}',
+        'rostopic://~/private/name:=/remapped/t{random_string}'
     ),
     'service_replacement': (
         '/remapped/s{random_string}',


### PR DESCRIPTION
This fixes a flaky test caused by topic/service names used in two tests having a roughly 1 in 10,000 chance of colliding. It fixes the issue by changing the remapped string so they cannot collide (ts = topic and service, t = topic, s = service).

I also changed the arguments to a call to `format` to use a keyword argument directly instead of `**locals()` to be more transparent about what is being passed.

Flaky test failed in:

https://ci.ros2.org/job/nightly_linux_repeated/2256

Fixes #469