### PR TITLE
Change up the formatting in the test_rclcpp tests.

### DIFF
--- a/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
+++ b/test_rclcpp/test/test_avoid_ros_namespace_conventions_qos.cpp
@@ -47,8 +47,7 @@ TEST_F(test_avoid_ros_namespace_conventions_qos, pub_sub_works)
   // code to create the callback and subscription
   int counter = 0;
   auto callback =
-    [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg,
-      const rclcpp::MessageInfo & info) -> void
+    [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg, const rclcpp::MessageInfo & info)
     {
       ++counter;
       printf("  callback() %d with message data %u\n", counter, msg->data);

--- a/test_rclcpp/test/test_publisher.cpp
+++ b/test_rclcpp/test/test_publisher.cpp
@@ -47,8 +47,7 @@ TEST_F(test_publisher, publish_with_const_reference)
   // code to create the callback and subscription
   int counter = 0;
   auto callback =
-    [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg,
-      const rclcpp::MessageInfo & info) -> void
+    [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg, const rclcpp::MessageInfo & info)
     {
       ++counter;
       printf("  callback() %d with message data %u\n", counter, msg->data);

--- a/test_rclcpp/test/test_subscription.cpp
+++ b/test_rclcpp/test/test_subscription.cpp
@@ -290,8 +290,7 @@ TEST_F(test_subscription, subscription_shared_ptr_const_with_info)
   // create the callback and subscription
   int counter = 0;
   auto callback =
-    [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg,
-      const rclcpp::MessageInfo & info) -> void
+    [&counter](test_rclcpp::msg::UInt32::ConstSharedPtr msg, const rclcpp::MessageInfo & info)
     {
       ++counter;
       printf("  callback() %d with message data %u\n", counter, msg->data);


### PR DESCRIPTION
Newer uncrustify changes the indentation around lambdas. Avoid that here by making sure the lambdas are all on either one or two lines, which should make this work for both current and newer uncrustify.