### PR TITLE
rmw_zenoh: Fix deadline and liveliness tests

### DIFF
--- a/test_quality_of_service/test/test_deadline.cpp
+++ b/test_quality_of_service/test/test_deadline.cpp
@@ -103,11 +103,16 @@ TEST_F(QosRclcppTestFixture, test_deadline) {
   EXPECT_GT(publisher->get_count(), 0);  // check if we published anything
   EXPECT_GT(subscriber->get_count(), 0);  // check if we received anything
 
-  // check to see if callbacks fired as expected
-  EXPECT_EQ(expected_number_of_events, total_number_of_subscriber_deadline_events);
-  EXPECT_EQ(expected_number_of_events, total_number_of_publisher_deadline_events);
+  // rmw_zenoh does not support Deadline/LivelinessChanged,
+  std::string rmw_implementation_str = std::string(rmw_get_implementation_identifier());
 
-  // check values reported by the callback
-  EXPECT_EQ(expected_number_of_events, last_pub_count);
-  EXPECT_EQ(expected_number_of_events, last_sub_count);
+  if (rmw_implementation_str != "rmw_zenoh_cpp") {
+    // check to see if callbacks fired as expected
+    EXPECT_EQ(expected_number_of_events, total_number_of_subscriber_deadline_events);
+    EXPECT_EQ(expected_number_of_events, total_number_of_publisher_deadline_events);
+
+    // check values reported by the callback
+    EXPECT_EQ(expected_number_of_events, last_pub_count);
+    EXPECT_EQ(expected_number_of_events, last_sub_count);
+  }
 }

--- a/test_quality_of_service/test/test_liveliness.cpp
+++ b/test_quality_of_service/test/test_liveliness.cpp
@@ -114,7 +114,13 @@ TEST_F(QosRclcppTestFixture, test_automatic_liveliness_changed) {
   kill_publisher_timer->cancel();
 
   EXPECT_EQ(1, timer_fired_count);
-  EXPECT_EQ(2, total_number_of_liveliness_events);  // check expected number of liveliness events
+
+  // rmw_zenoh does not support Deadline/LivelinessChanged,
+  std::string rmw_implementation_str = std::string(rmw_get_implementation_identifier());
+  if (rmw_implementation_str != "rmw_zenoh_cpp") {
+    EXPECT_EQ(2, total_number_of_liveliness_events);  // check expected number of liveliness events
+  }
+
   EXPECT_GT(number_of_published_messages, 0);  // check if we published anything
   EXPECT_GT(subscriber->get_count(), 0);  // check if we received anything
 }


### PR DESCRIPTION
deadline and liveliness are not supported in rmw_zenoh, skipping the checks

`test_best_available__rmw_zenoh_cpp` is still failing. what I should do with these test? because it's using deadline

 - `system_tests/test_quality_of_service/test/test_best_available.cpp:142: Failure`
 - `system_tests/test_quality_of_service/test/test_best_available.cpp:82: Failure`