### PR TITLE
Fix ODR errors with gtest

### DIFF
--- a/test_quality_of_service/CMakeLists.txt
+++ b/test_quality_of_service/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -44,6 +44,8 @@ if(BUILD_TESTING)
 
   ament_find_gtest()
   target_include_directories(${PROJECT_NAME}_support PUBLIC "${GTEST_INCLUDE_DIRS}")
+  target_compile_definitions(${PROJECT_NAME}_support PRIVATE
+    "TEST_QUALITY_OF_SERVICE_BUILDING_LIBRARY")
   ament_target_dependencies(${PROJECT_NAME}_support rclcpp rcutils std_msgs)
 
   function(add_custom_gtest target)

--- a/test_quality_of_service/CMakeLists.txt
+++ b/test_quality_of_service/CMakeLists.txt
@@ -44,7 +44,6 @@ if(BUILD_TESTING)
 
   ament_find_gtest()
   target_include_directories(${PROJECT_NAME}_support PUBLIC "${GTEST_INCLUDE_DIRS}")
-  target_link_libraries(${PROJECT_NAME}_support ${GTEST_LIBRARIES})
   ament_target_dependencies(${PROJECT_NAME}_support rclcpp rcutils std_msgs)
 
   function(add_custom_gtest target)

--- a/test_quality_of_service/include/test_quality_of_service/qos_test_node.hpp
+++ b/test_quality_of_service/include/test_quality_of_service/qos_test_node.hpp
@@ -20,43 +20,55 @@
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
+#include "test_quality_of_service/visibility_control.hpp"
 
 /// Base class used for QoS system test nodes
 class QosTestNode : public rclcpp::Node
 {
 public:
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   QosTestNode(
     const std::string & name,
     const std::string & topic,
     const rclcpp::QoS & qos_options);
 
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   virtual ~QosTestNode();
 
   /// start working
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   void start();
   /// stop working
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   void stop();
   /// toggle between start and stop
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   void toggle();
   /// stop all work, should be called before destructor
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   virtual void teardown() = 0;
   /// return the number of measurements counted
   /**
    * \return the current count
    */
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   int get_count() const;
 
 protected:
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   bool get_started() const;
 
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   virtual void setup_start() = 0;
 
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   virtual void setup_stop() = 0;
 
   /// a measurement was taken, increment the count
   /**
    * \return the incremented count
    */
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   int increment_count();
 
   /// name of this publisher (Node)

--- a/test_quality_of_service/include/test_quality_of_service/qos_test_publisher.hpp
+++ b/test_quality_of_service/include/test_quality_of_service/qos_test_publisher.hpp
@@ -23,23 +23,29 @@
 #include "std_msgs/msg/string.hpp"
 
 #include "test_quality_of_service/qos_test_node.hpp"
+#include "test_quality_of_service/visibility_control.hpp"
 
 /// Simple publishing node used for system tests
 class QosTestPublisher : public QosTestNode
 {
 public:
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   QosTestPublisher(
     const std::string & name,
     const std::string & topic,
     const rclcpp::QoS & qos_options,
     const std::chrono::milliseconds & publish_period);
 
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   virtual ~QosTestPublisher() = default;
+
   QosTestPublisher(QosTestPublisher const &) = delete;
   QosTestPublisher & operator=(QosTestPublisher const &) = delete;
 
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   rclcpp::PublisherOptions & options() {return publisher_options_;}
 
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   void teardown() override;
 
 private:

--- a/test_quality_of_service/include/test_quality_of_service/qos_test_subscriber.hpp
+++ b/test_quality_of_service/include/test_quality_of_service/qos_test_subscriber.hpp
@@ -22,22 +22,28 @@
 #include "std_msgs/msg/string.hpp"
 
 #include "test_quality_of_service/qos_test_node.hpp"
+#include "test_quality_of_service/visibility_control.hpp"
 
 /// Simple subscriber node used for system tests
 class QosTestSubscriber : public QosTestNode
 {
 public:
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   QosTestSubscriber(
     const std::string & name,
     const std::string & topic,
     const rclcpp::QoS & qos_options);
 
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   virtual ~QosTestSubscriber() = default;
+
   QosTestSubscriber(QosTestSubscriber const &) = delete;
   QosTestSubscriber & operator=(QosTestSubscriber const &) = delete;
 
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   rclcpp::SubscriptionOptions & options() {return sub_options_;}
 
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   void teardown() override;
 
 private:

--- a/test_quality_of_service/include/test_quality_of_service/qos_utilities.hpp
+++ b/test_quality_of_service/include/test_quality_of_service/qos_utilities.hpp
@@ -26,6 +26,7 @@
 #include "rcutils/macros.h"
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
+#include "test_quality_of_service/visibility_control.hpp"
 
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
@@ -39,6 +40,7 @@
  * @param milliseconds
  * @return tuple of milliseconds converted to <seconds, nanoseconds>
  */
+TEST_QUALITY_OF_SERVICE_PUBLIC
 std::tuple<size_t, size_t> convert_chrono_milliseconds_to_size_t(
   const std::chrono::milliseconds & milliseconds);
 
@@ -65,7 +67,9 @@ bool wait_for(
 class BaseQosRclcppTestFixture : public ::testing::Test
 {
 protected:
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   void SetUp() override;
+  TEST_QUALITY_OF_SERVICE_PUBLIC
   void TearDown() override;
   // executor used to submit work
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor;

--- a/test_quality_of_service/include/test_quality_of_service/visibility_control.hpp
+++ b/test_quality_of_service/include/test_quality_of_service/visibility_control.hpp
@@ -1,0 +1,58 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_QUALITY_OF_SERVICE__VISIBILITY_CONTROL_HPP_
+#define TEST_QUALITY_OF_SERVICE__VISIBILITY_CONTROL_HPP_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define TEST_QUALITY_OF_SERVICE_EXPORT __attribute__ ((dllexport))
+    #define TEST_QUALITY_OF_SERVICE_IMPORT __attribute__ ((dllimport))
+  #else
+    #define TEST_QUALITY_OF_SERVICE_EXPORT __declspec(dllexport)
+    #define TEST_QUALITY_OF_SERVICE_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef TEST_QUALITY_OF_SERVICE_BUILDING_LIBRARY
+    #define TEST_QUALITY_OF_SERVICE_PUBLIC TEST_QUALITY_OF_SERVICE_EXPORT
+  #else
+    #define TEST_QUALITY_OF_SERVICE_PUBLIC TEST_QUALITY_OF_SERVICE_IMPORT
+  #endif
+  #define TEST_QUALITY_OF_SERVICE_PUBLIC_TYPE TEST_QUALITY_OF_SERVICE_PUBLIC
+  #define TEST_QUALITY_OF_SERVICE_LOCAL
+#else
+  #define TEST_QUALITY_OF_SERVICE_EXPORT __attribute__ ((visibility("default")))
+  #define TEST_QUALITY_OF_SERVICE_IMPORT
+  #if __GNUC__ >= 4
+    #define TEST_QUALITY_OF_SERVICE_PUBLIC __attribute__ ((visibility("default")))
+    #define TEST_QUALITY_OF_SERVICE_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define TEST_QUALITY_OF_SERVICE_PUBLIC
+    #define TEST_QUALITY_OF_SERVICE_LOCAL
+  #endif
+  #define TEST_QUALITY_OF_SERVICE_PUBLIC_TYPE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TEST_QUALITY_OF_SERVICE__VISIBILITY_CONTROL_HPP_

--- a/test_quality_of_service/package.xml
+++ b/test_quality_of_service/package.xml
@@ -10,7 +10,7 @@
     <maintainer email="brandon@openrobotics.org">Brandon Ong</maintainer>
 
     <license>Apache License 2.0</license>
-    
+
 
     <author email="aditya.pande@openrobotics.org">Aditya Pande</author>
     <author email="ros-contributions@amazon.com">Amazon ROS Contributions</author>
@@ -18,9 +18,9 @@
     <author email="shane@openrobotics.org">Shane Loretz</author>
     <author email="william@openrobotics.org">William Woodall</author>
 
-    <buildtool_depend>ament_cmake</buildtool_depend>
+    <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-    <test_depend>ament_cmake</test_depend>
+    <test_depend>ament_cmake_ros</test_depend>
     <test_depend>ament_cmake_gtest</test_depend>
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
`test_quality_of_service` is explicitly linking against gtest, but it gets linked again as a result of the `ament_add_gtest` call.

This causes an ODR violation, but it didn't seem to cause any issues with tests.
Running the QOS tests with asan causes ODR violations though.