### PR TITLE
avoid flaky test

### DIFF
--- a/test_quality_of_service/include/test_quality_of_service/qos_utilities.hpp
+++ b/test_quality_of_service/include/test_quality_of_service/qos_utilities.hpp
@@ -42,7 +42,7 @@
 std::tuple<size_t, size_t> convert_chrono_milliseconds_to_size_t(
   const std::chrono::milliseconds & milliseconds);
 
-/// Helper wait for a predicate funtor to be true by a timeout
+/// Helper wait for a predicate to evaluate to true
 template<
   typename Predicate,
   typename TimeOutR, typename TimeOutP,

--- a/test_quality_of_service/include/test_quality_of_service/qos_utilities.hpp
+++ b/test_quality_of_service/include/test_quality_of_service/qos_utilities.hpp
@@ -42,6 +42,26 @@
 std::tuple<size_t, size_t> convert_chrono_milliseconds_to_size_t(
   const std::chrono::milliseconds & milliseconds);
 
+/// Helper wait for a predicate funtor to be true by a timeout
+template<
+  typename Predicate,
+  typename TimeOutR, typename TimeOutP,
+  typename PeriodR = int64_t, typename PeriodP = std::milli>
+bool wait_for(
+  Predicate predicate,
+  const std::chrono::duration<TimeOutR, TimeOutP> & timeout,
+  const std::chrono::duration<PeriodR, PeriodP> & period = std::chrono::milliseconds(100))
+{
+  auto end_time = std::chrono::steady_clock::now() + timeout;
+  while (!predicate()) {
+    if (std::chrono::steady_clock::now() > end_time) {
+      return predicate();
+    }
+    std::this_thread::sleep_for(period);
+  }
+  return true;
+}
+
 class BaseQosRclcppTestFixture : public ::testing::Test
 {
 protected:

--- a/test_quality_of_service/test/test_best_available.cpp
+++ b/test_quality_of_service/test/test_best_available.cpp
@@ -133,7 +133,7 @@ TEST_F(QosRclcppTestFixture, test_best_available_policies_publisher) {
   bool wait_ret = ::wait_for(
     [this, &topic, &publishers_info]() {
       publishers_info = publisher->get_publishers_info_by_topic(topic);
-      return publishers_info.size() == 1u ? true : false;
+      return publishers_info.size() == 1u;
     }, 5s);
   ASSERT_TRUE(wait_ret);
   ASSERT_EQ(publishers_info.size(), 1u);

--- a/test_quality_of_service/test/test_best_available.cpp
+++ b/test_quality_of_service/test/test_best_available.cpp
@@ -72,6 +72,8 @@ TEST_F(QosRclcppTestFixture, test_best_available_policies_subscription) {
   // Check actual subscription QoS
   // We expect it to have exactly the same policies as the publisher for some subset of policies
   std::vector<rclcpp::TopicEndpointInfo> subscriptions_info;
+  // Here we wait for the subscription created during the "toggle" above to appear, which may take
+  // some time.
   bool wait_ret = ::wait_for(
     [this, &topic, &subscriptions_info]() {
       subscriptions_info = subscriber->get_subscriptions_info_by_topic(topic);
@@ -130,6 +132,8 @@ TEST_F(QosRclcppTestFixture, test_best_available_policies_publisher) {
   // We expect it to have exactly the same policies as the publisher for some subset of policies
   // However, it should always be reliable and transient local (for DDS middlewares)
   std::vector<rclcpp::TopicEndpointInfo> publishers_info;
+  // Here we wait for the publisher created during the "toggle" above to appear, which may take
+  // some time.
   bool wait_ret = ::wait_for(
     [this, &topic, &publishers_info]() {
       publishers_info = publisher->get_publishers_info_by_topic(topic);


### PR DESCRIPTION
to fix https://github.com/ros2/rmw_cyclonedds/issues/440

refer to [ros2cli](https://github.com/ros2/ros2cli/blob/14e640c6060fcb191eee266c55bbf4bed6ac97db/ros2cli/ros2cli/helpers.py#L25) to implement a `wait_for`, and then wait to call the `get_subscriptions_info_by_topic` or `get_publishers_info_by_topic` by a timeout.

NOTE: keep the https://github.com/iuhilnehc-ynos/system_tests/blob/5b4ee6075a4a67ef7f8efbf27e0fcdf3adda6888/test_quality_of_service/test/test_best_available.cpp#L57-L68 and https://github.com/iuhilnehc-ynos/system_tests/blob/5b4ee6075a4a67ef7f8efbf27e0fcdf3adda6888/test_quality_of_service/test/test_best_available.cpp#L114-L125 because they do assert in the tests even if it's not the intention for the test name.