### PR TITLE
fix CMAKE deprecation

### DIFF
--- a/test_cli/CMakeLists.txt
+++ b/test_cli/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 
 project(test_cli)
 

--- a/test_cli_remapping/CMakeLists.txt
+++ b/test_cli_remapping/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 
 project(test_cli_remapping)
 

--- a/test_communication/CMakeLists.txt
+++ b/test_communication/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 
 project(test_communication)
 

--- a/test_quality_of_service/CMakeLists.txt
+++ b/test_quality_of_service/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 
 project(test_quality_of_service)
 

--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 
 project(test_rclcpp)
 

--- a/test_security/CMakeLists.txt
+++ b/test_security/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.20)
 
 project(test_security)
 

--- a/test_security/test/sros_artifacts.cmake
+++ b/test_security/test/sros_artifacts.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.20)
 
 set(node_names_list "/publisher;/subscriber;/publisher_missing_key;/publisher_invalid_cert")
 file(REMOVE_RECURSE "${KEYSTORE_DIRECTORY}/enclaves")


### PR DESCRIPTION


## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

cmake<3.10 is now deprecated with cmake 4.0

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
