### PR TITLE
Add test_rosidl_buffer for testing rosidl::Buffer features

### DIFF
--- a/test_rosidl_buffer/CMakeLists.txt
+++ b/test_rosidl_buffer/CMakeLists.txt
@@ -1,0 +1,194 @@
+cmake_minimum_required(VERSION 3.20)
+project(test_rosidl_buffer)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rmw REQUIRED)
+find_package(rosidl_buffer REQUIRED)
+find_package(rosidl_buffer_backend REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(rosidl_runtime_cpp REQUIRED)
+find_package(rosidl_typesupport_cpp REQUIRED)
+find_package(rosidl_typesupport_fastrtps_cpp REQUIRED)
+find_package(std_msgs REQUIRED)
+
+# Generate the descriptor + payload interfaces used by the backend and nodes.
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/ByteArray.msg"
+  "msg/ByteArrayList.msg"
+  "msg/TestBufferDescriptor.msg"
+)
+
+rosidl_get_typesupport_target(_cpp_ts ${PROJECT_NAME} "rosidl_typesupport_cpp")
+rosidl_get_typesupport_target(_fastrtps_ts ${PROJECT_NAME} "rosidl_typesupport_fastrtps_cpp")
+
+# Header-only target exposing TestBufferImpl<T>. Deliberately separated from
+# the pluginlib SHARED lib below: executables link this INTERFACE target only,
+# which avoids the double-free at shutdown caused by linking a pluginlib-loaded
+# plugin library directly (class_loader ProxyExec + __cxa_finalize both run dtors).
+add_library(${PROJECT_NAME}_impl INTERFACE)
+target_include_directories(${PROJECT_NAME}_impl INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+target_link_libraries(${PROJECT_NAME}_impl INTERFACE
+  ${_cpp_ts}
+  rosidl_buffer::rosidl_buffer
+  rosidl_runtime_cpp::rosidl_runtime_cpp
+)
+
+# Pluginlib-exported BufferBackend implementation (SHARED).
+add_library(${PROJECT_NAME}_backend_plugin SHARED
+  src/test_buffer_backend_plugin.cpp
+)
+target_include_directories(${PROJECT_NAME}_backend_plugin PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+target_compile_definitions(${PROJECT_NAME}_backend_plugin
+  PRIVATE "TEST_ROSIDL_BUFFER_BUILDING_DLL")
+target_link_libraries(${PROJECT_NAME}_backend_plugin PUBLIC
+  ${_cpp_ts}
+  ${_fastrtps_ts}
+  pluginlib::pluginlib
+  rmw::rmw
+  rosidl_buffer::rosidl_buffer
+  rosidl_buffer_backend::rosidl_buffer_backend
+  rosidl_runtime_cpp::rosidl_runtime_cpp
+  rosidl_typesupport_cpp::rosidl_typesupport_cpp
+  rosidl_typesupport_fastrtps_cpp::rosidl_typesupport_fastrtps_cpp
+)
+
+pluginlib_export_plugin_description_file(
+  rosidl_buffer_backend test_buffer_plugin.xml)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+install(
+  TARGETS ${PROJECT_NAME}_backend_plugin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+install(
+  FILES test_buffer_plugin.xml
+  DESTINATION share/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  # ---------------------------------------------------------------------------
+  # Tier 1: standalone gtest, no RMW involved.
+  # ---------------------------------------------------------------------------
+  ament_add_gtest(test_buffer_backend_unit test/test_buffer_backend_unit.cpp)
+  if(TARGET test_buffer_backend_unit)
+    target_link_libraries(test_buffer_backend_unit
+      ${PROJECT_NAME}_backend_plugin
+      ${PROJECT_NAME}_impl
+      rosidl_buffer::rosidl_buffer
+      rosidl_buffer_backend::rosidl_buffer_backend
+    )
+  endif()
+
+  # ---------------------------------------------------------------------------
+  # Tier 2: launch tests, gated by RMWs that have end-to-end buffer-backend
+  # support. Today that is only rmw_fastrtps_cpp — extend this list as other
+  # RMWs land full backend support.
+  # ---------------------------------------------------------------------------
+  set(_buffer_backend_capable_rmws rmw_fastrtps_cpp)
+
+  find_package(rmw_implementation_cmake REQUIRED)
+  get_available_rmw_implementations(_available_rmws)
+
+  set(_has_capable_rmw FALSE)
+  foreach(rmw_impl ${_available_rmws})
+    if(rmw_impl IN_LIST _buffer_backend_capable_rmws)
+      set(_has_capable_rmw TRUE)
+      find_package("${rmw_impl}" REQUIRED)
+    endif()
+  endforeach()
+
+  if(_has_capable_rmw)
+    find_package(launch_testing_ament_cmake REQUIRED)
+
+    # Pub/sub executables. Link only the header-only impl target and the
+    # generated cpp typesupport — NEVER the plugin SHARED lib (see note above).
+    add_executable(test_backend_publisher src/test_backend_publisher.cpp)
+    target_link_libraries(test_backend_publisher
+      ${PROJECT_NAME}_impl
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+    )
+
+    add_executable(test_backend_subscriber src/test_backend_subscriber.cpp)
+    target_link_libraries(test_backend_subscriber
+      ${PROJECT_NAME}_impl
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+    )
+
+    add_executable(test_backend_nested_msgs_publisher
+      src/test_backend_nested_msgs_publisher.cpp)
+    target_link_libraries(test_backend_nested_msgs_publisher
+      ${PROJECT_NAME}_impl
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+    )
+
+    add_executable(test_backend_nested_msgs_subscriber
+      src/test_backend_nested_msgs_subscriber.cpp)
+    target_link_libraries(test_backend_nested_msgs_subscriber
+      ${PROJECT_NAME}_impl
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+    )
+
+    install(
+      TARGETS
+        test_backend_publisher
+        test_backend_subscriber
+        test_backend_nested_msgs_publisher
+        test_backend_nested_msgs_subscriber
+      DESTINATION lib/${PROJECT_NAME}
+    )
+
+    # Register one launch test per capable RMW for each scenario.
+    foreach(rmw_impl ${_buffer_backend_capable_rmws})
+      if(NOT rmw_impl IN_LIST _available_rmws)
+        continue()
+      endif()
+
+      if(rmw_impl STREQUAL "rmw_fastrtps_cpp")
+        add_launch_test(test/test_test_to_test_fastrtps.py
+          TARGET test_test_to_test__${rmw_impl}
+          TIMEOUT 60
+        )
+        add_launch_test(test/test_test_to_cpu_fastrtps.py
+          TARGET test_test_to_cpu__${rmw_impl}
+          TIMEOUT 60
+        )
+        add_launch_test(test/test_nested_msgs_fastrtps.py
+          TARGET test_nested_msgs__${rmw_impl}
+          TIMEOUT 60
+        )
+      endif()
+    endforeach()
+  endif()
+endif()
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/test_rosidl_buffer/include/test_rosidl_buffer/test_buffer_backend.hpp
+++ b/test_rosidl_buffer/include/test_rosidl_buffer/test_buffer_backend.hpp
@@ -1,0 +1,86 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_ROSIDL_BUFFER__TEST_BUFFER_BACKEND_HPP_
+#define TEST_ROSIDL_BUFFER__TEST_BUFFER_BACKEND_HPP_
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "rmw/types.h"
+#include "rmw/topic_endpoint_info.h"
+#include "rosidl_buffer_backend/buffer_backend.hpp"
+
+#include "test_rosidl_buffer/visibility_control.h"
+
+namespace test_rosidl_buffer
+{
+
+/// Minimal pluginlib-exported BufferBackend used by system tests.
+///
+/// Reports its backend type as "test" and only returns a descriptor when the
+/// discovered peer also advertises the "test" backend. When the peer does not,
+/// create_descriptor_with_endpoint() returns nullptr so the serialization
+/// layer falls back to CPU — this is exactly the test-to-cpu scenario.
+class TEST_ROSIDL_BUFFER_PUBLIC TestBufferBackend : public rosidl::BufferBackend
+{
+public:
+  TestBufferBackend();
+  ~TestBufferBackend() override = default;
+
+  std::string get_backend_type() const override {return "test";}
+
+  std::string get_backend_metadata() const override {return "version=test";}
+
+  const rosidl_message_type_support_t * get_descriptor_type_support() const override;
+
+  std::shared_ptr<void> create_empty_descriptor() const override;
+
+  std::shared_ptr<void> create_descriptor_with_endpoint(
+    const void * impl,
+    const rmw_topic_endpoint_info_t & endpoint_info) const override;
+
+  std::unique_ptr<void, void (*)(void *)> from_descriptor_with_endpoint(
+    const void * descriptor,
+    const rmw_topic_endpoint_info_t & endpoint_info) const override;
+
+  std::pair<bool, std::vector<std::set<std::uint32_t>>> on_discovering_endpoint(
+    const rmw_topic_endpoint_info_t & endpoint_info,
+    const std::vector<rmw_topic_endpoint_info_t> & existing_endpoints,
+    const std::unordered_map<std::string, std::string> & endpoint_supported_backends) override;
+
+private:
+  static std::size_t gid_hash(const std::uint8_t * gid)
+  {
+    std::size_t h = 0;
+    for (std::size_t i = 0; i < RMW_GID_STORAGE_SIZE; ++i) {
+      h ^= std::hash<std::uint8_t>{}(gid[i]) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    }
+    return h;
+  }
+
+  mutable std::mutex compat_mutex_;
+  std::unordered_map<std::size_t, bool> endpoint_compat_cache_;
+};
+
+}  // namespace test_rosidl_buffer
+
+#endif  // TEST_ROSIDL_BUFFER__TEST_BUFFER_BACKEND_HPP_

--- a/test_rosidl_buffer/include/test_rosidl_buffer/test_buffer_impl.hpp
+++ b/test_rosidl_buffer/include/test_rosidl_buffer/test_buffer_impl.hpp
@@ -1,0 +1,145 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_ROSIDL_BUFFER__TEST_BUFFER_IMPL_HPP_
+#define TEST_ROSIDL_BUFFER__TEST_BUFFER_IMPL_HPP_
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rosidl_buffer/buffer_impl_base.hpp"
+#include "rosidl_buffer/cpu_buffer_impl.hpp"
+#include "test_rosidl_buffer/msg/test_buffer_descriptor.hpp"
+
+namespace test_rosidl_buffer
+{
+
+/// Process-wide counter of TestBufferImpl::to_cpu() invocations.
+///
+/// The launch tests use this to prove the test-to-test path never falls back
+/// to CPU: if the backend's descriptor path is wired up correctly, the RMW
+/// never needs to call `to_cpu()` on the publisher-side impl.
+inline std::atomic<std::size_t> & to_cpu_call_count()
+{
+  static std::atomic<std::size_t> counter{0};
+  return counter;
+}
+
+inline void reset_to_cpu_call_count()
+{
+  to_cpu_call_count().store(0, std::memory_order_relaxed);
+}
+
+/// Simple FNV-1a 64-bit hash for payload verification in descriptor round-trips.
+inline std::uint64_t fnv1a_hash(const std::uint8_t * data, std::size_t size)
+{
+  constexpr std::uint64_t kOffsetBasis = 14695981039346656037ULL;
+  constexpr std::uint64_t kPrime = 1099511628211ULL;
+  std::uint64_t h = kOffsetBasis;
+  for (std::size_t i = 0; i < size; ++i) {
+    h ^= static_cast<std::uint64_t>(data[i]);
+    h *= kPrime;
+  }
+  return h;
+}
+
+/// Minimal test-only implementation of rosidl::BufferImplBase.
+///
+/// Stores data in a std::vector<T>. Counts every call to `to_cpu()` in a
+/// process-wide atomic so launch tests can assert the descriptor path is
+/// exercised without any CPU fallback.
+template<typename T>
+class TestBufferImpl : public rosidl::BufferImplBase<T>
+{
+public:
+  TestBufferImpl() = default;
+
+  explicit TestBufferImpl(std::size_t n)
+  : storage_(n) {}
+
+  explicit TestBufferImpl(std::vector<T> data)
+  : storage_(std::move(data)) {}
+
+  ~TestBufferImpl() override = default;
+
+  std::vector<T> & get_storage() {return storage_;}
+  const std::vector<T> & get_storage() const {return storage_;}
+
+  std::string get_backend_type() const override {return "test";}
+
+  std::size_t size() const override {return storage_.size();}
+
+  std::unique_ptr<rosidl::BufferImplBase<T>> to_cpu() const override
+  {
+    to_cpu_call_count().fetch_add(1, std::memory_order_relaxed);
+    auto cpu = std::make_unique<rosidl::CpuBufferImpl<T>>();
+    cpu->get_storage() = storage_;
+    return cpu;
+  }
+
+  std::unique_ptr<rosidl::BufferImplBase<T>> clone() const override
+  {
+    return std::make_unique<TestBufferImpl<T>>(storage_);
+  }
+
+  /// Serialise this impl into a TestBufferDescriptor message.
+  std::shared_ptr<msg::TestBufferDescriptor> create_descriptor() const
+  {
+    auto desc = std::make_shared<msg::TestBufferDescriptor>();
+    desc->size = storage_.size();
+
+    const std::size_t byte_count = storage_.size() * sizeof(T);
+    std::vector<std::uint8_t> raw(byte_count);
+    if (byte_count > 0) {
+      std::memcpy(raw.data(), storage_.data(), byte_count);
+    }
+    desc->data_hash = fnv1a_hash(raw.data(), raw.size());
+    desc->data = std::move(raw);
+    return desc;
+  }
+
+  /// Deserialise a descriptor into a new TestBufferImpl.
+  static std::unique_ptr<rosidl::BufferImplBase<T>> from_descriptor(
+    const msg::TestBufferDescriptor & desc)
+  {
+    const std::size_t expected_bytes = desc.size * sizeof(T);
+    if (desc.data.size() != expected_bytes) {
+      throw std::runtime_error(
+              "test_rosidl_buffer: descriptor payload size does not match element count");
+    }
+    const std::uint64_t recomputed = fnv1a_hash(desc.data.data(), desc.data.size());
+    if (recomputed != desc.data_hash) {
+      throw std::runtime_error(
+              "test_rosidl_buffer: descriptor hash mismatch");
+    }
+    auto impl = std::make_unique<TestBufferImpl<T>>(desc.size);
+    if (expected_bytes > 0) {
+      std::memcpy(impl->storage_.data(), desc.data.data(), expected_bytes);
+    }
+    return impl;
+  }
+
+private:
+  std::vector<T> storage_;
+};
+
+}  // namespace test_rosidl_buffer
+
+#endif  // TEST_ROSIDL_BUFFER__TEST_BUFFER_IMPL_HPP_

--- a/test_rosidl_buffer/include/test_rosidl_buffer/visibility_control.h
+++ b/test_rosidl_buffer/include/test_rosidl_buffer/visibility_control.h
@@ -1,0 +1,42 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_ROSIDL_BUFFER__VISIBILITY_CONTROL_H_
+#define TEST_ROSIDL_BUFFER__VISIBILITY_CONTROL_H_
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define TEST_ROSIDL_BUFFER_EXPORT __attribute__ ((dllexport))
+    #define TEST_ROSIDL_BUFFER_IMPORT __attribute__ ((dllimport))
+  #else
+    #define TEST_ROSIDL_BUFFER_EXPORT __declspec(dllexport)
+    #define TEST_ROSIDL_BUFFER_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef TEST_ROSIDL_BUFFER_BUILDING_DLL
+    #define TEST_ROSIDL_BUFFER_PUBLIC TEST_ROSIDL_BUFFER_EXPORT
+  #else
+    #define TEST_ROSIDL_BUFFER_PUBLIC TEST_ROSIDL_BUFFER_IMPORT
+  #endif
+  #define TEST_ROSIDL_BUFFER_LOCAL
+#else
+  #if __GNUC__ >= 4
+    #define TEST_ROSIDL_BUFFER_PUBLIC __attribute__ ((visibility("default")))
+    #define TEST_ROSIDL_BUFFER_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define TEST_ROSIDL_BUFFER_PUBLIC
+    #define TEST_ROSIDL_BUFFER_LOCAL
+  #endif
+#endif
+
+#endif  // TEST_ROSIDL_BUFFER__VISIBILITY_CONTROL_H_

--- a/test_rosidl_buffer/msg/ByteArray.msg
+++ b/test_rosidl_buffer/msg/ByteArray.msg
@@ -1,0 +1,6 @@
+# Minimal payload message used by the pub/sub launch tests.
+# The `data` field is generated as rosidl::Buffer<uint8_t>, which is the
+# feature under test.
+
+uint32 seq
+uint8[] data

--- a/test_rosidl_buffer/msg/ByteArrayList.msg
+++ b/test_rosidl_buffer/msg/ByteArrayList.msg
@@ -1,0 +1,4 @@
+# Minimal nested payload used by the pub/sub launch tests.
+# Each ByteArray item contains a uint8[] field generated as rosidl::Buffer<uint8_t>.
+
+ByteArray[] items

--- a/test_rosidl_buffer/msg/TestBufferDescriptor.msg
+++ b/test_rosidl_buffer/msg/TestBufferDescriptor.msg
@@ -1,0 +1,5 @@
+# Wire descriptor used by the in-tree test buffer backend.
+
+uint64 size                    # number of elements in the original buffer
+uint64 data_hash               # FNV-1a hash of the element bytes
+uint8[] data                   # raw element bytes (size * sizeof(T))

--- a/test_rosidl_buffer/package.xml
+++ b/test_rosidl_buffer/package.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>test_rosidl_buffer</name>
+  <version>0.25.3</version>
+  <description>
+    System tests for the rosidl_buffer / rosidl_buffer_backend feature.
+  </description>
+
+  <maintainer email="cyc@nvidia.com">CY Chen</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="cyc@nvidia.com">CY Chen</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rmw</depend>
+  <depend>rosidl_buffer</depend>
+  <depend>rosidl_buffer_backend</depend>
+  <depend>rosidl_runtime_cpp</depend>
+  <depend>rosidl_typesupport_cpp</depend>
+  <depend>rosidl_typesupport_fastrtps_cpp</depend>
+  <depend>std_msgs</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>rmw_fastrtps_cpp</test_depend>
+  <test_depend>rmw_implementation_cmake</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/test_rosidl_buffer/src/test_backend_nested_msgs_publisher.cpp
+++ b/test_rosidl_buffer/src/test_backend_nested_msgs_publisher.cpp
@@ -1,0 +1,132 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Publisher used by test_rosidl_buffer nested-message launch tests.
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/u_int32.hpp"
+
+#include "rosidl_buffer/buffer.hpp"
+#include "test_rosidl_buffer/msg/byte_array_list.hpp"
+#include "test_rosidl_buffer/test_buffer_impl.hpp"
+
+namespace
+{
+constexpr std::size_t kItemCount = 3;
+constexpr std::size_t kPayloadSize = 16;
+
+std::vector<std::uint8_t> make_payload(std::uint32_t seq, std::size_t item_index)
+{
+  std::vector<std::uint8_t> bytes(kPayloadSize);
+  for (std::size_t i = 0; i < bytes.size(); ++i) {
+    bytes[i] = static_cast<std::uint8_t>((seq + item_index * 17 + i) & 0xFF);
+  }
+  return bytes;
+}
+}  // namespace
+
+class TestBackendNestedMsgsPublisher : public rclcpp::Node
+{
+public:
+  TestBackendNestedMsgsPublisher()
+  : rclcpp::Node("test_backend_nested_msgs_publisher")
+  {
+    backend_mode_ = declare_parameter<std::string>("backend_mode", "cpu");
+    const auto topic = declare_parameter<std::string>("topic_name", "test_byte_array_list");
+    const auto rate_ms = declare_parameter<int>("publish_rate_ms", 100);
+    max_count_ = static_cast<std::uint32_t>(declare_parameter<int>("max_publish_count", 50));
+
+    if (backend_mode_ != "cpu" && backend_mode_ != "test") {
+      RCLCPP_ERROR(
+        get_logger(), "Invalid backend_mode '%s', falling back to 'cpu'", backend_mode_.c_str());
+      backend_mode_ = "cpu";
+    }
+
+    test_rosidl_buffer::reset_to_cpu_call_count();
+
+    pub_ = create_publisher<test_rosidl_buffer::msg::ByteArrayList>(topic, 10);
+    count_pub_ = create_publisher<std_msgs::msg::UInt32>("publisher_count", 10);
+    to_cpu_pub_ = create_publisher<std_msgs::msg::UInt32>("publisher_to_cpu_count", 10);
+
+    timer_ = create_wall_timer(
+      std::chrono::milliseconds(rate_ms),
+      std::bind(&TestBackendNestedMsgsPublisher::on_timer, this));
+
+    RCLCPP_INFO(
+      get_logger(),
+      "test_backend_nested_msgs_publisher started (mode=%s, topic=%s, max=%u)",
+      backend_mode_.c_str(), topic.c_str(), max_count_);
+  }
+
+private:
+  void on_timer()
+  {
+    if (max_count_ > 0 && seq_ >= max_count_) {
+      return;
+    }
+
+    test_rosidl_buffer::msg::ByteArrayList msg;
+    msg.items.resize(kItemCount);
+
+    for (std::size_t item_index = 0; item_index < msg.items.size(); ++item_index) {
+      auto & item = msg.items[item_index];
+      item.seq = seq_;
+      auto bytes = make_payload(seq_, item_index);
+
+      if (backend_mode_ == "test") {
+        auto impl = std::make_unique<test_rosidl_buffer::TestBufferImpl<std::uint8_t>>(
+          std::move(bytes));
+        item.data = rosidl::Buffer<std::uint8_t>(std::move(impl));
+      } else {
+        item.data = std::move(bytes);
+      }
+    }
+
+    pub_->publish(msg);
+
+    ++seq_;
+
+    std_msgs::msg::UInt32 c;
+    c.data = seq_;
+    count_pub_->publish(c);
+
+    std_msgs::msg::UInt32 tc;
+    tc.data = static_cast<std::uint32_t>(
+      test_rosidl_buffer::to_cpu_call_count().load(std::memory_order_relaxed));
+    to_cpu_pub_->publish(tc);
+  }
+
+  std::string backend_mode_;
+  std::uint32_t seq_ = 0;
+  std::uint32_t max_count_ = 0;
+
+  rclcpp::Publisher<test_rosidl_buffer::msg::ByteArrayList>::SharedPtr pub_;
+  rclcpp::Publisher<std_msgs::msg::UInt32>::SharedPtr count_pub_;
+  rclcpp::Publisher<std_msgs::msg::UInt32>::SharedPtr to_cpu_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<TestBackendNestedMsgsPublisher>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test_rosidl_buffer/src/test_backend_nested_msgs_subscriber.cpp
+++ b/test_rosidl_buffer/src/test_backend_nested_msgs_subscriber.cpp
@@ -1,0 +1,149 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Subscriber used by test_rosidl_buffer nested-message launch tests.
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "std_msgs/msg/u_int32.hpp"
+
+#include "rosidl_buffer/buffer.hpp"
+#include "test_rosidl_buffer/msg/byte_array_list.hpp"
+
+namespace
+{
+constexpr std::size_t kItemCount = 3;
+constexpr std::size_t kPayloadSize = 16;
+
+std::vector<std::uint8_t> make_payload(std::uint32_t seq, std::size_t item_index)
+{
+  std::vector<std::uint8_t> bytes(kPayloadSize);
+  for (std::size_t i = 0; i < bytes.size(); ++i) {
+    bytes[i] = static_cast<std::uint8_t>((seq + item_index * 17 + i) & 0xFF);
+  }
+  return bytes;
+}
+}  // namespace
+
+class TestBackendNestedMsgsSubscriber : public rclcpp::Node
+{
+public:
+  TestBackendNestedMsgsSubscriber()
+  : rclcpp::Node("test_backend_nested_msgs_subscriber")
+  {
+    const auto topic = declare_parameter<std::string>("topic_name", "test_byte_array_list");
+    const auto acceptable =
+      declare_parameter<std::string>("acceptable_buffer_backends", "__unset__");
+
+    rclcpp::SubscriptionOptions options;
+    if (acceptable != "__unset__") {
+      options.acceptable_buffer_backends = acceptable;
+      RCLCPP_INFO(
+        get_logger(), "acceptable_buffer_backends set to '%s'", acceptable.c_str());
+    } else {
+      RCLCPP_INFO(get_logger(), "acceptable_buffer_backends: <default>");
+    }
+
+    sub_ = create_subscription<test_rosidl_buffer::msg::ByteArrayList>(
+      topic, 10,
+      std::bind(&TestBackendNestedMsgsSubscriber::on_msg, this, std::placeholders::_1),
+      options);
+
+    count_pub_ = create_publisher<std_msgs::msg::UInt32>("subscriber_count", 10);
+    validation_pub_ = create_publisher<std_msgs::msg::Bool>("validation_result", 10);
+    backend_pub_ = create_publisher<std_msgs::msg::String>("observed_backend_type", 10);
+
+    RCLCPP_INFO(
+      get_logger(),
+      "test_backend_nested_msgs_subscriber started (topic=%s)",
+      topic.c_str());
+  }
+
+private:
+  void on_msg(const test_rosidl_buffer::msg::ByteArrayList::SharedPtr msg)
+  {
+    ++received_;
+    bool ok = true;
+    std::string backend = "empty";
+
+    if (msg->items.size() != kItemCount) {
+      RCLCPP_ERROR(
+        get_logger(), "item count=%zu (expected %zu)", msg->items.size(), kItemCount);
+      ok = false;
+    }
+
+    for (std::size_t item_index = 0; item_index < msg->items.size(); ++item_index) {
+      const auto & item = msg->items[item_index];
+      if (item_index == 0) {
+        backend = item.data.get_backend_type();
+      }
+
+      if (item.data.size() != kPayloadSize) {
+        RCLCPP_ERROR(
+          get_logger(), "item=%zu seq=%u: size=%zu (expected %zu)",
+          item_index, item.seq, item.data.size(), kPayloadSize);
+        ok = false;
+        continue;
+      }
+
+      const auto expected = make_payload(item.seq, item_index);
+      const auto bytes = item.data.to_vector();
+      for (std::size_t i = 0; i < kPayloadSize; ++i) {
+        if (bytes[i] != expected[i]) {
+          RCLCPP_ERROR(
+            get_logger(), "item=%zu seq=%u: byte[%zu]=%u (expected %u)",
+            item_index, item.seq, i, bytes[i], expected[i]);
+          ok = false;
+          break;
+        }
+      }
+    }
+
+    validation_ = validation_ && ok;
+
+    std_msgs::msg::UInt32 c;
+    c.data = received_;
+    count_pub_->publish(c);
+
+    std_msgs::msg::Bool v;
+    v.data = validation_;
+    validation_pub_->publish(v);
+
+    std_msgs::msg::String b;
+    b.data = backend;
+    backend_pub_->publish(b);
+  }
+
+  std::uint32_t received_ = 0;
+  bool validation_ = true;
+
+  rclcpp::Subscription<test_rosidl_buffer::msg::ByteArrayList>::SharedPtr sub_;
+  rclcpp::Publisher<std_msgs::msg::UInt32>::SharedPtr count_pub_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr validation_pub_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr backend_pub_;
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<TestBackendNestedMsgsSubscriber>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test_rosidl_buffer/src/test_backend_publisher.cpp
+++ b/test_rosidl_buffer/src/test_backend_publisher.cpp
@@ -1,0 +1,134 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Publisher used by test_rosidl_buffer launch tests.
+//
+// Parameters:
+//   backend_mode      : "cpu" (default) or "test"
+//   topic_name        : std topic (default "test_bytes")
+//   publish_rate_ms   : timer period (default 100)
+//   max_publish_count : stop after N messages (0 = unlimited, default 50)
+//
+// Side channels published for the launch-test harness:
+//   /publisher_count         (std_msgs/UInt32)  — messages sent so far
+//   /publisher_to_cpu_count  (std_msgs/UInt32)  — TestBufferImpl::to_cpu() calls
+//
+// The to_cpu count is the direct signal the test uses to assert the
+// descriptor path is being taken in the test-to-test scenario.
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/u_int32.hpp"
+
+#include "rosidl_buffer/buffer.hpp"
+#include "test_rosidl_buffer/msg/byte_array.hpp"
+#include "test_rosidl_buffer/test_buffer_impl.hpp"
+
+namespace
+{
+constexpr std::size_t kPayloadSize = 64;
+}
+
+class TestBackendPublisher : public rclcpp::Node
+{
+public:
+  TestBackendPublisher()
+  : rclcpp::Node("test_backend_publisher")
+  {
+    backend_mode_ = declare_parameter<std::string>("backend_mode", "cpu");
+    const auto topic = declare_parameter<std::string>("topic_name", "test_bytes");
+    const auto rate_ms = declare_parameter<int>("publish_rate_ms", 100);
+    max_count_ = static_cast<std::uint32_t>(declare_parameter<int>("max_publish_count", 50));
+
+    if (backend_mode_ != "cpu" && backend_mode_ != "test") {
+      RCLCPP_ERROR(
+        get_logger(), "Invalid backend_mode '%s', falling back to 'cpu'", backend_mode_.c_str());
+      backend_mode_ = "cpu";
+    }
+
+    test_rosidl_buffer::reset_to_cpu_call_count();
+
+    pub_ = create_publisher<test_rosidl_buffer::msg::ByteArray>(topic, 10);
+    count_pub_ = create_publisher<std_msgs::msg::UInt32>("publisher_count", 10);
+    to_cpu_pub_ = create_publisher<std_msgs::msg::UInt32>("publisher_to_cpu_count", 10);
+
+    timer_ = create_wall_timer(
+      std::chrono::milliseconds(rate_ms),
+      std::bind(&TestBackendPublisher::on_timer, this));
+
+    RCLCPP_INFO(
+      get_logger(),
+      "test_backend_publisher started (mode=%s, topic=%s, max=%u)",
+      backend_mode_.c_str(), topic.c_str(), max_count_);
+  }
+
+private:
+  void on_timer()
+  {
+    if (max_count_ > 0 && seq_ >= max_count_) {
+      return;
+    }
+
+    test_rosidl_buffer::msg::ByteArray msg;
+    msg.seq = seq_;
+
+    std::vector<std::uint8_t> bytes(kPayloadSize);
+    for (std::size_t i = 0; i < kPayloadSize; ++i) {
+      bytes[i] = static_cast<std::uint8_t>((seq_ + i) & 0xFF);
+    }
+
+    if (backend_mode_ == "test") {
+      auto impl = std::make_unique<test_rosidl_buffer::TestBufferImpl<std::uint8_t>>(
+        std::move(bytes));
+      msg.data = rosidl::Buffer<std::uint8_t>(std::move(impl));
+    } else {
+      msg.data = std::move(bytes);
+    }
+
+    pub_->publish(msg);
+
+    ++seq_;
+
+    std_msgs::msg::UInt32 c;
+    c.data = seq_;
+    count_pub_->publish(c);
+
+    std_msgs::msg::UInt32 tc;
+    tc.data = static_cast<std::uint32_t>(
+      test_rosidl_buffer::to_cpu_call_count().load(std::memory_order_relaxed));
+    to_cpu_pub_->publish(tc);
+  }
+
+  std::string backend_mode_;
+  std::uint32_t seq_ = 0;
+  std::uint32_t max_count_ = 0;
+
+  rclcpp::Publisher<test_rosidl_buffer::msg::ByteArray>::SharedPtr pub_;
+  rclcpp::Publisher<std_msgs::msg::UInt32>::SharedPtr count_pub_;
+  rclcpp::Publisher<std_msgs::msg::UInt32>::SharedPtr to_cpu_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<TestBackendPublisher>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test_rosidl_buffer/src/test_backend_subscriber.cpp
+++ b/test_rosidl_buffer/src/test_backend_subscriber.cpp
@@ -1,0 +1,146 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Subscriber used by test_rosidl_buffer launch tests.
+//
+// Parameters:
+//   topic_name                  : std topic (default "test_bytes")
+//   expected_backend            : required backend_type reported on the wire
+//                                 (e.g. "test" or "cpu")
+//   acceptable_buffer_backends  : value for SubscriptionOptions; leave as the
+//                                 sentinel "__unset__" to use defaults
+//                                 (this is what the test-to-cpu scenario needs)
+//
+// Side channels published for the launch-test harness:
+//   /subscriber_count        (std_msgs/UInt32)  — callbacks observed so far
+//   /validation_result       (std_msgs/Bool)    — cumulative pass/fail
+//   /observed_backend_type   (std_msgs/String)  — backend of most recent msg
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "std_msgs/msg/u_int32.hpp"
+
+#include "rosidl_buffer/buffer.hpp"
+#include "test_rosidl_buffer/msg/byte_array.hpp"
+
+namespace
+{
+constexpr std::size_t kPayloadSize = 64;
+}
+
+class TestBackendSubscriber : public rclcpp::Node
+{
+public:
+  TestBackendSubscriber()
+  : rclcpp::Node("test_backend_subscriber")
+  {
+    const auto topic = declare_parameter<std::string>("topic_name", "test_bytes");
+    expected_backend_ = declare_parameter<std::string>("expected_backend", "test");
+    const auto acceptable =
+      declare_parameter<std::string>("acceptable_buffer_backends", "__unset__");
+
+    rclcpp::SubscriptionOptions options;
+    if (acceptable != "__unset__") {
+      options.acceptable_buffer_backends = acceptable;
+      RCLCPP_INFO(
+        get_logger(), "acceptable_buffer_backends set to '%s'", acceptable.c_str());
+    } else {
+      RCLCPP_INFO(get_logger(), "acceptable_buffer_backends: <default>");
+    }
+
+    sub_ = create_subscription<test_rosidl_buffer::msg::ByteArray>(
+      topic, 10,
+      std::bind(&TestBackendSubscriber::on_msg, this, std::placeholders::_1),
+      options);
+
+    count_pub_ = create_publisher<std_msgs::msg::UInt32>("subscriber_count", 10);
+    validation_pub_ = create_publisher<std_msgs::msg::Bool>("validation_result", 10);
+    backend_pub_ = create_publisher<std_msgs::msg::String>("observed_backend_type", 10);
+
+    RCLCPP_INFO(
+      get_logger(),
+      "test_backend_subscriber started (topic=%s, expected_backend=%s)",
+      topic.c_str(), expected_backend_.c_str());
+  }
+
+private:
+  void on_msg(const test_rosidl_buffer::msg::ByteArray::SharedPtr msg)
+  {
+    ++received_;
+    bool ok = true;
+
+    const std::string backend = msg->data.get_backend_type();
+    if (backend != expected_backend_) {
+      RCLCPP_ERROR(
+        get_logger(), "seq=%u: backend '%s' != expected '%s'",
+        msg->seq, backend.c_str(), expected_backend_.c_str());
+      ok = false;
+    }
+
+    if (msg->data.size() != kPayloadSize) {
+      RCLCPP_ERROR(
+        get_logger(), "seq=%u: size=%zu (expected %zu)",
+        msg->seq, msg->data.size(), kPayloadSize);
+      ok = false;
+    } else {
+      const auto bytes = msg->data.to_vector();
+      for (std::size_t i = 0; i < kPayloadSize; ++i) {
+        const auto expected = static_cast<std::uint8_t>((msg->seq + i) & 0xFF);
+        if (bytes[i] != expected) {
+          RCLCPP_ERROR(
+            get_logger(), "seq=%u: byte[%zu]=%u (expected %u)",
+            msg->seq, i, bytes[i], expected);
+          ok = false;
+          break;
+        }
+      }
+    }
+
+    validation_ = validation_ && ok;
+
+    std_msgs::msg::UInt32 c;
+    c.data = received_;
+    count_pub_->publish(c);
+
+    std_msgs::msg::Bool v;
+    v.data = validation_;
+    validation_pub_->publish(v);
+
+    std_msgs::msg::String b;
+    b.data = backend;
+    backend_pub_->publish(b);
+  }
+
+  std::string expected_backend_;
+  std::uint32_t received_ = 0;
+  bool validation_ = true;
+
+  rclcpp::Subscription<test_rosidl_buffer::msg::ByteArray>::SharedPtr sub_;
+  rclcpp::Publisher<std_msgs::msg::UInt32>::SharedPtr count_pub_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr validation_pub_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr backend_pub_;
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<TestBackendSubscriber>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test_rosidl_buffer/src/test_buffer_backend_plugin.cpp
+++ b/test_rosidl_buffer/src/test_buffer_backend_plugin.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<void> TestBufferBackend::create_empty_descriptor() const
 
 std::pair<bool, std::vector<std::set<std::uint32_t>>> TestBufferBackend::on_discovering_endpoint(
   const rmw_topic_endpoint_info_t & endpoint_info,
-  const std::vector<rmw_topic_endpoint_info_t> & existing_endpoints,
+  [[maybe_unused]] const std::vector<rmw_topic_endpoint_info_t> & existing_endpoints,
   const std::unordered_map<std::string, std::string> & endpoint_supported_backends)
 {
   (void)existing_endpoints;
@@ -83,7 +83,7 @@ std::shared_ptr<void> TestBufferBackend::create_descriptor_with_endpoint(
 
 std::unique_ptr<void, void (*)(void *)> TestBufferBackend::from_descriptor_with_endpoint(
   const void * descriptor,
-  const rmw_topic_endpoint_info_t & endpoint_info) const
+  [[maybe_unused]] const rmw_topic_endpoint_info_t & endpoint_info) const
 {
   (void)endpoint_info;
   const auto & desc = *static_cast<const msg::TestBufferDescriptor *>(descriptor);

--- a/test_rosidl_buffer/src/test_buffer_backend_plugin.cpp
+++ b/test_rosidl_buffer/src/test_buffer_backend_plugin.cpp
@@ -1,0 +1,101 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test_rosidl_buffer/test_buffer_backend.hpp"
+
+#include <cstring>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <pluginlib/class_list_macros.hpp>
+
+#include "rosidl_typesupport_cpp/message_type_support.hpp"
+
+#include "test_rosidl_buffer/msg/test_buffer_descriptor.hpp"
+#include "test_rosidl_buffer/test_buffer_impl.hpp"
+
+namespace test_rosidl_buffer
+{
+
+TestBufferBackend::TestBufferBackend() = default;
+
+const rosidl_message_type_support_t * TestBufferBackend::get_descriptor_type_support() const
+{
+  return rosidl_typesupport_cpp::get_message_type_support_handle<msg::TestBufferDescriptor>();
+}
+
+std::shared_ptr<void> TestBufferBackend::create_empty_descriptor() const
+{
+  return std::make_shared<msg::TestBufferDescriptor>();
+}
+
+std::pair<bool, std::vector<std::set<std::uint32_t>>> TestBufferBackend::on_discovering_endpoint(
+  const rmw_topic_endpoint_info_t & endpoint_info,
+  const std::vector<rmw_topic_endpoint_info_t> & existing_endpoints,
+  const std::unordered_map<std::string, std::string> & endpoint_supported_backends)
+{
+  (void)existing_endpoints;
+
+  const bool peer_supports_test =
+    endpoint_supported_backends.find("test") != endpoint_supported_backends.end();
+
+  {
+    std::lock_guard<std::mutex> lock(compat_mutex_);
+    endpoint_compat_cache_[gid_hash(endpoint_info.endpoint_gid)] = peer_supports_test;
+  }
+
+  return {peer_supports_test, {}};
+}
+
+std::shared_ptr<void> TestBufferBackend::create_descriptor_with_endpoint(
+  const void * impl,
+  const rmw_topic_endpoint_info_t & endpoint_info) const
+{
+  {
+    std::lock_guard<std::mutex> lock(compat_mutex_);
+    const auto it = endpoint_compat_cache_.find(gid_hash(endpoint_info.endpoint_gid));
+    // If we already know the peer is not "test"-capable, signal the RMW to fall
+    // back to CPU serialization. Unknown peers default to "try descriptor" so
+    // early publishes that race discovery still get a chance on the test path.
+    if (it != endpoint_compat_cache_.end() && !it->second) {
+      return nullptr;
+    }
+  }
+
+  const auto * test_impl = static_cast<const TestBufferImpl<std::uint8_t> *>(impl);
+  return test_impl->create_descriptor();
+}
+
+std::unique_ptr<void, void (*)(void *)> TestBufferBackend::from_descriptor_with_endpoint(
+  const void * descriptor,
+  const rmw_topic_endpoint_info_t & endpoint_info) const
+{
+  (void)endpoint_info;
+  const auto & desc = *static_cast<const msg::TestBufferDescriptor *>(descriptor);
+  auto impl = TestBufferImpl<std::uint8_t>::from_descriptor(desc);
+  return {
+    impl.release(),
+    [](void * p) {delete static_cast<rosidl::BufferImplBase<std::uint8_t> *>(p);}
+  };
+}
+
+}  // namespace test_rosidl_buffer
+
+PLUGINLIB_EXPORT_CLASS(
+  test_rosidl_buffer::TestBufferBackend,
+  rosidl::BufferBackend)

--- a/test_rosidl_buffer/test/test_buffer_backend_unit.cpp
+++ b/test_rosidl_buffer/test/test_buffer_backend_unit.cpp
@@ -1,0 +1,197 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "rmw/topic_endpoint_info.h"
+#include "rmw/types.h"
+
+#include "rosidl_buffer/cpu_buffer_impl.hpp"
+#include "rosidl_buffer_backend/buffer_backend.hpp"
+
+#include "test_rosidl_buffer/msg/test_buffer_descriptor.hpp"
+#include "test_rosidl_buffer/test_buffer_backend.hpp"
+#include "test_rosidl_buffer/test_buffer_impl.hpp"
+
+using test_rosidl_buffer::TestBufferBackend;
+using test_rosidl_buffer::TestBufferImpl;
+
+namespace
+{
+
+rmw_topic_endpoint_info_t make_dummy_endpoint()
+{
+  rmw_topic_endpoint_info_t info;
+  std::memset(&info, 0, sizeof(info));
+  info.topic_type = "test_rosidl_buffer/msg/ByteArray";
+  return info;
+}
+
+}  // namespace
+
+TEST(TestBufferImplUnit, BackendTypeAndSize)
+{
+  TestBufferImpl<std::uint8_t> impl(std::vector<std::uint8_t>{1, 2, 3});
+  EXPECT_EQ("test", impl.get_backend_type());
+  EXPECT_EQ(3u, impl.size());
+}
+
+TEST(TestBufferImplUnit, ToCpuIncrementsCounter)
+{
+  test_rosidl_buffer::reset_to_cpu_call_count();
+  TestBufferImpl<std::uint8_t> impl(std::vector<std::uint8_t>{1, 2, 3});
+
+  ASSERT_EQ(0u, test_rosidl_buffer::to_cpu_call_count().load());
+  auto cpu = impl.to_cpu();
+  ASSERT_NE(nullptr, cpu);
+  EXPECT_EQ(1u, test_rosidl_buffer::to_cpu_call_count().load());
+
+  auto * cpu_impl = dynamic_cast<rosidl::CpuBufferImpl<std::uint8_t> *>(cpu.get());
+  ASSERT_NE(nullptr, cpu_impl);
+  EXPECT_EQ((std::vector<std::uint8_t>{1, 2, 3}), cpu_impl->get_storage());
+}
+
+TEST(TestBufferImplUnit, DescriptorRoundTrip)
+{
+  test_rosidl_buffer::reset_to_cpu_call_count();
+
+  std::vector<std::uint8_t> bytes(256);
+  for (std::size_t i = 0; i < bytes.size(); ++i) {
+    bytes[i] = static_cast<std::uint8_t>(i);
+  }
+  TestBufferImpl<std::uint8_t> original(bytes);
+
+  auto desc = original.create_descriptor();
+  ASSERT_NE(nullptr, desc);
+  EXPECT_EQ(256u, desc->size);
+  EXPECT_EQ(256u, desc->data.size());
+  EXPECT_NE(0u, desc->data_hash);
+
+  auto reconstructed = TestBufferImpl<std::uint8_t>::from_descriptor(*desc);
+  ASSERT_NE(nullptr, reconstructed);
+  auto * typed = dynamic_cast<TestBufferImpl<std::uint8_t> *>(reconstructed.get());
+  ASSERT_NE(nullptr, typed);
+  EXPECT_EQ(bytes, typed->get_storage());
+
+  // Round-tripping must not require a to_cpu() conversion.
+  EXPECT_EQ(0u, test_rosidl_buffer::to_cpu_call_count().load());
+}
+
+TEST(TestBufferImplUnit, DescriptorHashMismatchThrows)
+{
+  test_rosidl_buffer::msg::TestBufferDescriptor desc;
+  desc.size = 3;
+  desc.data = std::vector<std::uint8_t>{1, 2, 3};
+  desc.data_hash = 0;   // Intentionally wrong.
+
+  EXPECT_THROW(
+    TestBufferImpl<std::uint8_t>::from_descriptor(desc),
+    std::runtime_error);
+}
+
+TEST(TestBufferBackendUnit, BackendTypeAndMetadata)
+{
+  TestBufferBackend backend;
+  EXPECT_EQ("test", backend.get_backend_type());
+  EXPECT_EQ("version=test", backend.get_backend_metadata());
+}
+
+TEST(TestBufferBackendUnit, EmptyDescriptorAndTypeSupportConsistent)
+{
+  TestBufferBackend backend;
+  auto empty = backend.create_empty_descriptor();
+  ASSERT_NE(nullptr, empty);
+
+  const auto * ts = backend.get_descriptor_type_support();
+  ASSERT_NE(nullptr, ts);
+  ASSERT_NE(nullptr, ts->data);
+}
+
+TEST(TestBufferBackendUnit, DescriptorRoundTripThroughBackend)
+{
+  TestBufferBackend backend;
+  const auto endpoint = make_dummy_endpoint();
+
+  const std::vector<std::uint8_t> bytes{10, 20, 30, 40, 50};
+  TestBufferImpl<std::uint8_t> impl(bytes);
+
+  // Pretend the peer supports us so the compat cache does not short-circuit.
+  std::unordered_map<std::string, std::string> peer_backends;
+  peer_backends["test"] = "version=test";
+  (void)backend.on_discovering_endpoint(endpoint, {}, peer_backends);
+
+  auto desc = backend.create_descriptor_with_endpoint(&impl, endpoint);
+  ASSERT_NE(nullptr, desc);
+
+  auto reconstructed = backend.from_descriptor_with_endpoint(desc.get(), endpoint);
+  ASSERT_NE(nullptr, reconstructed.get());
+
+  auto * base = static_cast<rosidl::BufferImplBase<std::uint8_t> *>(reconstructed.get());
+  auto * typed = dynamic_cast<TestBufferImpl<std::uint8_t> *>(base);
+  ASSERT_NE(nullptr, typed);
+  EXPECT_EQ(bytes, typed->get_storage());
+}
+
+TEST(TestBufferBackendUnit, CreateDescriptorReturnsNullForIncompatiblePeer)
+{
+  TestBufferBackend backend;
+  const auto endpoint = make_dummy_endpoint();
+
+  // Peer does NOT advertise "test".
+  std::unordered_map<std::string, std::string> peer_backends;
+  peer_backends["other"] = "x";
+  const auto disc = backend.on_discovering_endpoint(endpoint, {}, peer_backends);
+  EXPECT_FALSE(disc.first);
+
+  TestBufferImpl<std::uint8_t> impl(std::vector<std::uint8_t>{1, 2, 3});
+  auto desc = backend.create_descriptor_with_endpoint(&impl, endpoint);
+  EXPECT_EQ(nullptr, desc) <<
+    "Backend must return nullptr for peers that do not advertise the 'test' backend, "
+    "so the serialization layer can fall back to CPU.";
+}
+
+TEST(TestBufferBackendUnit, DescriptorSizeUnderLimit)
+{
+  // Largest payload we would realistically send through this test backend.
+  // Pick something big but within rosidl::kMaxBufferDescriptorSize after the
+  // small fixed overhead for size/hash fields.
+  constexpr std::size_t kPayload = 3584;
+  static_assert(
+    kPayload + 128 < rosidl::kMaxBufferDescriptorSize,
+    "payload + descriptor header overhead must fit within kMaxBufferDescriptorSize");
+
+  TestBufferImpl<std::uint8_t> impl(std::vector<std::uint8_t>(kPayload, 0xAB));
+  auto desc = impl.create_descriptor();
+  ASSERT_NE(nullptr, desc);
+
+  // Approximate serialized size: uint8[] len + header fixed overhead.
+  const std::size_t approx_serialized_bytes =
+    desc->data.size() + sizeof(desc->size) + sizeof(desc->data_hash) +
+    /* typical CDR padding/length fields */ 32u;
+  EXPECT_LE(approx_serialized_bytes, rosidl::kMaxBufferDescriptorSize);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test_rosidl_buffer/test/test_nested_msgs_fastrtps.py
+++ b/test_rosidl_buffer/test/test_nested_msgs_fastrtps.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Launch test: nested ByteArray messages over FastRTPS.
+
+Verifies that a message containing ByteArray[] round-trips nested uint8[]
+fields correctly when the publisher constructs each nested buffer with the
+test backend.
+"""
+
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable
+from launch_ros.actions import Node
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+import pytest
+import rclpy
+from std_msgs.msg import Bool, String, UInt32
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    publisher_node = Node(
+        package='test_rosidl_buffer',
+        executable='test_backend_nested_msgs_publisher',
+        name='test_backend_nested_msgs_publisher',
+        output='screen',
+        parameters=[{
+            'backend_mode': 'test',
+            'topic_name': 'test_byte_array_list',
+            'publish_rate_ms': 100,
+            'max_publish_count': 40,
+        }],
+    )
+
+    subscriber_node = Node(
+        package='test_rosidl_buffer',
+        executable='test_backend_nested_msgs_subscriber',
+        name='test_backend_nested_msgs_subscriber',
+        output='screen',
+        parameters=[{
+            'topic_name': 'test_byte_array_list',
+            'acceptable_buffer_backends': 'any',
+        }],
+    )
+
+    return LaunchDescription([
+        SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp'),
+        SetEnvironmentVariable('RCL_ASSERT_RMW_ID_MATCHES', 'rmw_fastrtps_cpp'),
+        publisher_node,
+        subscriber_node,
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+
+class TestNestedMsgsFastRTPS(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('test_nested_msgs')
+        self.subscriber_count = 0
+        self.validation_passed = None
+        self.observed_backend = None
+
+        self.node.create_subscription(
+            UInt32, 'subscriber_count', self._on_sub_count, 10)
+        self.node.create_subscription(
+            Bool, 'validation_result', self._on_validation, 10)
+        self.node.create_subscription(
+            String, 'observed_backend_type', self._on_backend, 10)
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def _on_sub_count(self, msg):
+        self.subscriber_count = msg.data
+
+    def _on_validation(self, msg):
+        self.validation_passed = msg.data
+
+    def _on_backend(self, msg):
+        self.observed_backend = msg.data
+
+    def _spin_until(self, target=20, timeout_sec=20.0):
+        start = time.time()
+        while (
+            (self.subscriber_count < target
+             or self.validation_passed is None
+             or self.observed_backend is None)
+            and time.time() - start < timeout_sec
+        ):
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+        return self.subscriber_count >= target
+
+    def test_nested_byte_arrays_round_trip(self):
+        self.assertTrue(
+            self._spin_until(target=20, timeout_sec=20.0),
+            f'Only received {self.subscriber_count} messages')
+        self.assertTrue(self.validation_passed, 'Subscriber validation failed')
+        self.assertIn(
+            self.observed_backend, ('test', 'cpu'),
+            f'Unexpected nested buffer backend: {self.observed_backend!r}')
+
+
+@launch_testing.post_shutdown_test()
+class TestNestedMsgsFastRTPSShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/test_rosidl_buffer/test/test_test_to_cpu_fastrtps.py
+++ b/test_rosidl_buffer/test/test_test_to_cpu_fastrtps.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Launch test: test backend publisher to plain CPU subscriber over FastRTPS.
+
+The subscriber is not given any backend-related SubscriptionOptions, so it
+advertises only the default "cpu" backend. The publisher must therefore
+fall back to CPU serialization and the subscriber must receive a CPU-backed
+buffer. Data content is still verified byte-for-byte.
+"""
+
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable
+from launch_ros.actions import Node
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+import pytest
+import rclpy
+from std_msgs.msg import Bool, String, UInt32
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    publisher_node = Node(
+        package='test_rosidl_buffer',
+        executable='test_backend_publisher',
+        name='test_backend_publisher',
+        output='screen',
+        parameters=[{
+            'backend_mode': 'test',
+            'topic_name': 'test_bytes',
+            'publish_rate_ms': 100,
+            'max_publish_count': 40,
+        }],
+    )
+
+    # No acceptable_buffer_backends override — default subscription options.
+    subscriber_node = Node(
+        package='test_rosidl_buffer',
+        executable='test_backend_subscriber',
+        name='test_backend_subscriber',
+        output='screen',
+        parameters=[{
+            'topic_name': 'test_bytes',
+            'expected_backend': 'cpu',
+        }],
+    )
+
+    return LaunchDescription([
+        SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp'),
+        SetEnvironmentVariable('RCL_ASSERT_RMW_ID_MATCHES', 'rmw_fastrtps_cpp'),
+        publisher_node,
+        subscriber_node,
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+
+class TestTestToCpuFastRTPS(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('test_test_to_cpu')
+        self.subscriber_count = 0
+        self.validation_passed = None
+        self.observed_backend = None
+
+        self.node.create_subscription(
+            UInt32, 'subscriber_count', self._on_sub_count, 10)
+        self.node.create_subscription(
+            Bool, 'validation_result', self._on_validation, 10)
+        self.node.create_subscription(
+            String, 'observed_backend_type', self._on_backend, 10)
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def _on_sub_count(self, msg):
+        self.subscriber_count = msg.data
+
+    def _on_validation(self, msg):
+        self.validation_passed = msg.data
+
+    def _on_backend(self, msg):
+        self.observed_backend = msg.data
+
+    def _spin_until(self, target=20, timeout_sec=20.0):
+        start = time.time()
+        while (
+            (self.subscriber_count < target
+             or self.validation_passed is None
+             or self.observed_backend is None)
+            and time.time() - start < timeout_sec
+        ):
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+        return self.subscriber_count >= target
+
+    def test_test_to_cpu_falls_back(self):
+        self.assertTrue(
+            self._spin_until(target=20, timeout_sec=20.0),
+            f'Only received {self.subscriber_count} messages')
+        self.assertTrue(self.validation_passed, 'Subscriber validation failed')
+        self.assertEqual(
+            'cpu', self.observed_backend,
+            'With a default-configured CPU subscriber, the subscriber must '
+            'observe backend_type == "cpu". Got '
+            f'{self.observed_backend!r}.')
+
+
+@launch_testing.post_shutdown_test()
+class TestTestToCpuFastRTPSShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/test_rosidl_buffer/test/test_test_to_test_fastrtps.py
+++ b/test_rosidl_buffer/test/test_test_to_test_fastrtps.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Launch test: test backend publisher to test backend subscriber over FastRTPS.
+
+Verifies that:
+  * The subscriber actually receives messages.
+  * Every received message reports backend_type == "test" (descriptor path).
+  * The publisher's TestBufferImpl::to_cpu() was never invoked, proving the
+    buffer was handed directly to the RMW via the backend descriptor rather
+    than converted to CPU bytes first.
+"""
+
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable
+from launch_ros.actions import Node
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+import pytest
+import rclpy
+from std_msgs.msg import Bool, String, UInt32
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    publisher_node = Node(
+        package='test_rosidl_buffer',
+        executable='test_backend_publisher',
+        name='test_backend_publisher',
+        output='screen',
+        parameters=[{
+            'backend_mode': 'test',
+            'topic_name': 'test_bytes',
+            'publish_rate_ms': 100,
+            'max_publish_count': 40,
+        }],
+    )
+
+    subscriber_node = Node(
+        package='test_rosidl_buffer',
+        executable='test_backend_subscriber',
+        name='test_backend_subscriber',
+        output='screen',
+        parameters=[{
+            'topic_name': 'test_bytes',
+            'expected_backend': 'test',
+            'acceptable_buffer_backends': 'any',
+        }],
+    )
+
+    return LaunchDescription([
+        SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp'),
+        SetEnvironmentVariable('RCL_ASSERT_RMW_ID_MATCHES', 'rmw_fastrtps_cpp'),
+        publisher_node,
+        subscriber_node,
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+
+class TestTestToTestFastRTPS(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('test_test_to_test')
+        self.subscriber_count = 0
+        self.validation_passed = None
+        self.observed_backend = None
+        self.publisher_to_cpu = None
+
+        self.node.create_subscription(
+            UInt32, 'subscriber_count', self._on_sub_count, 10)
+        self.node.create_subscription(
+            Bool, 'validation_result', self._on_validation, 10)
+        self.node.create_subscription(
+            String, 'observed_backend_type', self._on_backend, 10)
+        self.node.create_subscription(
+            UInt32, 'publisher_to_cpu_count', self._on_to_cpu, 10)
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def _on_sub_count(self, msg):
+        self.subscriber_count = msg.data
+
+    def _on_validation(self, msg):
+        self.validation_passed = msg.data
+
+    def _on_backend(self, msg):
+        self.observed_backend = msg.data
+
+    def _on_to_cpu(self, msg):
+        self.publisher_to_cpu = msg.data
+
+    def _spin_until(self, target=20, timeout_sec=20.0):
+        start = time.time()
+        while (
+            (self.subscriber_count < target
+             or self.validation_passed is None
+             or self.observed_backend is None
+             or self.publisher_to_cpu is None)
+            and time.time() - start < timeout_sec
+        ):
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+        return self.subscriber_count >= target
+
+    def test_test_to_test_uses_descriptor_path(self):
+        self.assertTrue(
+            self._spin_until(target=20, timeout_sec=20.0),
+            f'Only received {self.subscriber_count} messages')
+        self.assertTrue(self.validation_passed, 'Subscriber validation failed')
+        self.assertEqual(
+            'test', self.observed_backend,
+            'Subscriber must observe backend_type == "test"; got '
+            f'{self.observed_backend!r}. A "cpu" value means the serialization '
+            'layer fell back to CPU instead of going through '
+            'TestBufferBackend::from_descriptor_with_endpoint.')
+        self.assertEqual(
+            0, self.publisher_to_cpu,
+            'TestBufferImpl::to_cpu() must NEVER be called in the test→test '
+            f'scenario. Got {self.publisher_to_cpu} calls. A non-zero value '
+            'means the RMW fell back to CPU serialization on the publisher '
+            'side instead of using the backend descriptor path.')
+
+
+@launch_testing.post_shutdown_test()
+class TestTestToTestFastRTPSShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/test_rosidl_buffer/test_buffer_plugin.xml
+++ b/test_rosidl_buffer/test_buffer_plugin.xml
@@ -1,0 +1,10 @@
+<!-- Plugin descriptor for the in-tree test buffer backend used by system tests. -->
+<library path="test_rosidl_buffer_backend_plugin">
+  <class name="test"
+         type="test_rosidl_buffer::TestBufferBackend"
+         base_class_type="rosidl::BufferBackend">
+    <description>
+      Minimal BufferBackend plugin used by system_tests/test_rosidl_buffer.
+    </description>
+  </class>
+</library>


### PR DESCRIPTION
## Description

Adds a new `test_rosidl_buffer` system test package that exercises the `rosidl_buffer` / `rosidl_buffer_backend` feature end-to-end. It validates the `BufferBackend` contract with a minimal in-tree backend plugin and covers critical transport scenarios over `rmw_fastrtps_cpp`, which has full buffer-backend support today.

Layout under `src/ros2/system_tests/test_rosidl_buffer/`:

- `msg/TestBufferDescriptor.msg`, `msg/ByteArray.msg`, `msg/ByteArrayList.msg` — descriptor, direct payload, and minimal nested payload messages generated via `rosidl_generate_interfaces`.
- `include/test_rosidl_buffer/test_buffer_impl.hpp` — header-only `TestBufferImpl<T>` (a `BufferImplBase<T>` subclass) with a process-wide atomic counter of `to_cpu()` invocations.
- `src/test_buffer_backend_plugin.cpp` + `test_buffer_plugin.xml` — `TestBufferBackend` pluginlib plugin exported for discovery at runtime.
- `src/test_backend_publisher.cpp` / `src/test_backend_subscriber.cpp` — parameterized pub/sub executables used by the direct-buffer launch tests.
- `src/test_backend_nested_msgs_publisher.cpp` / `src/test_backend_nested_msgs_subscriber.cpp` — parameterized pub/sub executables used by the nested-buffer launch test.
- `test/test_buffer_backend_unit.cpp` — standalone gtest for the backend contract (no RMW involved).
- `test/test_test_to_test_fastrtps.py`, `test/test_test_to_cpu_fastrtps.py`, `test/test_nested_msgs_fastrtps.py` — launch tests.

What the tests prove:

- **test to test** (`acceptable_buffer_backends=any` on the subscriber): the subscriber observes `get_backend_type() == "test"`, and the publisher's `TestBufferImpl::to_cpu()` counter stays at **0**. Together these prove the RMW uses `TestBufferBackend::create_descriptor_with_endpoint` → `from_descriptor_with_endpoint` and never falls back to CPU serialization on the publisher side.
- **test to cpu** (default subscriber options, i.e. `acceptable_buffer_backends="cpu"`): the publisher sees a CPU-only peer in `on_discovering_endpoint`, `create_descriptor_with_endpoint` returns `nullptr`, the RMW falls back to CPU, and the subscriber observes `get_backend_type() == "cpu"` with byte-exact content.
- **nested messages** (`ByteArrayList` containing `ByteArray[]`): each nested `ByteArray.data` field is constructed with the test backend and validated byte-for-byte after transport. This covers nested `uint8[]` generation/serialization behavior while keeping the fixture minimal.

RMW gating is done at CMake time via an allowlist (`_buffer_backend_capable_rmws = rmw_fastrtps_cpp`) wrapped inside a `get_available_rmw_implementations` loop, plus `RMW_IMPLEMENTATION` / `RCL_ASSERT_RMW_ID_MATCHES` env vars in each launch description so a mismatched RMW fails loudly. The unit gtest is registered unconditionally since it does not touch any RMW. Additional backends can be supported later by just appending to the allowlist.

### Is this user-facing behavior change?

No. This only adds test coverage for the existing `rosidl_buffer` / `rosidl_buffer_backend` feature.

### Did you use Generative AI?

Yes. Cursor with Claude Opus 4.7 was used to assist with the draft version of the changes included in this pull request.