### PR TITLE
refactor the multi_access_publisher test to avoid dead locks

### DIFF
--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -378,6 +378,7 @@ static inline void multi_access_publisher(bool intra_process)
     if (timer_counter.load() == num_messages && subscription_counter.load() == num_messages) {
       break;
     }
+    std::this_thread::sleep_for(time_between_checks);
   }
 
   executor.cancel();

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -370,7 +370,9 @@ static inline void multi_access_publisher(bool intra_process)
         next_publish_count = publish_counter++;
       }
       // publish a new message
-      msg->data = next_publish_count;
+      using DataT = decltype(msg->data);
+      assert(next_publish_count <= std::numeric_limits<DataT>::max);
+      msg->data = static_cast<DataT>(next_publish_count);
       printf("Publishing message %u\n", msg->data);
       pub->publish(std::move(msg));
     };

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -345,8 +345,8 @@ static inline void multi_access_publisher(bool intra_process)
   std::atomic_uint timer_counter(0);
   auto timer_callback =
     [&executor, &pub, &timer_counter, &subscription_counter, &num_messages](
-    rclcpp::TimerBase & timer
-    ) {
+    rclcpp::TimerBase & timer)
+    {
       auto msg = std::make_unique<test_rclcpp::msg::UInt32>();
       auto next_timer_count = timer_counter.fetch_add(1);
       if (next_timer_count >= num_messages) {
@@ -370,7 +370,7 @@ static inline void multi_access_publisher(bool intra_process)
   executor.add_node(node);
   std::thread executor_thread([&executor]() {executor.spin();});
 
-  // wait order or magnitude longer than technically required to allow for system hiccups
+  // wait order of magnitude longer than technically required to allow for system hiccups
   auto time_to_wait = std::chrono::milliseconds(number_of_messages_per_timer * timer_period * 10);
   auto time_between_checks = time_to_wait / 100;
   auto start = std::chrono::steady_clock::now();

--- a/test_rclcpp/test/test_multithreaded.cpp
+++ b/test_rclcpp/test/test_multithreaded.cpp
@@ -353,13 +353,13 @@ static inline void multi_access_publisher(bool intra_process)
   test_rclcpp::wait_for_subscriber(node, node_topic_name);
 
   // timers
-  size_t publish_counter = 0;
+  uint32_t publish_counter = 0;
   auto timer_callback =
     [&executor, &pub, &publish_counter, &counters_mutex, &num_messages](
     rclcpp::TimerBase & timer)
     {
       auto msg = std::make_unique<test_rclcpp::msg::UInt32>();
-      size_t next_publish_count = 0;
+      uint32_t next_publish_count = 0;
       {
         std::lock_guard<std::mutex> lock(counters_mutex);
         if (publish_counter == num_messages) {
@@ -370,9 +370,8 @@ static inline void multi_access_publisher(bool intra_process)
         next_publish_count = publish_counter++;
       }
       // publish a new message
-      using DataT = decltype(msg->data);
-      assert(next_publish_count <= std::numeric_limits<DataT>::max);
-      msg->data = static_cast<DataT>(next_publish_count);
+      ASSERT_LE(next_publish_count, std::numeric_limits<uint32_t>::max());
+      msg->data = next_publish_count;
       printf("Publishing message %u\n", msg->data);
       pub->publish(std::move(msg));
     };


### PR DESCRIPTION
This is based on discussions with @clalancette and @mjcarroll about this test failing some times on low-core machines, the theory being that the timers all are waiting on the subscriptions, but doing so by blocking and therefore using all the executor threads. This change mainly changes this by having the timers give up after publishing everything and then having a separate thread to monitor the test and cancel the executor when done.