### PR TITLE
Skip all multi-vendor pub/sub tests with zenoh

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -195,6 +195,15 @@ if(BUILD_TESTING)
       set(rmw_implementation2_is_cyclonedds TRUE)
     endif()
 
+    set(rmw_implementation1_is_zenoh FALSE)
+    set(rmw_implementation2_is_zenoh FALSE)
+    if(rmw_implementation1 MATCHES "(.*)zenoh(.*)")
+      set(rmw_implementation1_is_zenoh TRUE)
+    endif()
+    if(rmw_implementation2 MATCHES "(.*)zenoh(.*)")
+      set(rmw_implementation2_is_zenoh TRUE)
+    endif()
+
     set(PUBLISHER_RMW ${rmw_implementation1})
     set(SUBSCRIBER_RMW ${rmw_implementation2})
     set(TEST_MESSAGE_TYPES "")
@@ -217,6 +226,14 @@ if(BUILD_TESTING)
           (rmw_implementation1_is_connext AND rmw_implementation2_is_cyclonedds) OR
           (rmw_implementation1_is_cyclonedds AND rmw_implementation2_is_connext)
         )
+      )
+        continue()
+      endif()
+      # Zenoh will not interoperate with any DDS based middlewares so we skip
+      # all multi-vendor pub/sub tests.
+      if(
+        (rmw_implementation1_is_zenoh AND NOT rmw_implementation2_is_zenoh) OR
+        (rmw_implementation2_is_zenoh AND NOT rmw_implementation1_is_zenoh)
       )
         continue()
       endif()

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -235,7 +235,7 @@ if(BUILD_TESTING)
         (rmw_implementation1_is_zenoh AND NOT rmw_implementation2_is_zenoh) OR
         (rmw_implementation2_is_zenoh AND NOT rmw_implementation1_is_zenoh)
       )
-        continue()
+        set(SKIP_TEST "SKIP_TEST")
       endif()
       list(APPEND TEST_MESSAGE_TYPES "${message_type}")
     endforeach()

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -203,6 +203,14 @@ if(BUILD_TESTING)
     if(rmw_implementation2 MATCHES "(.*)zenoh(.*)")
       set(rmw_implementation2_is_zenoh TRUE)
     endif()
+      # Zenoh will not interoperate with any DDS based middlewares so we skip
+      # all multi-vendor tests.
+    if(
+      (rmw_implementation1_is_zenoh AND NOT rmw_implementation2_is_zenoh) OR
+      (rmw_implementation2_is_zenoh AND NOT rmw_implementation1_is_zenoh)
+    )
+      set(SKIP_TEST "SKIP_TEST")
+    endif()
 
     set(PUBLISHER_RMW ${rmw_implementation1})
     set(SUBSCRIBER_RMW ${rmw_implementation2})
@@ -228,14 +236,6 @@ if(BUILD_TESTING)
         )
       )
         continue()
-      endif()
-      # Zenoh will not interoperate with any DDS based middlewares so we skip
-      # all multi-vendor pub/sub tests.
-      if(
-        (rmw_implementation1_is_zenoh AND NOT rmw_implementation2_is_zenoh) OR
-        (rmw_implementation2_is_zenoh AND NOT rmw_implementation1_is_zenoh)
-      )
-        set(SKIP_TEST "SKIP_TEST")
       endif()
       list(APPEND TEST_MESSAGE_TYPES "${message_type}")
     endforeach()


### PR DESCRIPTION
Address #559.

> Note: we already skip all multi-vendor tests between other RMWs for services & actions.

