### PR TITLE
info message comes from deferred signal handler with another thread.

### DIFF
--- a/test_rclcpp/test/expected_outputs/test_sigint_handler_before_shutdown__expected_output.txt
+++ b/test_rclcpp/test/expected_outputs/test_sigint_handler_before_shutdown__expected_output.txt
@@ -1,8 +1,8 @@
 [INFO] [test_signal_handler]: Registered custom signal handler.
 [INFO] [test_signal_handler]: Called rclcpp::init.
 [INFO] [test_signal_handler]: Waiting to give an opportunity for interrupt...
-[INFO] [rclcpp]: signal_handler(signum=2)
 [INFO] [test_signal_handler]: Custom sigint handler called.
+[INFO] [rclcpp]: signal_handler(signum=2)
 [INFO] [test_signal_handler]: Calling rclcpp::shutdown...
 [INFO] [test_signal_handler]: Called rclcpp::shutdown.
 [INFO] [test_signal_handler]: Waiting to give an opportunity for interrupt...

--- a/test_rclcpp/test/expected_outputs/test_sigterm_handler_before_shutdown__expected_output.txt
+++ b/test_rclcpp/test/expected_outputs/test_sigterm_handler_before_shutdown__expected_output.txt
@@ -1,8 +1,8 @@
 [INFO] [test_sigterm_handler]: Registered custom signal handler.
 [INFO] [test_sigterm_handler]: Called rclcpp::init.
 [INFO] [test_sigterm_handler]: Waiting to give an opportunity for interrupt...
-[INFO] [rclcpp]: signal_handler(signum=15)
 [INFO] [test_sigterm_handler]: Custom sigterm handler called.
+[INFO] [rclcpp]: signal_handler(signum=15)
 [INFO] [test_sigterm_handler]: Calling rclcpp::shutdown...
 [INFO] [test_sigterm_handler]: Called rclcpp::shutdown.
 [INFO] [test_sigterm_handler]: Waiting to give an opportunity for interrupt...


### PR DESCRIPTION
## Description

https://github.com/ros2/rclcpp/pull/2986 moves the info message print from actual signal hander managed by system to deferred signal handler managed by rclcpp. this changes the order of expected message for these tests.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Depends on https://github.com/ros2/rclcpp/pull/2986

### Is this user-facing behavior change?

No,

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No,

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

If this does not work, we probably change the message from deferred signal hander into DEBUG because it is hard to guarantee the order of the messages between application main thread and deferred signal thread.

<!--
If applicable, provide any additional context or details about the changes.
-->
