### PR TITLE
Set envars to run tests with rmw_zenoh_cpp with multicast discovery

### DIFF
--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -130,6 +130,9 @@ if(BUILD_TESTING)
   endfunction()
 
   function(custom_test_c target)
+    message(STATUS "Creating tests for '${rmw_implementation}'")
+    set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
+
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
@@ -144,9 +147,8 @@ if(BUILD_TESTING)
       TIMEOUT 90
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       ENV
-      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-      RMW_IMPLEMENTATION=${rmw_implementation})
-      ${rmw_implementation_env_var}
+        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+        ${rmw_implementation_env_var})
     if(TARGET ${target}${target_suffix})
       rosidl_get_typesupport_target(c_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_c")
       target_link_libraries(${target}${target_suffix}
@@ -477,8 +479,8 @@ if(BUILD_TESTING)
   endif()
 
   macro(serialize)
-    set(serialize_target_name "test_serialize${target}${target_suffix}")
-
+    message(STATUS "Creating tests for '${rmw_implementation}'")
+    set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
@@ -487,13 +489,14 @@ if(BUILD_TESTING)
         RUST_LOG=z=error
       )
     endif()
+    set(serialize_target_name "test_serialize${target}${target_suffix}")
 
     ament_add_gtest(
       ${serialize_target_name} test/test_message_serialization.cpp
       TIMEOUT 30
       ENV
       RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-      RMW_IMPLEMENTATION=${rmw_implementation}
+      ${rmw_implementation_env_var}
     )
     if(TARGET ${serialize_target_name})
       add_dependencies(${serialize_target_name} ${PROJECT_NAME})
@@ -512,8 +515,8 @@ if(BUILD_TESTING)
   endmacro()
 
   macro(pub_sub_serialized)
-    set(target_name "test_publisher_subscriber_serialized${target}${target_suffix}")
-
+    message(STATUS "Creating tests for '${rmw_implementation}'")
+    set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
@@ -522,14 +525,14 @@ if(BUILD_TESTING)
         RUST_LOG=z=error
       )
     endif()
+    set(target_name "test_publisher_subscriber_serialized${target}${target_suffix}")
 
     ament_add_gtest(
       ${target_name} test/test_publisher_subscriber_serialized.cpp
       TIMEOUT 30
       ENV
-      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-      RMW_IMPLEMENTATION=${rmw_implementation}
-      ${rmw_implementation_env_var}
+        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+        ${rmw_implementation_env_var}
     )
     if(TARGET ${target_name})
       add_dependencies(${target_name} ${PROJECT_NAME})

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -83,6 +83,15 @@ if(BUILD_TESTING)
   endforeach()
 
   function(custom_test target with_message_argument)
+    set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
     if(with_message_argument)
       # adding test for each message type
       foreach(message_file ${message_files})
@@ -94,8 +103,9 @@ if(BUILD_TESTING)
           GENERATE_RESULT_FOR_RETURN_CODE_ZERO
           APPEND_LIBRARY_DIRS "${append_library_dirs}"
           ENV
-          RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-          RMW_IMPLEMENTATION=${rmw_implementation})
+            RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+            ${rmw_implementation_env_var}
+          )
         set_tests_properties(
           "${target}${target_suffix}__${TEST_MESSAGE_TYPE}"
           PROPERTIES REQUIRED_FILES "$<TARGET_FILE:${target}>"
@@ -109,8 +119,9 @@ if(BUILD_TESTING)
         GENERATE_RESULT_FOR_RETURN_CODE_ZERO
         APPEND_LIBRARY_DIRS "${append_library_dirs}"
         ENV
-        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-        RMW_IMPLEMENTATION=${rmw_implementation})
+          RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+          ${rmw_implementation_env_var}
+        )
       set_tests_properties(
         "${target}${target_suffix}"
         PROPERTIES REQUIRED_FILES "$<TARGET_FILE:${target}>"
@@ -130,9 +141,7 @@ if(BUILD_TESTING)
   endfunction()
 
   function(custom_test_c target)
-    message(STATUS "Creating tests for '${rmw_implementation}'")
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
@@ -224,6 +233,15 @@ if(BUILD_TESTING)
       set(SKIP_TEST "SKIP_TEST")
     endif()
 
+    set(rmw_implementation_env_var "")
+    if(rmw_implementation1_is_zenoh OR rmw_implementation2_is_zenoh)
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     set(PUBLISHER_RMW ${rmw_implementation1})
     set(SUBSCRIBER_RMW ${rmw_implementation2})
     set(TEST_MESSAGE_TYPES "")
@@ -268,6 +286,7 @@ if(BUILD_TESTING)
       TARGET test_publisher_subscriber${suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT ${timeout}
+      ENV ${rmw_implementation_env_var}
       ${SKIP_TEST})
     if(TEST test_publisher_subscriber${suffix})
       set_tests_properties(
@@ -309,6 +328,7 @@ if(BUILD_TESTING)
       TARGET test_requester_replier${suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT ${timeout}
+      ENV ${rmw_implementation_env_var}
       ${SKIP_TEST})
     if(TEST test_requester_replier${suffix})
       set_tests_properties(
@@ -346,6 +366,7 @@ if(BUILD_TESTING)
       TARGET test_action_client_server${suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT ${timeout}
+      ENV ${rmw_implementation_env_var}
       ${SKIP_TEST})
     if(TEST test_action_client_server${suffix})
       set_tests_properties(

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -105,7 +105,7 @@ if(BUILD_TESTING)
           ENV
             RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
             ${rmw_implementation_env_var}
-          )
+        )
         set_tests_properties(
           "${target}${target_suffix}__${TEST_MESSAGE_TYPE}"
           PROPERTIES REQUIRED_FILES "$<TARGET_FILE:${target}>"
@@ -121,7 +121,7 @@ if(BUILD_TESTING)
         ENV
           RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
           ${rmw_implementation_env_var}
-        )
+      )
       set_tests_properties(
         "${target}${target_suffix}"
         PROPERTIES REQUIRED_FILES "$<TARGET_FILE:${target}>"

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -130,6 +130,15 @@ if(BUILD_TESTING)
   endfunction()
 
   function(custom_test_c target)
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     ament_add_gtest(
       "${target}${target_suffix}" ${ARGN}
       TIMEOUT 90
@@ -137,6 +146,7 @@ if(BUILD_TESTING)
       ENV
       RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
       RMW_IMPLEMENTATION=${rmw_implementation})
+      ${rmw_implementation_env_var}
     if(TARGET ${target}${target_suffix})
       rosidl_get_typesupport_target(c_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_c")
       target_link_libraries(${target}${target_suffix}
@@ -468,6 +478,16 @@ if(BUILD_TESTING)
 
   macro(serialize)
     set(serialize_target_name "test_serialize${target}${target_suffix}")
+
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     ament_add_gtest(
       ${serialize_target_name} test/test_message_serialization.cpp
       TIMEOUT 30
@@ -493,12 +513,23 @@ if(BUILD_TESTING)
 
   macro(pub_sub_serialized)
     set(target_name "test_publisher_subscriber_serialized${target}${target_suffix}")
+
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     ament_add_gtest(
       ${target_name} test/test_publisher_subscriber_serialized.cpp
       TIMEOUT 30
       ENV
       RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
       RMW_IMPLEMENTATION=${rmw_implementation}
+      ${rmw_implementation_env_var}
     )
     if(TARGET ${target_name})
       add_dependencies(${target_name} ${PROJECT_NAME})

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -85,11 +85,10 @@ if(BUILD_TESTING)
   function(custom_test target with_message_argument)
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    # Note: This is a temporary change that will be reverted before we branch into Kilted.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
     if(with_message_argument)
@@ -103,9 +102,8 @@ if(BUILD_TESTING)
           GENERATE_RESULT_FOR_RETURN_CODE_ZERO
           APPEND_LIBRARY_DIRS "${append_library_dirs}"
           ENV
-            RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-            ${rmw_implementation_env_var}
-        )
+          RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+          ${rmw_implementation_env_var})
         set_tests_properties(
           "${target}${target_suffix}__${TEST_MESSAGE_TYPE}"
           PROPERTIES REQUIRED_FILES "$<TARGET_FILE:${target}>"
@@ -119,9 +117,8 @@ if(BUILD_TESTING)
         GENERATE_RESULT_FOR_RETURN_CODE_ZERO
         APPEND_LIBRARY_DIRS "${append_library_dirs}"
         ENV
-          RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-          ${rmw_implementation_env_var}
-      )
+        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+        ${rmw_implementation_env_var})
       set_tests_properties(
         "${target}${target_suffix}"
         PROPERTIES REQUIRED_FILES "$<TARGET_FILE:${target}>"
@@ -143,21 +140,19 @@ if(BUILD_TESTING)
   function(custom_test_c target)
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    # Note: This is a temporary change that will be reverted before we branch into Kilted.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
-
     ament_add_gtest(
       "${target}${target_suffix}" ${ARGN}
       TIMEOUT 90
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       ENV
-        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-        ${rmw_implementation_env_var})
+      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+      ${rmw_implementation_env_var})
     if(TARGET ${target}${target_suffix})
       rosidl_get_typesupport_target(c_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_c")
       target_link_libraries(${target}${target_suffix}
@@ -500,18 +495,15 @@ if(BUILD_TESTING)
   endif()
 
   macro(serialize)
-    message(STATUS "Creating tests for '${rmw_implementation}'")
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    # Note: This is a temporary change that will be reverted before we branch into Kilted.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
     set(serialize_target_name "test_serialize${target}${target_suffix}")
-
     ament_add_gtest(
       ${serialize_target_name} test/test_message_serialization.cpp
       TIMEOUT 30
@@ -536,24 +528,21 @@ if(BUILD_TESTING)
   endmacro()
 
   macro(pub_sub_serialized)
-    message(STATUS "Creating tests for '${rmw_implementation}'")
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    # Note: This is a temporary change that will be reverted before we branch into Kilted.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
     set(target_name "test_publisher_subscriber_serialized${target}${target_suffix}")
-
     ament_add_gtest(
       ${target_name} test/test_publisher_subscriber_serialized.cpp
       TIMEOUT 30
       ENV
-        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-        ${rmw_implementation_env_var}
+      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+      ${rmw_implementation_env_var}
     )
     if(TARGET ${target_name})
       add_dependencies(${target_name} ${PROJECT_NAME})

--- a/test_quality_of_service/CMakeLists.txt
+++ b/test_quality_of_service/CMakeLists.txt
@@ -51,6 +51,9 @@ if(BUILD_TESTING)
   )
 
   function(add_custom_gtest target)
+  message(STATUS "Creating tests for '${rmw_implementation}'")
+    set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
+
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
@@ -63,7 +66,6 @@ if(BUILD_TESTING)
     ament_add_gtest(${target}${target_suffix} ${ARGN}
       ENV
         RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-        RMW_IMPLEMENTATION=${rmw_implementation}
         ${rmw_implementation_env_var}
     )
     target_compile_definitions(${target}${target_suffix}

--- a/test_quality_of_service/CMakeLists.txt
+++ b/test_quality_of_service/CMakeLists.txt
@@ -51,18 +51,14 @@ if(BUILD_TESTING)
   )
 
   function(add_custom_gtest target)
-  message(STATUS "Creating tests for '${rmw_implementation}'")
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    # Note: This is a temporary change that will be reverted before we branch into Kilted.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
-
     ament_add_gtest(${target}${target_suffix} ${ARGN}
       ENV
         RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}

--- a/test_quality_of_service/CMakeLists.txt
+++ b/test_quality_of_service/CMakeLists.txt
@@ -51,10 +51,20 @@ if(BUILD_TESTING)
   )
 
   function(add_custom_gtest target)
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     ament_add_gtest(${target}${target_suffix} ${ARGN}
       ENV
         RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
         RMW_IMPLEMENTATION=${rmw_implementation}
+        ${rmw_implementation_env_var}
     )
     target_compile_definitions(${target}${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -331,6 +331,7 @@ if(BUILD_TESTING)
   endmacro()
 
   function(test_target)
+    message(STATUS "Creating tests for '${rmw_implementation}'")
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -166,14 +166,10 @@ if(BUILD_TESTING)
     set(TEST_RMW_IMPLEMENTATION2 "${_ARG_RMW2}")
 
     set(rmw_implementation_env_var "")
-
     if("${TEST_RMW_IMPLEMENTATION1}" STREQUAL "rmw_zenoh_cpp" OR
       "${TEST_RMW_IMPLEMENTATION2}" STREQUAL "rmw_zenoh_cpp")
-
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
 
@@ -331,15 +327,12 @@ if(BUILD_TESTING)
   endmacro()
 
   function(test_target)
-    message(STATUS "Creating tests for '${rmw_implementation}'")
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    # Note: This is a temporary change that will be reverted before we branch into Kilted.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
 

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -471,6 +471,7 @@ if(BUILD_TESTING)
     # Parameter tests single implementation
     custom_launch_test_two_executables(test_parameter_server_cpp
       test_parameters_server_cpp test_remote_parameters_cpp
+      RMW1 ${rmw_implementation} RMW2 ${rmw_implementation}
       TIMEOUT 60
       ENV
         ${rmw_implementation_env_var}
@@ -479,6 +480,7 @@ if(BUILD_TESTING)
     # Service tests single implementation
     custom_launch_test_two_executables(test_services_cpp
       test_services_server_cpp test_services_client_cpp
+      RMW1 ${rmw_implementation} RMW2 ${rmw_implementation}
       TIMEOUT 60
       ENV
         ${rmw_implementation_env_var}
@@ -486,6 +488,7 @@ if(BUILD_TESTING)
 
     custom_launch_test_two_executables(test_client_scope_cpp
       test_client_scope_server_cpp test_client_scope_client_cpp
+      RMW1 ${rmw_implementation} RMW2 ${rmw_implementation}
       TIMEOUT 60
       ENV
         ${rmw_implementation_env_var}
@@ -493,6 +496,7 @@ if(BUILD_TESTING)
 
     custom_launch_test_two_executables(test_client_scope_consistency_cpp
       test_client_scope_consistency_server_cpp test_client_scope_consistency_client_cpp
+      RMW1 ${rmw_implementation} RMW2 ${rmw_implementation}
       TIMEOUT 60
       ENV
         ${rmw_implementation_env_var}

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -164,6 +164,19 @@ if(BUILD_TESTING)
     set(TEST_EXECUTABLE2_ARGS "${_ARG_ARGS2}")
     set(TEST_EXECUTABLE2_NAME "${executable2}")
     set(TEST_RMW_IMPLEMENTATION2 "${_ARG_RMW2}")
+
+    set(rmw_implementation_env_var "")
+
+    if("${TEST_RMW_IMPLEMENTATION1}" STREQUAL "rmw_zenoh_cpp" OR
+      "${TEST_RMW_IMPLEMENTATION2}" STREQUAL "rmw_zenoh_cpp")
+
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     configure_file(
       test/test_two_executables.py.in
       ${test_name}${target_suffix}.py.configure
@@ -178,6 +191,7 @@ if(BUILD_TESTING)
       TARGET "${test_name}${target_suffix}"
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       ${_ARG_UNPARSED_ARGUMENTS}
+      ENV ${rmw_implementation_env_var}
     )
     if(TEST ${test_name}${target_suffix})
       set_tests_properties(${test_name}${target_suffix}
@@ -318,6 +332,15 @@ if(BUILD_TESTING)
 
   function(test_target)
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
+
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
 
     ament_add_gtest_test(gtest_avoid_ros_namespace_conventions_qos
       TEST_NAME gtest_avoid_ros_namespace_conventions_qos${target_suffix}


### PR DESCRIPTION
See https://github.com/ros2/rmw_zenoh/issues/567

To test this PR, we can run the usual CI jobs to show there are no regressions and additionally run a CI job with a copy of the ros2.repos file from https://github.com/ros2/ros2/pull/1649 with CI Scripts branch set to yadu/cargo