### PR TITLE
Adjust for new rclcpp::Rate API

### DIFF
--- a/test_communication/test/test_publisher_subscriber.cpp
+++ b/test_communication/test/test_publisher_subscriber.cpp
@@ -38,21 +38,30 @@ void publish(
 
   auto publisher = node->create_publisher<T>(std::string("test/message/") + message_type, qos);
 
-  rclcpp::WallRate cycle_rate(10);
-  rclcpp::WallRate message_rate(100);
-  size_t cycle_index = 0;
-  // publish all messages up to number_of_cycles times, longer sleep between each cycle
-  while (rclcpp::ok() && cycle_index < number_of_cycles) {
-    size_t message_index = 0;
-    // publish all messages one by one, shorter sleep between each message
-    while (rclcpp::ok() && message_index < messages.size()) {
-      printf("publishing message #%zu\n", message_index + 1);
-      publisher->publish(*messages[message_index]);
-      ++message_index;
-      message_rate.sleep();
+  try {
+    rclcpp::WallRate cycle_rate(10);
+    rclcpp::WallRate message_rate(100);
+    size_t cycle_index = 0;
+    // publish all messages up to number_of_cycles times, longer sleep between each cycle
+    while (rclcpp::ok() && cycle_index < number_of_cycles) {
+      size_t message_index = 0;
+      // publish all messages one by one, shorter sleep between each message
+      while (rclcpp::ok() && message_index < messages.size()) {
+        printf("publishing message #%zu\n", message_index + 1);
+        publisher->publish(*messages[message_index]);
+        ++message_index;
+        message_rate.sleep();
+      }
+      ++cycle_index;
+      cycle_rate.sleep();
     }
-    ++cycle_index;
-    cycle_rate.sleep();
+  } catch (const std::exception & ex) {
+    // It is expected to get into invalid context during the sleep, since rclcpp::shutdown()
+    // might be called earlier (e.g. by subscribe() routine or when running *AfterShutdown case)
+    if (ex.what() != std::string("context cannot be slept with because it's invalid")) {
+      printf("ERROR: got unexpected exception: %s\n", ex.what());
+      throw ex;
+    }
   }
 }
 

--- a/test_security/test/test_secure_publisher.cpp
+++ b/test_security/test/test_secure_publisher.cpp
@@ -32,21 +32,30 @@ int8_t attempt_publish(
 
   auto publisher = node->create_publisher<T>(topic_name, messages.size());
 
-  rclcpp::WallRate cycle_rate(10);
-  rclcpp::WallRate message_rate(100);
-  size_t cycle_index = 0;
-  // publish all messages up to number_of_cycles times, longer sleep between each cycle
-  while (rclcpp::ok() && cycle_index < number_of_cycles) {
-    size_t message_index = 0;
-    // publish all messages one by one, shorter sleep between each message
-    while (rclcpp::ok() && message_index < messages.size()) {
-      printf("publishing message #%zu\n", message_index + 1);
-      publisher->publish(*messages[message_index]);
-      ++message_index;
-      message_rate.sleep();
+  try {
+    rclcpp::WallRate cycle_rate(10);
+    rclcpp::WallRate message_rate(100);
+    size_t cycle_index = 0;
+    // publish all messages up to number_of_cycles times, longer sleep between each cycle
+    while (rclcpp::ok() && cycle_index < number_of_cycles) {
+      size_t message_index = 0;
+      // publish all messages one by one, shorter sleep between each message
+      while (rclcpp::ok() && message_index < messages.size()) {
+        printf("publishing message #%zu\n", message_index + 1);
+        publisher->publish(*messages[message_index]);
+        ++message_index;
+        message_rate.sleep();
+      }
+      ++cycle_index;
+      cycle_rate.sleep();
     }
-    ++cycle_index;
-    cycle_rate.sleep();
+  } catch (const std::exception & ex) {
+    // It is expected to get into invalid context during the sleep, since rclcpp::shutdown()
+    // might be called earlier (e.g. when running *AfterShutdown case)
+    if (ex.what() != std::string("context cannot be slept with because it's invalid")) {
+      printf("ERROR: got unexpected exception: %s\n", ex.what());
+      throw ex;
+    }
   }
 
   auto end = std::chrono::steady_clock::now();


### PR DESCRIPTION
This is a adjustement fix for the test regressions appeared in `test_communication` and `test_security` after applying new `rclcpp::Rate` API (https://github.com/ros2/rclcpp/pull/2123).

The new `rclcpp::Rate` API after the change implies that RCLCPP context should exist at the `rate.sleep()` call time. However, internal test publisher's logic does not destroy the `Rate` objects after RCLCPP was stopped, which causes a runtime exceptions. Moreover, there are some tests (named `**AfterShutdown`), that intentionally runs the subscriber and publisher nodes (with `rclcpp::Rate` working inside) after the context was stopped and checks that everything is just closed correctly. This in our case is also causing the same run-time exception.

Thus, without large test modification, it is seems to be impossible to fix it by just changing the `rclcpp::Rate` usage logic. Therefore, it was chosen to handle the `context cannot be slept with because it's invalid` exceptions appears during the `rclcpp::Rate` usage w/o context. This exception raises in two cases described above, when test was already finished. So, this should be a simpler way to handle this, I suppose.