### PR TITLE
fix: ensure test verifies the existence of all spawning nodes

### DIFF
--- a/test_rclcpp/test/node_check_names.cpp
+++ b/test_rclcpp/test/node_check_names.cpp
@@ -28,7 +28,7 @@ int main(int argc, char ** argv)
   }
 
   int num_nodes = ::strtol(argv[1], nullptr, 10);
-  std::string node_to_look_for("/node_with_name");
+  std::string node_to_look_for("/node_with_name_");
   printf("Waiting for %d nodes with name: node_with_name_N\n", num_nodes);
   std::cout.flush();
 
@@ -42,11 +42,21 @@ int main(int argc, char ** argv)
   const std::chrono::steady_clock::time_point max_runtime =
     std::chrono::steady_clock::now() + std::chrono::seconds(10);
 
+  std::vector<bool> found(num_nodes);
+
   while (rclcpp::ok()) {
     auto names = node->get_node_graph_interface()->get_node_names();
     for (auto it : names) {
       if (it.compare(0, node_to_look_for.length(), node_to_look_for) == 0) {
-        counter++;
+        try {
+          int idx = std::stoi(it.substr(node_to_look_for.length()));
+          if (!found[idx]) {
+            found[idx] = true;
+            counter++;
+          }
+        } catch (const std::invalid_argument &) {
+          fprintf(stderr, "The name suffix of the node %s isn't a valid number.\n", it.c_str());
+        }
       }
     }
     if (counter >= num_nodes) {

--- a/test_rclcpp/test/test_n_nodes.py.in
+++ b/test_rclcpp/test/test_n_nodes.py.in
@@ -24,7 +24,7 @@ def generate_test_description():
     for i in range(@TEST_NUM_NODES@):
         launch_description.add_action(
             ExecuteProcess(
-                cmd=['@TEST_EXECUTABLE1@'],
+                cmd=['@TEST_EXECUTABLE1@', str(i)],
                 name='node_with_name_' + str(i),
                 env=env,
             )
@@ -52,13 +52,4 @@ class TestNNodes(unittest.TestCase):
 class TestNNodesAfterShutdown(unittest.TestCase):
 
     def test_@TEST_NUM_NODES@_nodes(self, proc_info):
-        launch_testing.asserts.assertExitCodes(
-            proc_info,
-            [launch_testing.asserts.EXIT_OK],
-            'node_check_names'
-        )
-        for i in range(@TEST_NUM_NODES@):
-            launch_testing.asserts.assertExitCodes(
-                proc_info,
-                process='node_with_name_' + str(i),
-            )
+        launch_testing.asserts.assertExitCodes(proc_info)


### PR DESCRIPTION
This PR aims to address #557. 

1. The checking node now checks all the required nodes to be ready.
2. Improve the assertion to support checking more than ten nodes. The old way relies on matching process names and can lead to process resolving failure (e.g. If we test 11 nodes,  `node_with_name_1` and `node_with_name_11` are matched by "node_with_name_1").