### PR TITLE
Use rcpputils/scope_exit.hpp instead of rclcpp/scope_exit.hpp

### DIFF
--- a/test_communication/package.xml
+++ b/test_communication/package.xml
@@ -33,6 +33,7 @@
   <test_depend>rclcpp</test_depend>
   <test_depend>rclcpp_action</test_depend>
   <test_depend>rclpy</test_depend>
+  <test_depend>rcpputils</test_depend>
   <test_depend>rmw_implementation</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
   <test_depend>ros2cli</test_depend>

--- a/test_communication/test/test_action_client.cpp
+++ b/test_communication/test/test_action_client.cpp
@@ -19,9 +19,10 @@
 #include <vector>
 
 #include "rclcpp/exceptions.hpp"
-#include "rclcpp/scope_exit.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
+
+#include "rcpputils/scope_exit.hpp"
 
 #include "test_msgs/action/fibonacci.hpp"
 #include "test_msgs/action/nested_message.hpp"
@@ -55,7 +56,7 @@ send_goals(
   size_t test_index = 0;
   bool invalid_feedback = false;
   auto start = std::chrono::steady_clock::now();
-  RCLCPP_SCOPE_EXIT(
+  RCPPUTILS_SCOPE_EXIT(
   {
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<float> diff = (end - start);
@@ -218,7 +219,7 @@ generate_nested_message_goal_tests()
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  RCLCPP_SCOPE_EXIT(
+  RCPPUTILS_SCOPE_EXIT(
   {
     rclcpp::shutdown();
   });

--- a/test_communication/test/test_action_server.cpp
+++ b/test_communication/test/test_action_server.cpp
@@ -22,6 +22,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 
+#include "rcpputils/scope_exit.hpp"
+
 #include "test_msgs/action/fibonacci.hpp"
 #include "test_msgs/action/nested_message.hpp"
 
@@ -244,7 +246,7 @@ int main(int argc, char ** argv)
     return 1;
   }
   rclcpp::init(argc, argv);
-  RCLCPP_SCOPE_EXIT(
+  RCPPUTILS_SCOPE_EXIT(
   {
     rclcpp::shutdown();
   });

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -19,6 +19,8 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#include "rcpputils/scope_exit.hpp"
+
 #include "test_msgs/message_fixtures.hpp"
 
 template<typename T>
@@ -101,7 +103,7 @@ rclcpp::SubscriptionBase::SharedPtr subscribe(
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  RCLCPP_SCOPE_EXIT(
+  RCPPUTILS_SCOPE_EXIT(
   {
     rclcpp::shutdown();
   });

--- a/test_rclcpp/package.xml
+++ b/test_rclcpp/package.xml
@@ -23,6 +23,7 @@
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>rclcpp</test_depend>
+  <test_depend>rcpputils</test_depend>
   <test_depend>rmw_implementation</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
   <test_depend>rosidl_default_generators</test_depend>

--- a/test_rclcpp/test/test_client_wait_for_service_shutdown.cpp
+++ b/test_rclcpp/test/test_client_wait_for_service_shutdown.cpp
@@ -17,7 +17,7 @@
 
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp/scope_exit.hpp"
+#include "rcpputils/scope_exit.hpp"
 #include "test_rclcpp/srv/add_two_ints.hpp"
 
 #ifdef RMW_IMPLEMENTATION
@@ -54,7 +54,7 @@ TEST_F(CLASSNAME(service_client, RMW_IMPLEMENTATION), wait_for_service_shutdown)
       std::this_thread::sleep_for(1s);
       rclcpp::shutdown();
     });
-  RCLCPP_SCOPE_EXIT({shutdown_thread.join();});
+  RCPPUTILS_SCOPE_EXIT({shutdown_thread.join();});
   auto start = std::chrono::steady_clock::now();
   client->wait_for_service(15s);
   auto end = std::chrono::steady_clock::now();


### PR DESCRIPTION
See https://github.com/ros2/rclcpp/issues/1725

This has to be merged before the header can be removed from `rclcpp`.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>