### PR TITLE
Add tests for SROS2 access control policies (Issue #238)

### DIFF
--- a/test_security/CMakeLists.txt
+++ b/test_security/CMakeLists.txt
@@ -121,6 +121,8 @@ if(BUILD_TESTING)
       set(index 0)
       # configure all non secure communication tests
       set(SUBSCRIBER_SHOULD_TIMEOUT "false")
+      set(PUBLISHER_ENCLAVE "/publisher")
+      set(SUBSCRIBER_ENCLAVE "/subscriber")
       while(index LESS ${n_non_secure_tests})
         # here we define all the variables needed for security template expansion
         list(GET non_secure_comm_PUBLISHER_ROS_SECURITY_ENABLE_LIST ${index} PUBLISHER_ROS_SECURITY_ENABLE)
@@ -163,6 +165,8 @@ if(BUILD_TESTING)
       set(SUBSCRIBER_SHOULD_TIMEOUT "false")
       set(PUBLISHER_ROS_SECURITY_KEYSTORE "${KEYSTORE_DIRECTORY_NATIVE_PATH}")
       set(SUBSCRIBER_ROS_SECURITY_KEYSTORE "${KEYSTORE_DIRECTORY_NATIVE_PATH}")
+      set(PUBLISHER_ENCLAVE "/publisher")
+      set(SUBSCRIBER_ENCLAVE "/subscriber")
       # configure all secure communication tests
       while(index LESS ${n_secure_communication_tests})
         # here we define all the variables needed for security template expansion
@@ -204,6 +208,8 @@ if(BUILD_TESTING)
       set(PUBLISHER_ROS_SECURITY_KEYSTORE "${KEYSTORE_DIRECTORY_NATIVE_PATH}")
       set(SUBSCRIBER_ROS_SECURITY_KEYSTORE "${KEYSTORE_DIRECTORY_NATIVE_PATH}")
       set(SUBSCRIBER_SHOULD_TIMEOUT "true")
+      set(PUBLISHER_ENCLAVE "/publisher")
+      set(SUBSCRIBER_ENCLAVE "/subscriber")
       # configure all not connecting tests
       while(index LESS ${n_not_connecting_tests})
         # here we define all the variables needed for security template expansion
@@ -213,6 +219,52 @@ if(BUILD_TESTING)
         list(GET not_connecting_SUBSCRIBER_ROS_SECURITY_STRATEGY_LIST ${index} SUBSCRIBER_ROS_SECURITY_STRATEGY)
 
         set(test_suffix "__${TEST_MESSAGE_TYPE}${suffix}__secure_not_connecting_${index}")
+        configure_file(
+          test/test_secure_publisher_subscriber.py.in
+          test_secure_publisher_subscriber${test_suffix}.py.configured
+          @ONLY
+        )
+        file(GENERATE
+          OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_secure_publisher_subscriber${test_suffix}_$<CONFIG>.py"
+          INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_secure_publisher_subscriber${test_suffix}.py.configured"
+        )
+        math(EXPR index "${index} + 1")
+
+        add_launch_test(
+          "${CMAKE_CURRENT_BINARY_DIR}/test_secure_publisher_subscriber${test_suffix}_$<CONFIG>.py"
+          TARGET test_secure_publisher_subscriber${test_suffix}
+          APPEND_LIBRARY_DIRS "${append_library_dirs}"
+          ENV
+          PATH="${TEST_PATH}"
+          TIMEOUT 20
+        )
+        if(TEST test_secure_publisher_subscriber${test_suffix})
+          set_tests_properties(
+            test_secure_publisher_subscriber${test_suffix}
+            PROPERTIES DEPENDS "test_secure_publisher_cpp__${rmw_implementation};test_secure_subscriber_cpp__${rmw_implementation}"
+            FIXTURES_REQUIRED "sros_artifacts"
+          )
+        endif()
+      endwhile()
+
+      # Test suite for access control policies
+      set(index 0)
+      set(PUBLISHER_ROS_SECURITY_KEYSTORE "${KEYSTORE_DIRECTORY_NATIVE_PATH}")
+      set(SUBSCRIBER_ROS_SECURITY_KEYSTORE "${KEYSTORE_DIRECTORY_NATIVE_PATH}")
+      set(SUBSCRIBER_SHOULD_TIMEOUT "true")
+      set(access_control_PUBLISHER_ENCLAVE_LIST "/publisher_denied;/publisher")
+      set(access_control_SUBSCRIBER_ENCLAVE_LIST "/subscriber;/subscriber_denied")
+      list(LENGTH access_control_PUBLISHER_ENCLAVE_LIST n_access_control_tests)
+
+      while(index LESS ${n_access_control_tests})
+        set(PUBLISHER_ROS_SECURITY_ENABLE "true")
+        set(SUBSCRIBER_ROS_SECURITY_ENABLE "true")
+        set(PUBLISHER_ROS_SECURITY_STRATEGY "Enforce")
+        set(SUBSCRIBER_ROS_SECURITY_STRATEGY "Enforce")
+        list(GET access_control_PUBLISHER_ENCLAVE_LIST ${index} PUBLISHER_ENCLAVE)
+        list(GET access_control_SUBSCRIBER_ENCLAVE_LIST ${index} SUBSCRIBER_ENCLAVE)
+
+        set(test_suffix "__${TEST_MESSAGE_TYPE}${suffix}__access_control_${index}")
         configure_file(
           test/test_secure_publisher_subscriber.py.in
           test_secure_publisher_subscriber${test_suffix}.py.configured

--- a/test_security/test/sros_artifacts.cmake
+++ b/test_security/test/sros_artifacts.cmake
@@ -26,6 +26,34 @@ if(NOT ${GENERATE_ARTIFACTS_RESULT} EQUAL 0)
   message(FATAL_ERROR "Failed to generate security artifacts: ${GENERATE_ARTIFACTS_ERROR}")
 endif()
 
+# Generate access control artifacts for publisher denied
+set(generate_publisher_denied_command ${ROS2_EXECUTABLE} security generate_artifacts
+  -k ${KEYSTORE_DIRECTORY_NATIVE_PATH}
+  -e /publisher_denied
+  -p ${KEYSTORE_DIRECTORY_NATIVE_PATH}/policies/policy_publisher_denied.xml)
+execute_process(
+  COMMAND ${generate_publisher_denied_command}
+  RESULT_VARIABLE GENERATE_ARTIFACTS_RESULT
+  ERROR_VARIABLE GENERATE_ARTIFACTS_ERROR
+)
+if(NOT ${GENERATE_ARTIFACTS_RESULT} EQUAL 0)
+  message(FATAL_ERROR "Failed to generate publisher denied artifacts: ${GENERATE_ARTIFACTS_ERROR}")
+endif()
+
+# Generate access control artifacts for subscriber denied
+set(generate_subscriber_denied_command ${ROS2_EXECUTABLE} security generate_artifacts
+  -k ${KEYSTORE_DIRECTORY_NATIVE_PATH}
+  -e /subscriber_denied
+  -p ${KEYSTORE_DIRECTORY_NATIVE_PATH}/policies/policy_subscriber_denied.xml)
+execute_process(
+  COMMAND ${generate_subscriber_denied_command}
+  RESULT_VARIABLE GENERATE_ARTIFACTS_RESULT
+  ERROR_VARIABLE GENERATE_ARTIFACTS_ERROR
+)
+if(NOT ${GENERATE_ARTIFACTS_RESULT} EQUAL 0)
+  message(FATAL_ERROR "Failed to generate subscriber denied artifacts: ${GENERATE_ARTIFACTS_ERROR}")
+endif()
+
 # deleting key of /publisher_missing_key
 file(REMOVE "${KEYSTORE_DIRECTORY}/enclaves/publisher_missing_key/key.pem")
 

--- a/test_security/test/test_secure_publisher.cpp
+++ b/test_security/test/test_secure_publisher.cpp
@@ -74,8 +74,7 @@ int main(int argc, char ** argv)
       "pass a message type\n");
     return 1;
   }
-  const char * args[] = {"--ros-args", "--enclave", "/publisher"};
-  rclcpp::init(sizeof(args) / sizeof(char *), args);
+  rclcpp::init(argc, argv);
   std::string message = argv[1];
   std::string namespace_ = argv[2];
   std::string node_name = "test_secure_publisher";

--- a/test_security/test/test_secure_publisher_subscriber.py.in
+++ b/test_security/test/test_secure_publisher_subscriber.py.in
@@ -22,11 +22,13 @@ def generate_test_description():
     launch_description = LaunchDescription()
 
     publisher_cmd = [
-        '@TEST_PUBLISHER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@', namespace
+        '@TEST_PUBLISHER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@', namespace,
+        '--ros-args', '--enclave', '@PUBLISHER_ENCLAVE@'
     ]
     subscriber_cmd = [
         '@TEST_SUBSCRIBER_EXECUTABLE@', '@TEST_MESSAGE_TYPE@',
-        '@SUBSCRIBER_SHOULD_TIMEOUT@', namespace
+        '@SUBSCRIBER_SHOULD_TIMEOUT@', namespace,
+        '--ros-args', '--enclave', '@SUBSCRIBER_ENCLAVE@'
     ]
 
     publisher_env = dict(os.environ)

--- a/test_security/test/test_secure_subscriber.cpp
+++ b/test_security/test/test_secure_subscriber.cpp
@@ -124,8 +124,7 @@ int main(int argc, char ** argv)
   bool should_timeout =
     ((0 == strcmp(argv[2], "false")) || (0 == strcmp(argv[2], "0"))) ? false : true;
 
-  const char * args[] = {"--ros-args", "--enclave", "/subscriber"};
-  rclcpp::init(sizeof(args) / sizeof(char *), args);
+  rclcpp::init(argc, argv);
   std::shared_ptr<rclcpp::Node> node = nullptr;
   try {
     node = rclcpp::Node::make_shared(node_name, namespace_);

--- a/test_security/test/test_security_files/policies/policy_publisher_denied.xml
+++ b/test_security/test/test_security_files/policies/policy_publisher_denied.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<policy version="0.2.0"
+  xmlns:xi="http://www.w3.org/2001/XInclude">
+  <enclaves>
+    <enclave path="/publisher_denied">
+      <profiles>
+        <profile ns="/" node="default">
+          <topics publish="DENY" subscribe="ALLOW">
+            <topic>chatter</topic>
+          </topics>
+          <topics publish="ALLOW" subscribe="ALLOW">
+            <topic>/*</topic>
+          </topics>
+          <services reply="ALLOW" request="ALLOW">
+            <service>/*</service>
+          </services>
+          <actions call="ALLOW" execute="ALLOW">
+            <action>/*</action>
+          </actions>
+        </profile>
+      </profiles>
+    </enclave>
+  </enclaves>
+</policy>

--- a/test_security/test/test_security_files/policies/policy_subscriber_denied.xml
+++ b/test_security/test/test_security_files/policies/policy_subscriber_denied.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<policy version="0.2.0"
+  xmlns:xi="http://www.w3.org/2001/XInclude">
+  <enclaves>
+    <enclave path="/subscriber_denied">
+      <profiles>
+        <profile ns="/" node="default">
+          <topics publish="ALLOW" subscribe="DENY">
+            <topic>chatter</topic>
+          </topics>
+          <topics publish="ALLOW" subscribe="ALLOW">
+            <topic>/*</topic>
+          </topics>
+          <services reply="ALLOW" request="ALLOW">
+            <service>/*</service>
+          </services>
+          <actions call="ALLOW" execute="ALLOW">
+            <action>/*</action>
+          </actions>
+        </profile>
+      </profiles>
+    </enclave>
+  </enclaves>
+</policy>


### PR DESCRIPTION
## Description

This PR adds negative testing for SROS2 access control policies by ensuring that nodes configured with restricted security policies (DENY rules) correctly fail to communicate. 

Key changes include :- 
- Created two new security policies (`policy_publisher_denied.xml` and `policy_subscriber_denied.xml`) that restrict publishing and subscribing on the `chatter` topic.
- Updated `sros_artifacts.cmake` to generate cryptographic artifacts for the new `/publisher_denied` and `/subscriber_denied` enclaves.
- Refactored `test_secure_publisher.cpp` and `test_secure_subscriber.cpp` to dynamically parse their enclave names from `argv` rather than hardcoding them.
- Updated `test_secure_publisher_subscriber.py.in` to explicitly pass `--ros-args --enclave` to both nodes.
- Added a new `access_control_tests` matrix in `CMakeLists.txt` that pairs authorized nodes with denied nodes and asserts that the subscriber gracefully times out.

Fixes #238

### Is this user-facing behavior change?

No, these changes are strictly related to internal testing.

### Did you use Generative AI?

Yes ai agent was used to assist in scaffolding the test implementations and CMake loops.

### Additional Information

The tests have been verified locally (with `SECURITY=ON`) and all security/access-control related test timeouts function correctly, ensuring that invalid access attempts are blocked at the middleware level.