### PR TITLE
Stop using python_cmake_module.

### DIFF
--- a/test_cli/CMakeLists.txt
+++ b/test_cli/CMakeLists.txt
@@ -5,16 +5,6 @@ project(test_cli)
 find_package(ament_cmake_auto REQUIRED)
 
 if(BUILD_TESTING)
-  # Provides PYTHON_EXECUTABLE_DEBUG
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra REQUIRED)
-  set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
-  if(WIN32)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-      set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-    endif()
-  endif()
-
   # Default to C++17
   if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 17)
@@ -29,6 +19,8 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   find_package(rclcpp REQUIRED)
 
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
   ament_lint_auto_find_test_dependencies()
 
   add_executable(initial_params_rclcpp
@@ -39,7 +31,6 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(test_params_yaml
     test/test_params_yaml.py
-    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     ENV
       INITIAL_PARAMS_RCLCPP=$<TARGET_FILE:initial_params_rclcpp>
       INITIAL_PARAMS_RCLPY=${CMAKE_CURRENT_LIST_DIR}/test/initial_params.py

--- a/test_cli/package.xml
+++ b/test_cli/package.xml
@@ -17,7 +17,6 @@
   <author email="william@openrobotics.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <build_depend>ament_cmake</build_depend>
 

--- a/test_cli_remapping/CMakeLists.txt
+++ b/test_cli_remapping/CMakeLists.txt
@@ -5,16 +5,6 @@ project(test_cli_remapping)
 find_package(ament_cmake_auto REQUIRED)
 
 if(BUILD_TESTING)
-  # Provides PYTHON_EXECUTABLE_DEBUG
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra REQUIRED)
-  set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
-  if(WIN32)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-      set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-    endif()
-  endif()
-
   # Default to C++17
   if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 17)
@@ -30,6 +20,8 @@ if(BUILD_TESTING)
   find_package(rclcpp REQUIRED)
   find_package(test_msgs REQUIRED)
 
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
   ament_lint_auto_find_test_dependencies()
 
   add_executable(name_maker_rclcpp
@@ -42,7 +34,6 @@ if(BUILD_TESTING)
   add_launch_test(
     test/test_cli_remapping.py
     TARGET test_cli_remapping
-    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     ENV
       NAME_MAKER_RCLCPP=$<TARGET_FILE:name_maker_rclcpp>
       NAME_MAKER_RCLPY=${CMAKE_CURRENT_SOURCE_DIR}/test/name_maker.py

--- a/test_cli_remapping/package.xml
+++ b/test_cli_remapping/package.xml
@@ -17,7 +17,6 @@
   <author email="william@openrobotics.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <build_depend>ament_cmake</build_depend>
 

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -75,10 +75,6 @@ if(BUILD_TESTING)
 
   find_package(launch_testing_ament_cmake REQUIRED)
 
-  # Provides PYTHON_EXECUTABLE_DEBUG
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra REQUIRED)
-
   # get the rmw implementations ahead of time
   find_package(rmw_implementation_cmake REQUIRED)
   get_available_rmw_implementations(rmw_implementations2)
@@ -241,7 +237,6 @@ if(BUILD_TESTING)
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_publisher_subscriber${suffix}_$<CONFIG>.py"
       TARGET test_publisher_subscriber${suffix}
-      PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT ${timeout}
       ${SKIP_TEST})
@@ -283,7 +278,6 @@ if(BUILD_TESTING)
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_requester_replier${suffix}_$<CONFIG>.py"
       TARGET test_requester_replier${suffix}
-      PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT ${timeout}
       ${SKIP_TEST})
@@ -321,7 +315,6 @@ if(BUILD_TESTING)
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_action_client_server${suffix}_$<CONFIG>.py"
       TARGET test_action_client_server${suffix}
-      PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT ${timeout}
       ${SKIP_TEST})
@@ -335,7 +328,6 @@ if(BUILD_TESTING)
   endmacro()
 
   macro(configure_template _client_library1 _client_library2)
-    set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
     set(_client_library1 "${_client_library1}")
     set(_client_library2 "${_client_library2}")
     set(TEST_PUBLISHER_RCL "${_client_library1}")
@@ -349,14 +341,6 @@ if(BUILD_TESTING)
       set(suffix "__${_client_library1}")
     else()
       set(suffix "__${_client_library1}__${_client_library2}")
-    endif()
-
-    if(_client_library1 STREQUAL "rclpy" OR _client_library2 STREQUAL "rclpy")
-      if(WIN32)
-        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-          set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-        endif()
-      endif()
     endif()
 
     if(_client_library1 STREQUAL "rclpy")

--- a/test_communication/package.xml
+++ b/test_communication/package.xml
@@ -22,7 +22,6 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
We really don't need it anymore, and can just use the builtin find_package(Python3).

This must be merged before https://github.com/ros2/ros2/pull/1524 ; see that pull request for more information about this change.