### PR TITLE
Add tests for BoundedPlainSequences

### DIFF
--- a/test_communication/test/test_publisher.cpp
+++ b/test_communication/test/test_publisher.cpp
@@ -78,6 +78,9 @@ int main(int argc, char ** argv)
   } else if (message == "UnboundedSequences") {
     publish<test_msgs::msg::UnboundedSequences>(
       node, message, get_messages_unbounded_sequences());
+  } else if (message == "BoundedPlainSequences") {
+    publish<test_msgs::msg::BoundedPlainSequences>(
+      node, message, get_messages_bounded_plain_sequences());
   } else if (message == "BoundedSequences") {
     publish<test_msgs::msg::BoundedSequences>(
       node, message, get_messages_bounded_sequences());

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -123,6 +123,7 @@ int main(int argc, char ** argv)
   auto messages_empty = get_messages_empty();
   auto messages_basic_types = get_messages_basic_types();
   auto messages_arrays = get_messages_arrays();
+  auto messages_bounded_plain_sequences = get_messages_bounded_plain_sequences();
   auto messages_bounded_sequences = get_messages_bounded_sequences();
   auto messages_unbounded_sequences = get_messages_unbounded_sequences();
   auto messages_multi_nested = get_messages_multi_nested();
@@ -154,6 +155,11 @@ int main(int argc, char ** argv)
       node, message, messages_unbounded_sequences, received_messages);
     publish<test_msgs::msg::UnboundedSequences>(
       node, message, messages_unbounded_sequences);
+  } else if (message == "BoundedPlainSequences") {
+    subscriber = subscribe<test_msgs::msg::BoundedPlainSequences>(
+      node, message, messages_bounded_plain_sequences, received_messages);
+    publish<test_msgs::msg::BoundedPlainSequences>(
+      node, message, messages_bounded_plain_sequences);
   } else if (message == "BoundedSequences") {
     subscriber = subscribe<test_msgs::msg::BoundedSequences>(
       node, message, messages_bounded_sequences, received_messages);

--- a/test_communication/test/test_subscriber.cpp
+++ b/test_communication/test/test_subscriber.cpp
@@ -87,6 +87,7 @@ int main(int argc, char ** argv)
   auto messages_basic_types = get_messages_basic_types();
   auto messages_arrays = get_messages_arrays();
   auto messages_unbounded_sequences = get_messages_unbounded_sequences();
+  auto messages_bounded_plain_sequences = get_messages_bounded_plain_sequences();
   auto messages_bounded_sequences = get_messages_bounded_sequences();
   auto messages_nested = get_messages_nested();
   auto messages_multi_nested = get_messages_multi_nested();
@@ -110,6 +111,9 @@ int main(int argc, char ** argv)
   } else if (message == "UnboundedSequences") {
     subscriber = subscribe<test_msgs::msg::UnboundedSequences>(
       node, message, messages_unbounded_sequences, received_messages);
+  } else if (message == "BoundedPlainSequences") {
+    subscriber = subscribe<test_msgs::msg::BoundedPlainSequences>(
+      node, message, messages_bounded_plain_sequences, received_messages);
   } else if (message == "BoundedSequences") {
     subscriber = subscribe<test_msgs::msg::BoundedSequences>(
       node, message, messages_bounded_sequences, received_messages);


### PR DESCRIPTION
`test_communication` makes tests for every message type in `test_interface_files`. This PR adds code support in the tests for the new message.


Requires https://github.com/ros2/rcl_interfaces/pull/125 - together they should fix the nightlies