### PR TITLE
Pass rclcpp::QoS to create_client

### DIFF
--- a/test_quality_of_service/test/test_best_available.cpp
+++ b/test_quality_of_service/test/test_best_available.cpp
@@ -151,5 +151,5 @@ TEST_F(QosRclcppTestFixture, test_best_available_policies_clients) {
   // Test no errors occur when creating a client with best available policies
   rclcpp::Node node("test_create_client_with_best_available_policies");
   node.create_client<test_msgs::srv::Empty>(
-    "test_best_available_client", rmw_qos_profile_best_available);
+    "test_best_available_client", rclcpp::BestAvailableQoS());
 }

--- a/test_rclcpp/test/test_client_scope_consistency_client.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_client.cpp
@@ -52,7 +52,7 @@ TEST_F(CLASSNAME(service_client, RMW_IMPLEMENTATION), client_scope_consistency_r
   auto node = rclcpp::Node::make_shared("client_scope_consistency_regression_test");
 
   // Replicate the settings that caused https://github.com/ros2/system_tests/issues/153
-  rmw_qos_profile_t rmw_qos_profile = rmw_qos_profile_default;
+  rclcpp::QoS rmw_qos_profile(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
   rclcpp::FutureReturnCode ret1;
 
   // Extra scope so the first client will be deleted afterwards

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -180,12 +180,12 @@ TEST_F(CLASSNAME(test_multithreaded, RMW_IMPLEMENTATION), multi_consumer_clients
       response->sum = request->a + request->b;
     };
 
-  rmw_qos_profile_t qos_profile = rmw_qos_profile_services_default;
-  qos_profile.depth = std::min<size_t>(executor.get_number_of_threads(), 16) * 2;
+  rclcpp::ServicesQoS qos_profile;
+  qos_profile.keep_last(std::min<size_t>(executor.get_number_of_threads(), 16) * 2);
   auto callback_group = node->create_callback_group(
     rclcpp::CallbackGroupType::Reentrant);
   auto service = node->create_service<test_rclcpp::srv::AddTwoInts>(
-    "multi_consumer_clients", callback, qos_profile, callback_group);
+    "multi_consumer_clients", callback, qos_profile.get_rmw_qos_profile(), callback_group);
 
   using ClientRequestPair = std::pair<
     rclcpp::Client<test_rclcpp::srv::AddTwoInts>::SharedPtr,


### PR DESCRIPTION
Part of ros2/rclcpp#1964

This passes `rclcpp::QoS` to `create_client`.