### PR TITLE
test_rclcpp :- Add local and async set_parameters_atomically tests

### DIFF
--- a/test_rclcpp/test/parameter_fixtures.hpp
+++ b/test_rclcpp/test/parameter_fixtures.hpp
@@ -104,6 +104,23 @@ void test_set_parameters_atomically_sync(
   ASSERT_EQ(set_parameters_result.successful, expect_result_successful);
 }
 
+void test_set_parameters_atomically_async(
+  std::shared_ptr<rclcpp::Node> node,
+  std::shared_ptr<rclcpp::AsyncParametersClient> parameters_client,
+  bool expect_result_successful = true)
+{
+  printf("Setting parameters atomically\n");
+  std::vector<rclcpp::Parameter> parameters = get_test_parameters();
+  auto set_parameters_result = parameters_client->set_parameters_atomically(parameters);
+  rclcpp::spin_until_future_complete(node, set_parameters_result);  // Wait for the results.
+  printf("Got set_parameters_atomically result\n");
+
+  const auto result = set_parameters_result.get();
+
+  // Check to see if they were set.
+  ASSERT_EQ(result.successful, expect_result_successful);
+}
+
 void test_set_parameters_async(
   std::shared_ptr<rclcpp::Node> node,
   std::shared_ptr<rclcpp::AsyncParametersClient> parameters_client,

--- a/test_rclcpp/test/test_local_parameters.cpp
+++ b/test_rclcpp/test/test_local_parameters.cpp
@@ -101,6 +101,23 @@ TEST_F(test_local_parameters, local_synchronous_repeated)
   }
 }
 
+TEST_F(test_local_parameters, local_set_parameters_atomically)
+{
+  auto node = rclcpp::Node::make_shared("test_parameters_local_set_atomically");
+  declare_test_parameters(node);
+
+  auto parameters = get_test_parameters();
+  auto result = node->set_parameters_atomically(parameters);
+
+  ASSERT_TRUE(result.successful);
+
+  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
+  test_get_parameters_sync(parameters_client);
+}
+
 TEST_F(test_local_parameters, local_asynchronous)
 {
   auto node = rclcpp::Node::make_shared(std::string("test_parameters_local_asynchronous"));

--- a/test_rclcpp/test/test_remote_parameters.cpp
+++ b/test_rclcpp/test/test_remote_parameters.cpp
@@ -59,6 +59,23 @@ TEST_F(parameters, test_remote_parameters_async)
   test_get_parameters_async(node, parameters_client, true);
 }
 
+TEST_F(parameters, test_set_remote_parameters_atomically_async)
+{
+  std::string test_server_name = "test_parameters_server_allow_undeclared";
+
+  auto node = rclcpp::Node::make_shared(std::string("test_set_remote_parameters_atomically_async"));
+
+  auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(
+    node, test_server_name);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
+
+  test_set_parameters_atomically_async(node, parameters_client);
+
+  test_get_parameters_async(node, parameters_client, true);
+}
+
 TEST_F(parameters, test_remote_parameters_sync)
 {
   std::string test_server_name = "test_parameters_server_allow_undeclared";
@@ -121,6 +138,22 @@ TEST_F(parameters_must_declare, test_remote_parameters_async)
   }
 
   test_set_parameters_async(node, parameters_client, 0);
+}
+
+TEST_F(parameters_must_declare, test_set_remote_parameters_atomically_async)
+{
+  std::string test_server_name = "test_parameters_server_must_declare";
+
+  auto node = rclcpp::Node::make_shared(std::string("test_set_remote_parameters_atomically_async"));
+
+  auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(
+    node,
+    test_server_name);
+  if (!parameters_client->wait_for_service(20s)) {
+    ASSERT_TRUE(false) << "service not available after waiting";
+  }
+
+  test_set_parameters_atomically_async(node, parameters_client, false);
 }
 
 TEST_F(parameters_must_declare, test_remote_parameters_sync)


### PR DESCRIPTION
## Description

This PR adds the missing tests for `set_parameters_atomically` to the `test_rclcpp` suite. It includes both local parameter assignment and remote asynchronous parameter assignment tests.

Changes included:
- Added `test_set_parameters_atomically_async` helper function to `parameter_fixtures.hpp`.
- Added `local_set_parameters_atomically` test case in `test_local_parameters.cpp` to verify atomic parameter assignment on a local node.
- Added asynchronous `set_parameters_atomically` tests to `test_remote_parameters.cpp` to verify remote atomic assignment (both for regular parameters and strict `parameters_must_declare` nodes).

Fixes #282

### Is this user-facing behavior change?



### Did you use Generative AI?

Yes, this pull request was generated with the assistance of Antigravity (a generative AI assistant ) to implement the test logic and boilerplate.

### Additional Information

All newly added integration tests successfully pass locally against the Jazzy distribution in a WSL2 Ubuntu 24.04 environment.

