### PR TITLE
Fix test_security tests using rmw_connextdds by disabling Monitoring 2.0

### DIFF
--- a/test_security/CMakeLists.txt
+++ b/test_security/CMakeLists.txt
@@ -51,15 +51,22 @@ if(BUILD_TESTING)
   endfunction()
 
   function(custom_security_test_c target)
+    set(test_env
+      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+      RMW_IMPLEMENTATION=${rmw_implementation}
+      ROS_SECURITY_KEYSTORE=${KEYSTORE_DIRECTORY_NATIVE_PATH}
+      PATH="${TEST_PATH}"
+    )
+    if(rmw_implementation STREQUAL "rmw_connextdds")
+      list(APPEND test_env RTI_MONITORING2_ENABLE=false)
+    endif()
+
     ament_add_gtest(
       "${target}${target_suffix}" ${ARGN}
       TIMEOUT 10
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       ENV
-      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-      RMW_IMPLEMENTATION=${rmw_implementation}
-      ROS_SECURITY_KEYSTORE=${KEYSTORE_DIRECTORY_NATIVE_PATH}
-      PATH="${TEST_PATH}"
+      ${test_env}
     )
     if(TARGET ${target}${target_suffix})
       target_link_libraries(${target}${target_suffix}

--- a/test_security/test/test_secure_publisher_subscriber.py.in
+++ b/test_security/test/test_secure_publisher_subscriber.py.in
@@ -45,6 +45,8 @@ def generate_test_description():
     publisher_env['ROS_SECURITY_ENABLE'] = '@PUBLISHER_ROS_SECURITY_ENABLE@'
     publisher_env['ROS_SECURITY_STRATEGY'] = '@PUBLISHER_ROS_SECURITY_STRATEGY@'
     publisher_env['ROS_SECURITY_KEYSTORE'] = '@PUBLISHER_ROS_SECURITY_KEYSTORE@'
+    if '@PUBLISHER_RMW@' == 'rmw_connextdds':
+        publisher_env['RTI_MONITORING2_ENABLE'] = 'false'
 
     launch_description.add_action(ExecuteProcess(
         cmd=publisher_cmd,
@@ -57,6 +59,8 @@ def generate_test_description():
     subscriber_env['ROS_SECURITY_ENABLE'] = '@SUBSCRIBER_ROS_SECURITY_ENABLE@'
     subscriber_env['ROS_SECURITY_STRATEGY'] = '@SUBSCRIBER_ROS_SECURITY_STRATEGY@'
     subscriber_env['ROS_SECURITY_KEYSTORE'] = '@SUBSCRIBER_ROS_SECURITY_KEYSTORE@'
+    if '@SUBSCRIBER_RMW@' == 'rmw_connextdds':
+        subscriber_env['RTI_MONITORING2_ENABLE'] = 'false'
 
     subscriber_process = ExecuteProcess(
         cmd=subscriber_cmd,


### PR DESCRIPTION
## Description

With the enabling of the Monitoring 2.0 Library in rolling (see https://github.com/ros2/rmw_connextdds/pull/243), security tests are failing because the Monitoring Participant must be secured if other Participants are also secured.

To fix these tests, we explicitly disable Monitoring 2.0 through the environment variable `RTI_MONITORING2_ENABLE`.

### Is this user-facing behavior change?

Tests in `test_security` using the `rmw_connextdds` will now pass again.

### Did you use Generative AI?

No

### Additional Information

Monitoring is specific to the Connext RMW. We don't need to test for it in `system_tests`.
