### PR TITLE
Add tests isolation in test_rclcpp

### DIFF
--- a/test_rclcpp/CMakeLists.txt
+++ b/test_rclcpp/CMakeLists.txt
@@ -23,6 +23,7 @@ if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake REQUIRED)
 
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_ros REQUIRED)
 
   # finding gtest once in the highest scope
   # prevents finding it repeatedly in each local scope
@@ -319,7 +320,7 @@ if(BUILD_TESTING)
   function(test_target)
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
-    ament_add_gtest_test(gtest_avoid_ros_namespace_conventions_qos
+    ament_add_ros_isolated_gtest_test(gtest_avoid_ros_namespace_conventions_qos
       TEST_NAME gtest_avoid_ros_namespace_conventions_qos${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 15
@@ -327,7 +328,7 @@ if(BUILD_TESTING)
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_publisher
+    ament_add_ros_isolated_gtest_test(gtest_publisher
       TEST_NAME gtest_publisher${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 15
@@ -335,14 +336,14 @@ if(BUILD_TESTING)
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_client_wait_for_service_shutdown
+    ament_add_ros_isolated_gtest_test(gtest_client_wait_for_service_shutdown
       TEST_NAME gtest_client_wait_for_service_shutdown${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       ENV
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_executor
+    ament_add_ros_isolated_gtest_test(gtest_executor
       TEST_NAME gtest_executor${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 60
@@ -350,7 +351,7 @@ if(BUILD_TESTING)
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_repeated_publisher_subscriber
+    ament_add_ros_isolated_gtest_test(gtest_repeated_publisher_subscriber
       TEST_NAME gtest_repeated_publisher_subscriber${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 15
@@ -358,7 +359,7 @@ if(BUILD_TESTING)
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_spin
+    ament_add_ros_isolated_gtest_test(gtest_spin
       TEST_NAME gtest_spin${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 30
@@ -369,7 +370,7 @@ if(BUILD_TESTING)
     # TODO(clalancette): Under load, the gtest_subscription__rmw_connextdds test fails deep in the
     # bowels of Connext; see https://github.com/ros2/rmw_connextdds/issues/136 for details.  Skip it
     # for now so we can keep CI green.
-    ament_add_gtest_test(gtest_subscription
+    ament_add_ros_isolated_gtest_test(gtest_subscription
       TEST_NAME gtest_subscription${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 60
@@ -380,7 +381,7 @@ if(BUILD_TESTING)
       ament_add_test_label(gtest_subscription${target_suffix} xfail)
     endif()
 
-    ament_add_gtest_test(gtest_multiple_service_calls
+    ament_add_ros_isolated_gtest_test(gtest_multiple_service_calls
       TEST_NAME gtest_multiple_service_calls${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 60
@@ -388,7 +389,7 @@ if(BUILD_TESTING)
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_timer
+    ament_add_ros_isolated_gtest_test(gtest_timer
       TEST_NAME gtest_timer${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 30
@@ -396,7 +397,7 @@ if(BUILD_TESTING)
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_timeout_subscriber
+    ament_add_ros_isolated_gtest_test(gtest_timeout_subscriber
       TEST_NAME gtest_timeout_subscriber${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 30
@@ -404,7 +405,7 @@ if(BUILD_TESTING)
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_intra_process
+    ament_add_ros_isolated_gtest_test(gtest_intra_process
       TEST_NAME gtest_intra_process${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 15
@@ -412,7 +413,7 @@ if(BUILD_TESTING)
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_multithreaded
+    ament_add_ros_isolated_gtest_test(gtest_multithreaded
       TEST_NAME gtest_multithreaded${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 90
@@ -420,7 +421,7 @@ if(BUILD_TESTING)
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_local_parameters
+    ament_add_ros_isolated_gtest_test(gtest_local_parameters
       TEST_NAME gtest_local_parameters${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 300
@@ -428,7 +429,7 @@ if(BUILD_TESTING)
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_services_in_constructor
+    ament_add_ros_isolated_gtest_test(gtest_services_in_constructor
       TEST_NAME gtest_services_in_constructor${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 30
@@ -436,7 +437,7 @@ if(BUILD_TESTING)
         ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(gtest_waitable
+    ament_add_ros_isolated_gtest_test(gtest_waitable
       TEST_NAME gtest_waitable${target_suffix}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 300

--- a/test_rclcpp/package.xml
+++ b/test_rclcpp/package.xml
@@ -21,6 +21,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>launch</test_depend>

--- a/test_rclcpp/test/test_executable_output.py.in
+++ b/test_rclcpp/test/test_executable_output.py.in
@@ -9,20 +9,21 @@ import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
+from launch_testing_ros.actions import EnableRmwIsolation
+
 import os
 import unittest
 
 
 def generate_test_description():
-    env = os.environ.copy()
-    env['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '[{severity}] [{name}]: {message}'
     launch_description = LaunchDescription()
+    launch_description.add_action(EnableRmwIsolation())
     proc_under_test = ExecuteProcess(
         cmd=['@TEST_EXECUTABLE@'],
         name='@TEST_EXECUTABLE_NAME@',
         sigterm_timeout='15',
         output='screen',
-        env=env,
+        additional_env={'RCUTILS_CONSOLE_OUTPUT_FORMAT': '[{severity}] [{name}]: {message}'},
     )
     launch_description.add_action(proc_under_test)
     launch_description.add_action(

--- a/test_rclcpp/test/test_sigterm.py.in
+++ b/test_rclcpp/test/test_sigterm.py.in
@@ -10,6 +10,8 @@ import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
+from launch_testing_ros.actions import EnableRmwIsolation
+
 import os
 import signal
 import sys
@@ -17,15 +19,14 @@ import unittest
 
 
 def generate_test_description():
-    env = os.environ.copy()
-    env['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '[{severity}] [{name}]: {message}'
     launch_description = LaunchDescription()
+    launch_description.add_action(EnableRmwIsolation())
     proc_under_test = ExecuteProcess(
         cmd=['@TEST_EXECUTABLE@'],
         name='@TEST_EXECUTABLE_NAME@',
         sigterm_timeout='15',
         output='screen',
-        env=env,
+        additional_env={'RCUTILS_CONSOLE_OUTPUT_FORMAT': '[{severity}] [{name}]: {message}'},
     )
     launch_description.add_action(proc_under_test)
     launch_description.add_action(launch_testing.util.KeepAliveProc())


### PR DESCRIPTION
## Description

As discussed in https://github.com/ros2/rmw_zenoh/issues/881#issuecomment-3891134977, this PR adds tests isolation to all tests initializing a Context or a Node, in order to start a Zenoh router in case of rmw_zenoh_cpp.

More specifically:
- in `test_rclcpp/CMakeLists.txt`: 
  calls to `ament_add_gtest_test` are replaced with call to `ament_add_ros_isolated_gtest_test`
- in `test_rclcpp/test/test_executable_output.py.in` and `test_rclcpp/test/test_sigterm.py.in` which are using `LaunchDescription`:
  a `EnableRmwIsolation()` is added, and the the way to update the `env` for output format is changed to not override that environment change made by `EnableRmwIsolation()`
  
### Is this user-facing behavior change?

No

### Did you use Generative AI?

No