### PR TITLE
fix(test_cli_remapping): use EnableRmwIsolation for zenoh router

### DIFF
--- a/test_cli_remapping/package.xml
+++ b/test_cli_remapping/package.xml
@@ -25,6 +25,8 @@
   <test_depend>launch</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+  <test_depend>rmw_test_fixture_implementation</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rclpy</test_depend>
   <test_depend>test_msgs</test_depend>

--- a/test_cli_remapping/test/test_cli_remapping.py
+++ b/test_cli_remapping/test/test_cli_remapping.py
@@ -23,6 +23,7 @@ from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 import launch_testing
 import launch_testing.actions
+from launch_testing_ros.actions import EnableRmwIsolation
 
 import rclpy
 
@@ -68,12 +69,11 @@ TEST_CASES = {
 def generate_test_description(executable):
     command = [executable]
     # Execute python files using same python used to start this test
-    env = dict(os.environ)
     if command[0][-3:] == '.py':
         command.insert(0, sys.executable)
-    env['PYTHONUNBUFFERED'] = '1'
 
     launch_description = LaunchDescription()
+    launch_description.add_action(EnableRmwIsolation())
 
     test_context = {}
     for replacement_name, (replacement_value, cli_argument) in TEST_CASES.items():
@@ -82,7 +82,8 @@ def generate_test_description(executable):
         launch_description.add_action(
             ExecuteProcess(
                 cmd=command + ['--ros-args', '--remap', cli_argument.format(**locals())],
-                name='name_maker_' + replacement_name, env=env
+                name='name_maker_' + replacement_name,
+                additional_env={'PYTHONUNBUFFERED': '1'},
             )
         )
         test_context[replacement_name] = replacement_value.format(random_string=random_string)


### PR DESCRIPTION
## Summary
`test_cli_remapping` fails in the `Rci__nightly-zenoh_ubuntu_noble_amd64` CI because its nodes cannot discover each other — the test uses `add_launch_test` without RMW isolation, so there is no shared network for cross-process node discovery.

## Key Changes
- Add `EnableRmwIsolation()` as the first launch action so the isolated network is set up before any subprocesses are spawned
- Replace `env=dict(os.environ)` (snapshot taken before isolation runs) with `additional_env={'PYTHONUNBUFFERED': '1'}` so each subprocess inherits the live environment at spawn time and joins the isolated network
- Add `launch_testing_ros` and `rmw_test_fixture_implementation` as test dependencies in `package.xml`

## Breaking Changes
None

## Deep Dive

`EnableRmwIsolation` calls [`rmw_test_isolation_start()`](https://github.com/ros2/rmw_zenoh/blob/944a8715f5af6f58e74e318d31510409f69a5e6e/rmw_zenoh_cpp/src/rmw_test_fixture.cpp#L87), which starts an in-process Zenoh router on a random port and then sets `ZENOH_CONFIG_OVERRIDE=connect/endpoints=[tcp/127.0.0.1:<port>]` in the current process environment ([line 136–139](https://github.com/ros2/rmw_zenoh/blob/944a8715f5af6f58e74e318d31510409f69a5e6e/rmw_zenoh_cpp/src/rmw_test_fixture.cpp#L136-L139)). Any subprocess that inherits `os.environ` will have rmw_zenoh_cpp connect to that router and share the same discovery graph.

The original code does `env=dict(os.environ)` before the launch description executes, so the snapshot is taken before `EnableRmwIsolation.execute()` runs and `ZENOH_CONFIG_OVERRIDE` is not yet set. The subprocesses receive a frozen copy of the environment that predates isolation and therefore never connect to the in-process router. Replacing it with `additional_env` causes the subprocess to inherit the live `os.environ` at the time it is actually spawned, after isolation has started.

Closes ros2/rmw_zenoh#932
