### PR TITLE
Removed xml lint warning

### DIFF
--- a/test_rosidl_buffer/package.xml
+++ b/test_rosidl_buffer/package.xml
@@ -29,8 +29,6 @@
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <member_of_group>rosidl_interface_packages</member_of_group>
-
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
@@ -41,6 +39,8 @@
   <test_depend>rclpy</test_depend>
   <test_depend>rmw_fastrtps_cpp</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Description

Removed xml lint warning. Related with https://ci.ros2.org/job/ci_windows/29327/
