### PR TITLE
Fix test QoS on macOS by re-adding target_link_libraries *_support GTEST_LIBRARIES

### DIFF
--- a/test_quality_of_service/CMakeLists.txt
+++ b/test_quality_of_service/CMakeLists.txt
@@ -39,11 +39,9 @@ if(BUILD_TESTING)
     test/qos_test_node.cpp
     test/qos_test_publisher.cpp
     test/qos_test_subscriber.cpp
-    test/qos_utilities.cpp
   )
 
   ament_find_gtest()
-  target_include_directories(${PROJECT_NAME}_support PUBLIC "${GTEST_INCLUDE_DIRS}")
   target_compile_definitions(${PROJECT_NAME}_support PRIVATE
     "TEST_QUALITY_OF_SERVICE_BUILDING_LIBRARY")
   ament_target_dependencies(${PROJECT_NAME}_support rclcpp rcutils std_msgs)
@@ -61,10 +59,10 @@ if(BUILD_TESTING)
   endfunction()
 
   macro(tests)
-    add_custom_gtest(test_deadline test/test_deadline.cpp)
-    add_custom_gtest(test_lifespan test/test_lifespan.cpp)
-    add_custom_gtest(test_liveliness test/test_liveliness.cpp)
-    add_custom_gtest(test_best_available test/test_best_available.cpp)
+    add_custom_gtest(test_deadline test/test_deadline.cpp test/qos_utilities.cpp)
+    add_custom_gtest(test_lifespan test/test_lifespan.cpp test/qos_utilities.cpp)
+    add_custom_gtest(test_liveliness test/test_liveliness.cpp test/qos_utilities.cpp)
+    add_custom_gtest(test_best_available test/test_best_available.cpp test/qos_utilities.cpp)
   endmacro()
 
   call_for_each_rmw_implementation(tests)

--- a/test_quality_of_service/include/test_quality_of_service/qos_utilities.hpp
+++ b/test_quality_of_service/include/test_quality_of_service/qos_utilities.hpp
@@ -40,7 +40,6 @@
  * @param milliseconds
  * @return tuple of milliseconds converted to <seconds, nanoseconds>
  */
-TEST_QUALITY_OF_SERVICE_PUBLIC
 std::tuple<size_t, size_t> convert_chrono_milliseconds_to_size_t(
   const std::chrono::milliseconds & milliseconds);
 
@@ -67,9 +66,7 @@ bool wait_for(
 class BaseQosRclcppTestFixture : public ::testing::Test
 {
 protected:
-  TEST_QUALITY_OF_SERVICE_PUBLIC
   void SetUp() override;
-  TEST_QUALITY_OF_SERVICE_PUBLIC
   void TearDown() override;
   // executor used to submit work
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor;


### PR DESCRIPTION
Fixes #517 by re-adding `target_link_libraries(${PROJECT_NAME}_support ${GTEST_LIBRARIES})` to `test_quality_of_service/CMakeLists.txt:47`.

Tested with macOS Ventura 13.4 arm64 and Docker container [arm64v8/ubuntu:latest](https://hub.docker.com/r/arm64v8/ubuntu/)