### PR TITLE
get rid of deprecated rclcpp::spin_some().

### DIFF
--- a/test_communication/test/test_publisher_subscriber_serialized.cpp
+++ b/test_communication/test/test_publisher_subscriber_serialized.cpp
@@ -75,6 +75,8 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), serialized_callb
     "test_publisher_subscriber_serialized_topic", 10, serialized_callback);
   auto publisher = node->create_publisher<test_msgs::msg::BasicTypes>(
     "test_publisher_subscriber_serialized_topic", 10);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
 
   test_msgs::msg::BasicTypes msg;
 
@@ -82,7 +84,7 @@ TEST_F(CLASSNAME(TestMessageSerialization, RMW_IMPLEMENTATION), serialized_callb
   for (auto i = 0u; i < 10; ++i) {
     msg.uint8_value = i;
     publisher->publish(msg);
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
   }
   EXPECT_GT(counter, 0u);

--- a/test_communication/test/test_requester.cpp
+++ b/test_communication/test/test_requester.cpp
@@ -50,6 +50,8 @@ int request(
   auto start = std::chrono::steady_clock::now();
   // publish the first request up to number_of_cycles times, longer sleep between each cycle
   // publish all requests one by one, shorter sleep between each request
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   while (rclcpp::ok() && cycle_index < number_of_cycles && service_index < services.size()) {
     printf("publishing request #%zu\n", service_index + 1);
     auto f = requester->async_send_request(services[service_index].first);
@@ -57,7 +59,7 @@ int request(
     auto wait_for_response_until = std::chrono::steady_clock::now() + wait_between_services;
     std::future_status status;
     do {
-      rclcpp::spin_some(node);
+      executor.spin_some();
       status = f.wait_for(std::chrono::milliseconds(10));
     } while (
       status != std::future_status::ready && rclcpp::ok() &&

--- a/test_communication/test/test_subscription_valid_data.cpp
+++ b/test_communication/test/test_subscription_valid_data.cpp
@@ -42,6 +42,8 @@ int main(int argc, char ** argv)
   auto subscriber = node->create_subscription<test_communication::msg::UInt32>(
     "test_subscription_valid_data", 10, callback);
 
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   rclcpp::WallRate message_rate(5);
   {
     auto publisher = node->create_publisher<test_communication::msg::UInt32>(
@@ -58,16 +60,16 @@ int main(int argc, char ** argv)
       publisher->publish(std::move(msg));
       ++index;
       message_rate.sleep();
-      rclcpp::spin_some(node);
+      executor.spin_some();
     }
 
     message_rate.sleep();
-    rclcpp::spin_some(node);
+    executor.spin_some();
   }
   // the publisher goes out of scope and the subscriber should be not receive any callbacks anymore
 
   message_rate.sleep();
-  rclcpp::spin_some(node);
+  executor.spin_some();
 
   auto end = std::chrono::steady_clock::now();
   std::chrono::duration<float> diff = (end - start);

--- a/test_rclcpp/test/test_client_scope_consistency_server.cpp
+++ b/test_rclcpp/test/test_client_scope_consistency_server.cpp
@@ -37,11 +37,13 @@ int main(int argc, char ** argv)
   rclcpp::QoS qos(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
   auto service = node->create_service<test_rclcpp::srv::AddTwoInts>(
     "client_scope", handle_add_two_ints, qos);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
 
   rclcpp::WallRate loop_rate(30);
   try {
     while (rclcpp::ok()) {
-      rclcpp::spin_some(node);
+      executor.spin_some();
       loop_rate.sleep();
     }
   } catch (const rclcpp::exceptions::RCLError & ex) {

--- a/test_rclcpp/test/test_client_scope_server.cpp
+++ b/test_rclcpp/test/test_client_scope_server.cpp
@@ -36,10 +36,12 @@ int main(int argc, char ** argv)
   auto service = node->create_service<test_rclcpp::srv::AddTwoInts>(
     "client_scope", handle_add_two_ints);
 
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   rclcpp::WallRate loop_rate(30);
   try {
     while (rclcpp::ok()) {
-      rclcpp::spin_some(node);
+      executor.spin_some();
       loop_rate.sleep();
     }
   } catch (const rclcpp::exceptions::RCLError & ex) {

--- a/test_rclcpp/test/test_multiple_service_calls.cpp
+++ b/test_rclcpp/test/test_multiple_service_calls.cpp
@@ -102,6 +102,8 @@ TEST_F(test_two_service_calls, recursive_service_call)
   if (!client->wait_for_service(20s)) {
     ASSERT_TRUE(false) << "service not available after waiting";
   }
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
 
   auto request1 = std::make_shared<test_rclcpp::srv::AddTwoInts::Request>();
   request1->a = 1;
@@ -134,7 +136,7 @@ TEST_F(test_two_service_calls, recursive_service_call)
   printf("Waiting for reply...\n");
   fflush(stdout);
   while (!second_result_received) {
-    rclcpp::spin_some(node);
+    executor.spin_some();
   }
   EXPECT_TRUE(second_result_received);
 }

--- a/test_rclcpp/test/test_timer.cpp
+++ b/test_rclcpp/test/test_timer.cpp
@@ -144,6 +144,8 @@ TEST_F(test_time, timer_during_wait)
 TEST_F(test_time, finite_timer)
 {
   auto node = rclcpp::Node::make_shared("finite_timer");
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
 
   int counter = 0;
   auto callback =
@@ -168,7 +170,7 @@ TEST_F(test_time, finite_timer)
     // spin a few times
     for (uint32_t i = 0; i < 6; ++i) {
       std::this_thread::sleep_for(period);
-      rclcpp::spin_some(node);
+      executor.spin_some();
     }
 
     EXPECT_EQ(counter, 2);


### PR DESCRIPTION
## Description

This depends on https://github.com/ros2/rclcpp/pull/2848

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
