### PR TITLE
Use rmw_event_type_is_supported to skip tests

### DIFF
--- a/test_quality_of_service/test/test_deadline.cpp
+++ b/test_quality_of_service/test/test_deadline.cpp
@@ -35,8 +35,9 @@ TEST_F(QosRclcppTestFixture, test_deadline) {
   std::string this_rmw_implementation = std::string(rmw_get_implementation_identifier());
 
   if (!rmw_event_type_is_supported(RMW_EVENT_OFFERED_DEADLINE_MISSED) ||
-    !rmw_event_type_is_supported(RMW_EVENT_REQUESTED_DEADLINE_MISSED)) {
-      GTEST_SKIP();
+    !rmw_event_type_is_supported(RMW_EVENT_REQUESTED_DEADLINE_MISSED))
+  {
+    GTEST_SKIP();
   }
 
   int expected_number_of_events = 4;

--- a/test_quality_of_service/test/test_deadline.cpp
+++ b/test_quality_of_service/test/test_deadline.cpp
@@ -34,8 +34,9 @@ using namespace std::chrono_literals;
 TEST_F(QosRclcppTestFixture, test_deadline) {
   std::string this_rmw_implementation = std::string(rmw_get_implementation_identifier());
 
-  if (this_rmw_implementation == "rmw_zenoh_cpp") {
-    GTEST_SKIP();
+  if (!rmw_event_type_is_supported(RMW_EVENT_OFFERED_DEADLINE_MISSED) ||
+    !rmw_event_type_is_supported(RMW_EVENT_REQUESTED_DEADLINE_MISSED)) {
+      GTEST_SKIP();
   }
 
   int expected_number_of_events = 4;

--- a/test_quality_of_service/test/test_liveliness.cpp
+++ b/test_quality_of_service/test/test_liveliness.cpp
@@ -38,8 +38,9 @@ using namespace std::chrono_literals;
 TEST_F(QosRclcppTestFixture, test_automatic_liveliness_changed) {
   std::string this_rmw_implementation = std::string(rmw_get_implementation_identifier());
 
-  if (this_rmw_implementation == "rmw_zenoh_cpp") {
-    GTEST_SKIP();
+  if (!rmw_event_type_is_supported(RMW_EVENT_LIVELINESS_CHANGED) ||
+    !rmw_event_type_is_supported(RMW_EVENT_LIVELINESS_LOST)) {
+      GTEST_SKIP();
   }
 
   const std::chrono::milliseconds max_test_length = 8s;

--- a/test_quality_of_service/test/test_liveliness.cpp
+++ b/test_quality_of_service/test/test_liveliness.cpp
@@ -39,8 +39,9 @@ TEST_F(QosRclcppTestFixture, test_automatic_liveliness_changed) {
   std::string this_rmw_implementation = std::string(rmw_get_implementation_identifier());
 
   if (!rmw_event_type_is_supported(RMW_EVENT_LIVELINESS_CHANGED) ||
-    !rmw_event_type_is_supported(RMW_EVENT_LIVELINESS_LOST)) {
-      GTEST_SKIP();
+    !rmw_event_type_is_supported(RMW_EVENT_LIVELINESS_LOST))
+  {
+    GTEST_SKIP();
   }
 
   const std::chrono::milliseconds max_test_length = 8s;


### PR DESCRIPTION
Related with this issue https://github.com/ros2/rmw_zenoh/issues/285. Use the new API in rmw to check if an event is supported 