### PR TITLE
Extract sros_artifacts fixture into a CMake script

### DIFF
--- a/test_security/CMakeLists.txt
+++ b/test_security/CMakeLists.txt
@@ -322,44 +322,16 @@ if(BUILD_TESTING)
     #   for the tests in this package.
     #
 
-    # remove previously generated enclaves
-    add_test(NAME pre_clean_artifacts
-      COMMAND ${CMAKE_COMMAND} -E rm -rf "${KEYSTORE_DIRECTORY}/enclaves/"
-    )
-    set_tests_properties(pre_clean_artifacts PROPERTIES
-      FIXTURES_SETUP sros_artifacts
-    )
+    find_program(ROS2_EXECUTABLE ros2)
 
-    # generate security artifacts using sros2
-    find_program(PROGRAM ros2)
-
-    set(node_names_list "/publisher;/subscriber;/publisher_missing_key;/publisher_invalid_cert")
-    set(generate_artifacts_command ${PROGRAM} security generate_artifacts -k ${KEYSTORE_DIRECTORY_NATIVE_PATH} -e ${node_names_list})
-    add_test(NAME generate_artifacts
-      COMMAND ${generate_artifacts_command}
+    add_test(NAME sros_artifacts
+      COMMAND ${CMAKE_COMMAND}
+        "-DROS2_EXECUTABLE=${ROS2_EXECUTABLE}"
+        "-DKEYSTORE_DIRECTORY=${KEYSTORE_DIRECTORY}"
+        "-DKEYSTORE_DIRECTORY_NATIVE_PATH=${KEYSTORE_DIRECTORY_NATIVE_PATH}"
+        "-P${CMAKE_CURRENT_SOURCE_DIR}/test/sros_artifacts.cmake"
     )
-    set_tests_properties(generate_artifacts PROPERTIES
-      DEPENDS pre_clean_artifacts
-      FIXTURES_SETUP sros_artifacts
-    )
-
-    # deleting key of /publisher_missing_key
-    add_test(NAME remove_missing_key
-      COMMAND ${CMAKE_COMMAND} -E rm "${KEYSTORE_DIRECTORY}/enclaves/publisher_missing_key/key.pem"
-    )
-    set_tests_properties(remove_missing_key PROPERTIES
-      DEPENDS generate_artifacts
-      FIXTURES_SETUP sros_artifacts
-    )
-
-    # copy invalid certificate from source tree
-    add_test(NAME copy_invalid_cert
-      COMMAND ${CMAKE_COMMAND} -E copy
-        "${CMAKE_CURRENT_SOURCE_DIR}/test/test_security_files/publisher_invalid_cert/cert.pem"
-        "${KEYSTORE_DIRECTORY}/enclaves/publisher_invalid_cert/cert.pem"
-    )
-    set_tests_properties(copy_invalid_cert PROPERTIES
-      DEPENDS generate_artifacts
+    set_tests_properties(sros_artifacts PROPERTIES
       FIXTURES_SETUP sros_artifacts
     )
 

--- a/test_security/test/sros_artifacts.cmake
+++ b/test_security/test/sros_artifacts.cmake
@@ -1,0 +1,35 @@
+# Copyright 2023 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.7)
+
+set(node_names_list "/publisher;/subscriber;/publisher_missing_key;/publisher_invalid_cert")
+file(REMOVE_RECURSE "${KEYSTORE_DIRECTORY}/enclaves")
+set(generate_artifacts_command ${ROS2_EXECUTABLE} security generate_artifacts -k ${KEYSTORE_DIRECTORY_NATIVE_PATH} -e ${node_names_list})
+execute_process(
+  COMMAND ${generate_artifacts_command}
+  RESULT_VARIABLE GENERATE_ARTIFACTS_RESULT
+  ERROR_VARIABLE GENERATE_ARTIFACTS_ERROR
+)
+if(NOT ${GENERATE_ARTIFACTS_RESULT} EQUAL 0)
+  message(FATAL_ERROR "Failed to generate security artifacts: ${GENERATE_ARTIFACTS_ERROR}")
+endif()
+
+# deleting key of /publisher_missing_key
+file(REMOVE "${KEYSTORE_DIRECTORY}/enclaves/publisher_missing_key/key.pem")
+
+# copy invalid certificate from source tree
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/test_security_files/publisher_invalid_cert/cert.pem
+  DESTINATION ${KEYSTORE_DIRECTORY}/enclaves/publisher_invalid_cert/
+)


### PR DESCRIPTION
All of these commands should be run together to set up the fixture for the tests. When running tests with repitition, we want to run through the entire artifact setup and not run each individual command multiple times.

Fixes #522

CI, using `--retest-until-fail 2`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=19310)](http://ci.ros2.org/job/ci_linux/19310/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=13841)](http://ci.ros2.org/job/ci_linux-aarch64/13841/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=20030)](http://ci.ros2.org/job/ci_windows/20030/)