### PR TITLE
Remove Werror from test_quality_of_service.

### DIFF
--- a/test_quality_of_service/CMakeLists.txt
+++ b/test_quality_of_service/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
There really isn't a reason to hard-code it here, and this
makes it match the rest of packages in this repository (and
in all of ROS 2 more generally).

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>