### PR TITLE
Remove use of ament_target_dependencies

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -482,9 +482,7 @@ if(BUILD_TESTING)
         rosidl_typesupport_c::rosidl_typesupport_c
         rosidl_typesupport_cpp::rosidl_typesupport_cpp
         ${test_msgs_TARGETS}
-      )
-      ament_target_dependencies(${serialize_target_name}
-        ${rmw_implementation}
+        ${${rmw_implementation}_TARGETS}
       )
       set_tests_properties(
         ${serialize_target_name}
@@ -511,9 +509,7 @@ if(BUILD_TESTING)
         rosidl_typesupport_c::rosidl_typesupport_c
         rosidl_typesupport_cpp::rosidl_typesupport_cpp
         ${test_msgs_TARGETS}
-      )
-      ament_target_dependencies(${target_name}
-        ${rmw_implementation}
+        ${${rmw_implementation}_TARGETS}
       )
       set_tests_properties(
         ${target_name}


### PR DESCRIPTION
This is the last user of `ament_target_dependencies` in `ros2.repos` outside of `ament_cmake_auto`. This PR requires all rmw_implementations that `test_communication` export modern CMake targets, and put those targets into a `project_name_TARGETS` variable. This is done automatically for packages that use `ament_export_targets`.

edit: ready for review! ~~Draft until https://github.com/ros2/rmw_fastrtps/pull/814 is merged, as that's the last RMW implementation that only exports old-style standard CMake variables.~~

https://github.com/ament/ament_cmake/issues/292