### PR TITLE
Split test_subscriber into multiple compilation units.

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -426,6 +426,9 @@ if(BUILD_TESTING)
   custom_executable(test_publisher_cpp
     "test/test_publisher.cpp")
   custom_executable(test_subscriber_cpp
+    "test/subscribe_array_types.cpp"
+    "test/subscribe_basic_types.cpp"
+    "test/subscribe_string_types.cpp"
     "test/test_subscriber.cpp")
   # executables requester / replier
   custom_executable(test_requester_cpp

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -416,9 +416,18 @@ if(BUILD_TESTING)
     endforeach()
   endmacro()
 
+  add_library(subscribe_types SHARED
+    "test/subscribe_array_types.cpp"
+    "test/subscribe_basic_types.cpp"
+    "test/subscribe_string_types.cpp")
+  ament_target_dependencies(subscribe_types
+    "rclcpp"
+    "test_msgs")
+
   # publisher combined with a subscriber
   custom_executable(test_publisher_subscriber_cpp
     "test/test_publisher_subscriber.cpp")
+  target_link_libraries(test_publisher_subscriber_cpp subscribe_types)
   # subcription valid data
   custom_executable(test_subscription_valid_data_cpp
     "test/test_subscription_valid_data.cpp")
@@ -426,10 +435,8 @@ if(BUILD_TESTING)
   custom_executable(test_publisher_cpp
     "test/test_publisher.cpp")
   custom_executable(test_subscriber_cpp
-    "test/subscribe_array_types.cpp"
-    "test/subscribe_basic_types.cpp"
-    "test/subscribe_string_types.cpp"
     "test/test_subscriber.cpp")
+  target_link_libraries(test_subscriber_cpp subscribe_types)
   # executables requester / replier
   custom_executable(test_requester_cpp
     "test/test_requester.cpp")

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -416,7 +416,7 @@ if(BUILD_TESTING)
     endforeach()
   endmacro()
 
-  add_library(subscribe_types SHARED
+  add_library(subscribe_types STATIC
     "test/subscribe_array_types.cpp"
     "test/subscribe_basic_types.cpp"
     "test/subscribe_string_types.cpp")

--- a/test_communication/test/subscribe_array_types.cpp
+++ b/test_communication/test/subscribe_array_types.cpp
@@ -1,0 +1,87 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "test_msgs/msg/arrays.hpp"
+#include "test_msgs/msg/unbounded_sequences.hpp"
+#include "test_msgs/msg/bounded_plain_sequences.hpp"
+#include "test_msgs/msg/bounded_sequences.hpp"
+#include "test_msgs/msg/multi_nested.hpp"
+#include "test_msgs/msg/nested.hpp"
+
+#include "subscribe_array_types.hpp"
+#include "subscribe_helper.hpp"
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_arrays(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Arrays::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::Arrays>(
+    node, message_type, expected_messages, received_messages);
+}
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_unbounded_sequences(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::UnboundedSequences::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::UnboundedSequences>(
+    node, message_type, expected_messages, received_messages);
+}
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_bounded_plain_sequences(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::BoundedPlainSequences::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::BoundedPlainSequences>(
+    node, message_type, expected_messages, received_messages);
+}
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_bounded_sequences(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::BoundedSequences::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::BoundedSequences>(
+    node, message_type, expected_messages, received_messages);
+}
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_multi_nested(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::MultiNested::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::MultiNested>(
+    node, message_type, expected_messages, received_messages);
+}
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_nested(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Nested::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::Nested>(
+    node, message_type, expected_messages, received_messages);
+}

--- a/test_communication/test/subscribe_array_types.hpp
+++ b/test_communication/test/subscribe_array_types.hpp
@@ -1,0 +1,65 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SUBSCRIBE_ARRAY_TYPES_HPP_
+#define SUBSCRIBE_ARRAY_TYPES_HPP_
+
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "test_msgs/msg/arrays.hpp"
+#include "test_msgs/msg/unbounded_sequences.hpp"
+#include "test_msgs/msg/bounded_plain_sequences.hpp"
+#include "test_msgs/msg/bounded_sequences.hpp"
+#include "test_msgs/msg/multi_nested.hpp"
+#include "test_msgs/msg/nested.hpp"
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_arrays(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Arrays::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages);
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_unbounded_sequences(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::UnboundedSequences::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages);
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_bounded_plain_sequences(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::BoundedPlainSequences::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages);
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_bounded_sequences(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::BoundedSequences::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages);
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_multi_nested(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::MultiNested::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages);
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_nested(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Nested::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages);
+
+#endif  // SUBSCRIBE_ARRAY_TYPES_HPP_

--- a/test_communication/test/subscribe_basic_types.cpp
+++ b/test_communication/test/subscribe_basic_types.cpp
@@ -1,0 +1,75 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "test_msgs/msg/empty.hpp"
+#include "test_msgs/msg/basic_types.hpp"
+#include "test_msgs/msg/builtins.hpp"
+#include "test_msgs/msg/constants.hpp"
+#include "test_msgs/msg/defaults.hpp"
+
+#include "subscribe_basic_types.hpp"
+#include "subscribe_helper.hpp"
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_empty(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Empty::SharedPtr> & messages_expected,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::Empty>(node, message_type, messages_expected, received_messages);
+}
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_basic_types(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::BasicTypes::SharedPtr> & messages_expected,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::BasicTypes>(
+    node, message_type, messages_expected, received_messages);
+}
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_builtins(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Builtins::SharedPtr> & messages_expected,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::Builtins>(
+    node, message_type, messages_expected, received_messages);
+}
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_constants(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Constants::SharedPtr> & messages_expected,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::Constants>(
+    node, message_type, messages_expected, received_messages);
+}
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_defaults(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Defaults::SharedPtr> & messages_expected,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::Defaults>(
+    node, message_type, messages_expected, received_messages);
+}

--- a/test_communication/test/subscribe_basic_types.hpp
+++ b/test_communication/test/subscribe_basic_types.hpp
@@ -1,0 +1,58 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SUBSCRIBE_BASIC_TYPES_HPP_
+#define SUBSCRIBE_BASIC_TYPES_HPP_
+
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "test_msgs/msg/empty.hpp"
+#include "test_msgs/msg/basic_types.hpp"
+#include "test_msgs/msg/builtins.hpp"
+#include "test_msgs/msg/constants.hpp"
+#include "test_msgs/msg/defaults.hpp"
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_empty(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Empty::SharedPtr> & messages_expected,
+  std::vector<bool> & received_messages);
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_basic_types(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::BasicTypes::SharedPtr> & messages_expected,
+  std::vector<bool> & received_messages);
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_builtins(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Builtins::SharedPtr> & messages_expected,
+  std::vector<bool> & received_messages);
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_constants(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Constants::SharedPtr> & messages_expected,
+  std::vector<bool> & received_messages);
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_defaults(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Defaults::SharedPtr> & messages_expected,
+  std::vector<bool> & received_messages);
+
+#endif  // SUBSCRIBE_BASIC_TYPES_HPP_

--- a/test_communication/test/subscribe_helper.hpp
+++ b/test_communication/test/subscribe_helper.hpp
@@ -1,0 +1,72 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SUBSCRIBE_HELPER_HPP_
+#define SUBSCRIBE_HELPER_HPP_
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+
+template<typename T>
+rclcpp::SubscriptionBase::SharedPtr subscribe(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<typename T::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages)
+{
+  received_messages.assign(expected_messages.size(), false);
+
+  auto callback =
+    [&expected_messages, &received_messages](
+    const typename T::ConstSharedPtr received_message
+    ) -> void
+    {
+      // find received message in vector of expected messages
+      auto received = received_messages.begin();
+      bool known_message = false;
+      size_t index = 0;
+      for (auto expected_message : expected_messages) {
+        if (*received_message == *expected_message) {
+          *received = true;
+          printf("received message #%zu of %zu\n", index + 1, expected_messages.size());
+          known_message = true;
+          break;
+        }
+        ++received;
+        ++index;
+      }
+      if (!known_message) {
+        throw std::runtime_error("received message does not match any expected message");
+      }
+
+      // shutdown node when all expected messages have been received
+      for (auto received_msg : received_messages) {
+        if (!received_msg) {
+          return;
+        }
+      }
+      rclcpp::shutdown();
+    };
+
+  auto qos = rclcpp::QoS(rclcpp::KeepLast(expected_messages.size()));
+
+  return
+    node->create_subscription<T>(std::string("test/message/") + message_type, qos, callback);
+}
+
+#endif  // SUBSCRIBE_HELPER_HPP_

--- a/test_communication/test/subscribe_string_types.cpp
+++ b/test_communication/test/subscribe_string_types.cpp
@@ -1,0 +1,43 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "test_msgs/msg/strings.hpp"
+#include "test_msgs/msg/w_strings.hpp"
+
+#include "subscribe_helper.hpp"
+#include "subscribe_string_types.hpp"
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_strings(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Strings::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::Strings>(
+    node, message_type, expected_messages, received_messages);
+}
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_wstrings(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::WStrings::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages)
+{
+  return subscribe<test_msgs::msg::WStrings>(
+    node, message_type, expected_messages, received_messages);
+}

--- a/test_communication/test/subscribe_string_types.hpp
+++ b/test_communication/test/subscribe_string_types.hpp
@@ -1,0 +1,37 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SUBSCRIBE_STRING_TYPES_HPP_
+#define SUBSCRIBE_STRING_TYPES_HPP_
+
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "test_msgs/msg/strings.hpp"
+#include "test_msgs/msg/w_strings.hpp"
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_strings(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::Strings::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages);
+
+rclcpp::SubscriptionBase::SharedPtr subscribe_wstrings(
+  rclcpp::Node::SharedPtr node,
+  const std::string & message_type,
+  const std::vector<test_msgs::msg::WStrings::SharedPtr> & expected_messages,
+  std::vector<bool> & received_messages);
+
+#endif  // SUBSCRIBE_STRING_TYPES_HPP_

--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -23,6 +23,10 @@
 
 #include "test_msgs/message_fixtures.hpp"
 
+#include "subscribe_array_types.hpp"
+#include "subscribe_basic_types.hpp"
+#include "subscribe_string_types.hpp"
+
 template<typename T>
 void publish(
   rclcpp::Node::SharedPtr node,
@@ -32,7 +36,7 @@ void publish(
 {
   auto qos = rclcpp::QoS(rclcpp::KeepLast(messages.size()));
 
-  auto publisher = node->create_publisher<T>(std::string("test_message_") + message_type, qos);
+  auto publisher = node->create_publisher<T>(std::string("test/message/") + message_type, qos);
 
   rclcpp::WallRate cycle_rate(10);
   rclcpp::WallRate message_rate(100);
@@ -50,56 +54,6 @@ void publish(
     ++cycle_index;
     cycle_rate.sleep();
   }
-}
-
-template<typename T>
-rclcpp::SubscriptionBase::SharedPtr subscribe(
-  rclcpp::Node::SharedPtr node,
-  const std::string & message_type,
-  std::vector<typename T::SharedPtr> & expected_messages,
-  std::vector<bool> & received_messages)
-{
-  received_messages.assign(expected_messages.size(), false);
-
-  auto callback =
-    [&expected_messages, &received_messages](
-    const typename T::ConstSharedPtr received_message
-    ) -> void
-    {
-      // find received message in vector of expected messages
-      auto received = received_messages.begin();
-      bool known_message = false;
-      size_t index = 0;
-      for (auto expected_message : expected_messages) {
-        if (*received_message == *expected_message) {
-          *received = true;
-          printf("received message #%zu of %zu\n", index + 1, expected_messages.size());
-          known_message = true;
-          break;
-        }
-        ++received;
-        ++index;
-      }
-      if (!known_message) {
-        fprintf(stderr, "received message does not match any expected message\n");
-        rclcpp::shutdown();
-        throw std::runtime_error("received message does not match any expected message");
-      }
-
-      // shutdown node when all expected messages have been received
-      for (auto received_msg : received_messages) {
-        if (!received_msg) {
-          return;
-        }
-      }
-      rclcpp::shutdown();
-    };
-
-  auto qos = rclcpp::QoS(rclcpp::KeepLast(expected_messages.size()));
-
-  auto subscriber =
-    node->create_subscription<T>(std::string("test_message_") + message_type, qos, callback);
-  return subscriber;
 }
 
 int main(int argc, char ** argv)
@@ -141,59 +95,49 @@ int main(int argc, char ** argv)
     });
 
   if (message == "Empty") {
-    subscriber = subscribe<test_msgs::msg::Empty>(
-      node, message, messages_empty, received_messages);
+    subscriber = subscribe_empty(node, message, messages_empty, received_messages);
     publish<test_msgs::msg::Empty>(node, message, messages_empty);
   } else if (message == "BasicTypes") {
-    subscriber = subscribe<test_msgs::msg::BasicTypes>(
-      node, message, messages_basic_types, received_messages);
+    subscriber = subscribe_basic_types(node, message, messages_basic_types, received_messages);
     publish<test_msgs::msg::BasicTypes>(node, message, messages_basic_types);
   } else if (message == "Arrays") {
-    subscriber = subscribe<test_msgs::msg::Arrays>(
-      node, message, messages_arrays, received_messages);
+    subscriber = subscribe_arrays(node, message, messages_arrays, received_messages);
     publish<test_msgs::msg::Arrays>(node, message, messages_arrays);
   } else if (message == "UnboundedSequences") {
-    subscriber = subscribe<test_msgs::msg::UnboundedSequences>(
+    subscriber = subscribe_unbounded_sequences(
       node, message, messages_unbounded_sequences, received_messages);
     publish<test_msgs::msg::UnboundedSequences>(
       node, message, messages_unbounded_sequences);
   } else if (message == "BoundedPlainSequences") {
-    subscriber = subscribe<test_msgs::msg::BoundedPlainSequences>(
+    subscriber = subscribe_bounded_plain_sequences(
       node, message, messages_bounded_plain_sequences, received_messages);
     publish<test_msgs::msg::BoundedPlainSequences>(
       node, message, messages_bounded_plain_sequences);
   } else if (message == "BoundedSequences") {
-    subscriber = subscribe<test_msgs::msg::BoundedSequences>(
+    subscriber = subscribe_bounded_sequences(
       node, message, messages_bounded_sequences, received_messages);
     publish<test_msgs::msg::BoundedSequences>(
       node, message, messages_bounded_sequences);
   } else if (message == "MultiNested") {
-    subscriber = subscribe<test_msgs::msg::MultiNested>(
-      node, message, messages_multi_nested, received_messages);
+    subscriber = subscribe_multi_nested(node, message, messages_multi_nested, received_messages);
     publish<test_msgs::msg::MultiNested>(node, message, messages_multi_nested);
   } else if (message == "Nested") {
-    subscriber = subscribe<test_msgs::msg::Nested>(
-      node, message, messages_nested, received_messages);
+    subscriber = subscribe_nested(node, message, messages_nested, received_messages);
     publish<test_msgs::msg::Nested>(node, message, messages_nested);
   } else if (message == "Builtins") {
-    subscriber = subscribe<test_msgs::msg::Builtins>(
-      node, message, messages_builtins, received_messages);
+    subscriber = subscribe_builtins(node, message, messages_builtins, received_messages);
     publish<test_msgs::msg::Builtins>(node, message, messages_builtins);
   } else if (message == "Constants") {
-    subscriber = subscribe<test_msgs::msg::Constants>(
-      node, message, messages_constants, received_messages);
+    subscriber = subscribe_constants(node, message, messages_constants, received_messages);
     publish<test_msgs::msg::Constants>(node, message, messages_constants);
   } else if (message == "Defaults") {
-    subscriber = subscribe<test_msgs::msg::Defaults>(
-      node, message, messages_defaults, received_messages);
+    subscriber = subscribe_defaults(node, message, messages_defaults, received_messages);
     publish<test_msgs::msg::Defaults>(node, message, messages_defaults);
   } else if (message == "Strings") {
-    subscriber = subscribe<test_msgs::msg::Strings>(
-      node, message, messages_strings, received_messages);
+    subscriber = subscribe_strings(node, message, messages_strings, received_messages);
     publish<test_msgs::msg::Strings>(node, message, messages_strings);
   } else if (message == "WStrings") {
-    subscriber = subscribe<test_msgs::msg::WStrings>(
-      node, message, messages_wstrings, received_messages);
+    subscriber = subscribe_wstrings(node, message, messages_wstrings, received_messages);
     publish<test_msgs::msg::WStrings>(node, message, messages_wstrings);
   } else {
     fprintf(stderr, "Unknown message argument '%s'\n", message.c_str());


### PR DESCRIPTION
This should avoid an OOM error when compiling on the buildfarm.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

In particular, the https://ci.ros2.org/view/nightly/job/nightly_linux_coverage/ jobs have been flaky for the last two nights, failing while building exactly this.  In my testing, this reduces the maximum amount of resident memory needed for any one compilation unit from 2.9G to 1.9G.

Regular CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16507)](http://ci.ros2.org/job/ci_linux/16507/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11094)](http://ci.ros2.org/job/ci_linux-aarch64/11094/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=16878)](http://ci.ros2.org/job/ci_windows/16878/)

Coverage build *without* this PR (this may or may not fail):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux_coverage&build=222)](http://ci.ros2.org/job/ci_linux_coverage/222/)

Coverage build *with* this PR:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux_coverage&build=223)](http://ci.ros2.org/job/ci_linux_coverage/223/)
